### PR TITLE
feat(core): Add functions for uploading and listing datasets

### DIFF
--- a/examples/datasets/workflow.js
+++ b/examples/datasets/workflow.js
@@ -1,0 +1,14 @@
+import 'dotenv/config';
+import { getDatasets, createDataset } from '@rungalileo/galileo';
+
+// Upload a dataset
+const dataset = await createDataset({
+  col1: ['val1', 'val2'],
+  col2: ['val3', 'val4']
+});
+console.log(`Uploaded datset: ${dataset.name}`);
+
+// Get all datasets
+console.log('All datasets:');
+const datasets = await getDatasets();
+datasets.forEach((dataset) => console.log(dataset));

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.7",
-        "jsonwebtoken": "^9.0.2"
+        "jsonwebtoken": "^9.0.2",
+        "tmp": "^0.2.3"
       },
       "devDependencies": {
         "@types/jsonwebtoken": "^9.0.6",
@@ -7073,6 +7074,15 @@
       "integrity": "sha512-UuFHqpy/DxOfNiC3otsqbx3oS6jr5uKdQhB/CvDEroZQbVHt+qAK+4JbIooabUWKU9g6PpsFylNu9Wcg4MxSGA==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/tmp": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/tmpl": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "homepage": "https://www.rungalileo.io/",
   "dependencies": {
     "axios": "^1.6.7",
-    "jsonwebtoken": "^9.0.2"
+    "jsonwebtoken": "^9.0.2",
+    "tmp": "^0.2.3"
   },
   "optionalDependencies": {
     "@langchain/core": "^0.3.13",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,10 +4,14 @@ import GalileoObserveApiClient from './observe/api-client';
 import GalileoObserveCallback from './observe/callback';
 import GalileoObserveWorkflow from './observe/workflow';
 
+import { getDatasets, createDataset } from './utils/datasets';
+
 export {
   GalileoObserveApiClient,
   GalileoObserveCallback,
   GalileoObserveWorkflow,
   GalileoEvaluateApiClient,
-  GalileoEvaluateWorkflow
+  GalileoEvaluateWorkflow,
+  getDatasets,
+  createDataset
 };

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -1,0 +1,6 @@
+export interface PaginatedResponse {
+  starting_token: number;
+  limit: number;
+  paginated: boolean;
+  next_starting_token: number | null;
+}

--- a/src/types/dataset.types.ts
+++ b/src/types/dataset.types.ts
@@ -1,0 +1,15 @@
+import { PaginatedResponse } from './api.types';
+
+export interface Dataset {
+  id: string;
+  name: string;
+  created_at: string;
+  updated_at: string;
+  project_count: number;
+  num_rows: number | null;
+  column_names: string[] | null;
+}
+
+export interface DatasetResponse extends PaginatedResponse {
+  datasets: Dataset[];
+}

--- a/src/types/routes.types.ts
+++ b/src/types/routes.types.ts
@@ -9,5 +9,6 @@ export enum Routes {
   observeIngest = 'projects/{project_id}/observe/ingest',
   observeRows = 'projects/{project_id}/observe/rows',
   observeDelete = 'projects/{project_id}/observe/delete',
-  evaluateIngest = 'projects/{project_id}/runs/{run_id}/chains/ingest'
+  evaluateIngest = 'projects/{project_id}/runs/{run_id}/chains/ingest',
+  datasets = 'datasets'
 }

--- a/src/utils/datasets.ts
+++ b/src/utils/datasets.ts
@@ -1,0 +1,95 @@
+import { Dataset } from '../types/dataset.types';
+import { GalileoApiClient } from '../api-client';
+
+import { existsSync, PathLike, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+type DatasetType =
+  | PathLike
+  | string
+  | Record<string, string[]>
+  | Array<Record<string, string>>;
+
+enum DatasetFormat {
+  CSV = 'csv',
+  JSONL = 'jsonl',
+  FEATHER = 'feather'
+}
+
+function transposeDictToRows(
+  dataset: Record<string, string[]>
+): Array<Record<string, string>> {
+  const keyRows = Object.entries(dataset).map(([key, values]) =>
+    values.map((value) => ({ [key]: value }))
+  );
+  return keyRows[0].map((_, i) =>
+    Object.assign({}, ...keyRows.map((keyRow) => keyRow[i]))
+  );
+}
+
+function parseDataset(dataset: DatasetType): [PathLike, DatasetFormat] {
+  let datasetPath: PathLike;
+  let datasetFormat: DatasetFormat;
+
+  if (typeof dataset === 'string') {
+    datasetPath = dataset;
+  } else if (typeof dataset === 'object' && !Array.isArray(dataset)) {
+    const datasetRows = transposeDictToRows(
+      dataset as Record<string, string[]>
+    );
+    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.CSV}`);
+    const header = Object.keys(datasetRows[0]).join(',') + '\n';
+    const rows = datasetRows
+      .map((row) => Object.values(row).join(','))
+      .join('\n');
+    writeFileSync(tempFilePath, header + rows, { encoding: 'utf-8' });
+    datasetPath = tempFilePath;
+  } else if (Array.isArray(dataset)) {
+    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.CSV}`);
+    const header = Object.keys(dataset[0]).join(',') + '\n';
+    const rows = dataset.map((row) => Object.values(row).join(',')).join('\n');
+    writeFileSync(tempFilePath, header + rows, { encoding: 'utf-8' });
+    datasetPath = tempFilePath;
+  } else {
+    throw new Error(
+      'Dataset must be a path to a file, a string, an array of objects, or an object of arrays.'
+    );
+  }
+
+  if (!existsSync(datasetPath)) {
+    throw new Error(`Dataset file ${datasetPath} does not exist.`);
+  }
+
+  const suffix = datasetPath.toString().split('.').pop()?.toLowerCase();
+  switch (suffix) {
+    case DatasetFormat.CSV:
+      datasetFormat = DatasetFormat.CSV;
+      break;
+    case DatasetFormat.JSONL:
+      datasetFormat = DatasetFormat.JSONL;
+      break;
+    case DatasetFormat.FEATHER:
+      datasetFormat = DatasetFormat.FEATHER;
+      break;
+    default:
+      throw new Error(
+        `Dataset file ${datasetPath} must be a CSV, JSONL, or Feather file.`
+      );
+  }
+
+  return [datasetPath, datasetFormat];
+}
+
+export const createDataset = async (dataset: DatasetType): Promise<Dataset> => {
+  const [datasetPath, datasetFormat] = parseDataset(dataset);
+  const apiClient = new GalileoApiClient();
+  await apiClient.init(undefined);
+  return await apiClient.createDataset(datasetPath.toString(), datasetFormat);
+};
+
+export const getDatasets = async (): Promise<Dataset[]> => {
+  const apiClient = new GalileoApiClient();
+  await apiClient.init(undefined);
+  return await apiClient.getDatasets();
+};


### PR DESCRIPTION
This adds two new functions: `createDataset` and `listDatasets`. The allowed formats are the same as what promptquality allowed, and much of the logic for validating the dataset is transpiled from [promptquality](https://github.com/rungalileo/promptquality/blob/main/src/promptquality/utils/dataset.py).