### PR TITLE
ci: Add workflow to publish package

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,19 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/galileo/story/13724/add-publish-to-npm-workflow

New package that goes to NPM, so we gotta publish it. Just replicating the flow that I had locally with [inspiration from this one](https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages).