### PR TITLE
feat(datasets): Add `createDataset` function

### DIFF
--- a/examples/datasets/workflow.js
+++ b/examples/datasets/workflow.js
@@ -1,5 +1,15 @@
 import 'dotenv/config';
-import { getDatasets } from '@rungalileo/galileo';
+import { getDatasets, createDataset } from '@rungalileo/galileo';
+
+// Create a dataset
+const dataset = await createDataset(
+  {
+    col1: [1, 2, 3],
+    col2: ['a', 'b', 'c']
+  },
+  'My dataset'
+);
+console.log('Created dataset:', dataset);
 
 // Get all datasets
 console.log('Listing datasets...');

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.6.7",
+        "form-data": "^4.0.1",
         "jsonwebtoken": "^9.0.2",
         "openapi-fetch": "^0.13.3",
         "openapi-typescript-helpers": "^0.0.15"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "npm run format && npm run lint && tsc",
-    "test": "jest",
+    "test": "jest --detectOpenHandles --forceExit",
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "format": "prettier --config .prettierrc.js 'src/**/*.ts' --write",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://www.rungalileo.io/",
   "dependencies": {
     "axios": "^1.6.7",
+    "form-data": "^4.0.1",
     "jsonwebtoken": "^9.0.2",
     "openapi-fetch": "^0.13.3",
     "openapi-typescript-helpers": "^0.0.15"

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,12 +3,13 @@ import GalileoEvaluateWorkflow from './evaluate/workflow';
 import GalileoObserveApiClient from './observe/api-client';
 import GalileoObserveCallback from './observe/callback';
 import GalileoObserveWorkflow from './observe/workflow';
-import { getDatasets } from './utils/datasets';
+import { getDatasets, createDataset } from './utils/datasets';
 export {
   GalileoObserveApiClient,
   GalileoObserveCallback,
   GalileoObserveWorkflow,
   GalileoEvaluateApiClient,
   GalileoEvaluateWorkflow,
-  getDatasets
+  getDatasets,
+  createDataset
 };

--- a/src/types/routes.types.ts
+++ b/src/types/routes.types.ts
@@ -9,5 +9,6 @@ export enum Routes {
   observeIngest = 'projects/{project_id}/observe/ingest',
   observeRows = 'projects/{project_id}/observe/rows',
   observeDelete = 'projects/{project_id}/observe/delete',
-  evaluateIngest = 'projects/{project_id}/runs/{run_id}/chains/ingest'
+  evaluateIngest = 'projects/{project_id}/runs/{run_id}/chains/ingest',
+  datasets = 'datasets'
 }

--- a/src/utils/datasets.ts
+++ b/src/utils/datasets.ts
@@ -1,5 +1,8 @@
 import { GalileoApiClient } from '../api-client';
 import { Dataset } from '../types/dataset.types';
+import { existsSync, PathLike, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 export const getDatasets = async (): Promise<Dataset[]> => {
   const apiClient = new GalileoApiClient();
@@ -13,4 +16,111 @@ export const getDatasets = async (): Promise<Dataset[]> => {
     updated_at: dataset.updated_at,
     num_rows: dataset.num_rows
   }));
+};
+
+type DatasetType =
+  | PathLike
+  | string
+  | Record<string, string[]>
+  | Array<Record<string, string>>;
+
+enum DatasetFormat {
+  CSV = 'csv',
+  JSONL = 'jsonl',
+  FEATHER = 'feather'
+}
+
+function transposeDictToRows(
+  dataset: Record<string, string[]>
+): Array<Record<string, string>> {
+  const keyRows = Object.entries(dataset).map(([key, values]) =>
+    values.map((value) => ({ [key]: value }))
+  );
+  return keyRows[0].map((_, i) =>
+    Object.assign({}, ...keyRows.map((keyRow) => keyRow[i]))
+  );
+}
+
+function parseDataset(dataset: DatasetType): [PathLike, DatasetFormat] {
+  let datasetPath: PathLike;
+  let datasetFormat: DatasetFormat;
+
+  if (typeof dataset === 'string') {
+    datasetPath = dataset;
+  } else if (typeof dataset === 'object' && !Array.isArray(dataset)) {
+    const datasetRows = transposeDictToRows(
+      dataset as Record<string, string[]>
+    );
+    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.CSV}`);
+    const header = Object.keys(datasetRows[0]).join(',') + '\n';
+    const rows = datasetRows
+      .map((row) => Object.values(row).join(','))
+      .join('\n');
+    writeFileSync(tempFilePath, header + rows, { encoding: 'utf-8' });
+    datasetPath = tempFilePath;
+  } else if (Array.isArray(dataset)) {
+    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.CSV}`);
+    const header = Object.keys(dataset[0]).join(',') + '\n';
+    const rows = dataset.map((row) => Object.values(row).join(',')).join('\n');
+    writeFileSync(tempFilePath, header + rows, { encoding: 'utf-8' });
+    datasetPath = tempFilePath;
+  } else {
+    throw new Error(
+      'Dataset must be a path to a file, a string, an array of objects, or an object of arrays.'
+    );
+  }
+
+  if (!existsSync(datasetPath)) {
+    throw new Error(`Dataset file ${datasetPath} does not exist.`);
+  }
+
+  const suffix = datasetPath.toString().split('.').pop()?.toLowerCase();
+  switch (suffix) {
+    case DatasetFormat.CSV:
+      datasetFormat = DatasetFormat.CSV;
+      break;
+    case DatasetFormat.JSONL:
+      datasetFormat = DatasetFormat.JSONL;
+      break;
+    case DatasetFormat.FEATHER:
+      datasetFormat = DatasetFormat.FEATHER;
+      break;
+    default:
+      throw new Error(
+        `Dataset file ${datasetPath} must be a CSV, JSONL, or Feather file.`
+      );
+  }
+
+  return [datasetPath, datasetFormat];
+}
+
+export const createDataset = async (
+  dataset: DatasetType,
+  name?: string
+): Promise<Dataset> => {
+  const [datasetPath, datasetFormat] = parseDataset(dataset);
+
+  if (!name) {
+    // use file name
+    name = datasetPath.toString().split('/').pop() ?? datasetPath.toString();
+  }
+
+  const apiClient = new GalileoApiClient();
+  await apiClient.init();
+
+  const createdDataset = await apiClient.createDataset(
+    name,
+    datasetPath.toString(),
+    datasetFormat
+  );
+
+  return {
+    id: createdDataset.id,
+    name: createdDataset.name,
+    column_names: createdDataset.column_names,
+    project_count: createdDataset.project_count,
+    created_at: createdDataset.created_at,
+    updated_at: createdDataset.updated_at,
+    num_rows: createdDataset.num_rows
+  };
 };

--- a/tests/utils/datasets.test.ts
+++ b/tests/utils/datasets.test.ts
@@ -1,10 +1,10 @@
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
-import { getDatasets } from '../../src';
+import { getDatasets, createDataset } from '../../src';
 import { commonHandlers, TEST_HOST } from '../common';
-import { ListDatasetResponse } from '../../src/api-client';
+import { Dataset, ListDatasetResponse } from '../../src/api-client';
 
-const EXAMPLE_DATASET = {
+const EXAMPLE_DATASET: Dataset = {
   id: 'c7b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3d',
   name: 'My Dataset',
   column_names: ['firstName', 'lastName'],
@@ -14,14 +14,21 @@ const EXAMPLE_DATASET = {
   num_rows: 1
 };
 
+const postDatasetHandler = jest.fn().mockImplementation(() => {
+  return HttpResponse.json(EXAMPLE_DATASET);
+});
+
+const getDatasetHandler = jest.fn().mockImplementation(() => {
+  const response: ListDatasetResponse = {
+    datasets: [EXAMPLE_DATASET]
+  };
+  return HttpResponse.json(response);
+});
+
 export const handlers = [
   ...commonHandlers,
-  http.get(`${TEST_HOST}/datasets`, () => {
-    const response: ListDatasetResponse = {
-      datasets: [EXAMPLE_DATASET]
-    };
-    return HttpResponse.json(response);
-  })
+  http.post(`${TEST_HOST}/datasets`, postDatasetHandler),
+  http.get(`${TEST_HOST}/datasets`, getDatasetHandler)
 ];
 
 const server = setupServer(...handlers);
@@ -36,7 +43,14 @@ afterEach(() => server.resetHandlers());
 
 afterAll(() => server.close());
 
+test('create dataset', async () => {
+  const dataset = await createDataset({ col1: ['val1', 'val2'] }, 'My Dataset');
+  expect(dataset).toEqual(EXAMPLE_DATASET);
+  expect(postDatasetHandler).toHaveBeenCalled();
+});
+
 test('test get datasets', async () => {
   const datasets = await getDatasets();
   expect(datasets).toEqual([EXAMPLE_DATASET]);
+  expect(getDatasetHandler).toHaveBeenCalled();
 });


### PR DESCRIPTION
This function accepts datasets in the same format as in the Python
client, as well as an optional name.
