### PR TITLE
Add time to first token

### DIFF
--- a/src/observe/callback.ts
+++ b/src/observe/callback.ts
@@ -287,13 +287,13 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
     fields?: HandleLLMNewTokenCallbackFields
   ): void {
     const node_id = runId;
-    if (!this.records[node_id].time_to_first_token) {
+    if (!this.records[node_id].time_to_first_token_ms) {
       const chain_root_id = this.records[node_id].chain_root_id;
       if (chain_root_id !== undefined) {
         const start_time = this.timers[chain_root_id]['start'];
         const now = performance.now();
         // Time to first token in milliseconds
-        this.records[node_id].time_to_first_token = Math.round(now - start_time);
+        this.records[node_id].time_to_first_token_ms = Math.round(now - start_time);
       }
     }
   }

--- a/src/types/transaction.types.ts
+++ b/src/types/transaction.types.ts
@@ -26,7 +26,7 @@ export interface TransactionRecord {
   temperature?: number;
   node_type: StepType;
   has_children: boolean;
-  time_to_first_token?: number;
+  time_to_first_token_ms?: number;
   version?: string;
 }
 


### PR DESCRIPTION
Shortcut story: Log time to first token from langchain [sc-22094](https://app.shortcut.com/galileo/story/22094/observe-ts-log-time-to-first-token-from-langchain-callbacks-allow-logging-as-workflow)
Epic: Shortcut: [Observe] Support Time to first Token [sc-22092](https://app.shortcut.com/galileo/epic/22092)