### PR TITLE
Don't require token for api key login route

### DIFF
--- a/src/api-client.ts
+++ b/src/api-client.ts
@@ -160,7 +160,7 @@ export class GalileoApiClient {
   ): Promise<T> {
     // Check to see if our token is expired before making a request
     // and refresh token if it's expired
-    if (endpoint !== Routes.login && this.token) {
+    if (![Routes.login, Routes.apiKeyLogin].includes(endpoint) && this.token) {
       const payload = decode(this.token, { json: true });
       if (payload?.exp && payload.exp < Math.floor(Date.now() / 1000)) {
         this.token = await this.getToken();


### PR DESCRIPTION
There's currently an infinite loop due to a circular dependency: `apiKeyLogin` &rarr; `makeRequest` &rarr; `getToken` &rarr; `apiKeyLogin` &rarr; `makeRequest` &rarr; `getToken` etc.

This results in some call stack exceeded errors like this:
```
/app/node_modules/@rungalileo/galileo/dist/api-client.js:140
        return response.data;
RangeError: Maximum call stack size exceeded
Exception in PromiseRejectCallback:
/app/node_modules/@rungalileo/galileo/dist/api-client.js:79
        return await this.makeRequest(RequestMethod.POST, routes_types_js_1.Routes.apiKeyLogin, {
                          ^
RangeError: Maximum call stack size exceeded
```

This changes fixes this by not getting the token for the `/login/api_key` route