### PR TITLE
G2.0 Prompt run experiments

### DIFF
--- a/README_G20.md
+++ b/README_G20.md
@@ -1,0 +1,280 @@
+# Galileo
+
+The Typescript client library for the Galileo platform.
+
+Note: This library is in pre-release mode and may not be stable.
+
+## Getting Started
+
+### Installation
+
+Without optional dependencies
+
+`npm i galileo-experimental --no-optional`
+
+With optional dependencies
+
+`npm i galileo-experimental`
+
+### Setup
+
+Set the following environment variables:
+
+- `GALILEO_API_KEY`: Your Galileo API key
+- `GALILEO_PROJECT`: (Optional) Project name
+- `GALILEO_LOG_STREAM`: (Optional) Log stream name
+
+Note: if you would like to point to an environment other than app.galileo.ai, you'll need to set the GALILEO_CONSOLE_URL environment variable.
+
+### Usage
+
+#### Logging
+
+Logging with the OpenAI wrapper
+
+```js
+import { wrapOpenAI, flush, log, init } from 'galileo-experimental';
+import { OpenAI } from 'openai';
+
+const openai = wrapOpenAI(new OpenAI({ apiKey: process.env.OPENAI_API_KEY }));
+
+const result = await openai.chat.completions.create({
+  model: 'gpt-4o',
+  messages: [{ content: 'Say hello world!', role: 'user' }]
+});
+
+console.log(result);
+
+await flush();
+```
+
+Using the `log` function wrapper
+
+```js
+import { wrapOpenAI, flush, log, init } from 'galileo-experimental';
+import { OpenAI } from 'openai';
+
+const openai = wrapOpenAI(new OpenAI({ apiKey: process.env.OPENAI_API_KEY }));
+
+// This will automatically create an llm span since we're using the `wrapOpenAI` wrapper
+const callOpenAI = async (input) => {
+  const result = await openai.chat.completions.create({
+    model: 'gpt-4o',
+    messages: [{ content: `Say hello ${input}!`, role: 'user' }]
+  });
+  return result;
+};
+
+// Optionally initialize the logger if you haven't set GALILEO_PROJECT and GALILEO_LOG_STREAM environment variables
+await init({
+  projectName: 'my-test-project-4',
+  logStreamName: 'my-test-log-stream'
+});
+
+const wrappedToolCall = log(
+  { name: 'tool span', spanType: 'tool' },
+  (input) => {
+    return 'tool call result';
+  }
+);
+
+const wrappedFunc = await log({ name: 'workflow span' }, async (input) => {
+  const result = await callOpenAI(input);
+  return wrappedToolCall(result);
+});
+
+// This will create a workflow span with an llm span and a tool span
+const result = await wrappedFunc('world');
+
+await flush();
+```
+
+Logging with the GalileoLogger
+
+```js
+import { GalileoLogger } from 'galileo-experimental';
+
+// You can set the GALILEO_PROJECT and GALILEO_LOG_STREAM environment variables
+const logger = new GalileoLogger({
+  projectName: 'my-test-project',
+  logStreamName: 'my-test-log-stream'
+});
+
+console.log('Creating trace with spans...');
+
+// Create a new trace
+const trace = logger.startTrace(
+  'Example trace input', // input
+  undefined, // output (will be set later)
+  'Example Trace', // name
+  Date.now() * 1000000, // createdAt in nanoseconds
+  undefined, // durationNs
+  { source: 'test-script' }, // metadata
+  ['test', 'example'] // tags
+);
+
+// Add a workflow span (parent span)
+const workflowSpan = logger.addWorkflowSpan(
+  'Processing workflow', // input
+  undefined, // output (will be set later)
+  'Main Workflow', // name
+  undefined, // durationNs
+  Date.now() * 1000000, // createdAt in nanoseconds
+  { workflow_type: 'test' }, // userMetadata
+  ['workflow'] // tags
+);
+
+// Add an LLM span as a child of the workflow span
+logger.addLlmSpan({
+  input: [{ role: 'user', content: 'Hello, how are you?' }], // input messages
+  output: {
+    role: 'assistant',
+    content: 'I am doing well, thank you for asking!'
+  }, // output message
+  model: 'gpt-3.5-turbo', // model name
+  name: 'Chat Completion', // name
+  durationNs: 1000000000, // durationNs (1s)
+  userMetadata: { temperature: '0.7' }, // userMetadata
+  tags: ['llm', 'chat'] // tags
+});
+
+// Conclude the workflow span
+logger.conclude({
+  output: 'Workflow completed successfully',
+  durationNs: 2000000000 // 2 seconds
+});
+
+// Conclude the trace
+logger.conclude({
+  output: 'Final trace output with all spans completed',
+  durationNs: 3000000000 // 3 seconds
+});
+
+// Flush the traces to Galileo
+const flushedTraces = await logger.flush();
+```
+
+#### Experimentation
+
+Create a prompt template and use it to run a prompt experiment
+
+```js
+import { createPromptTemplate, runExperiment } from 'galileo-experimental';
+
+const template = await createPromptTemplate({
+  template: [{ role: 'user', content: 'Say "Hello, {name}"!' }],
+  projectName: 'my-test-project-5',
+  name: `Hello name prompt`
+});
+
+// Run the experiment. You'll receive a URL to view the results.
+await runExperiment({
+  name: `Test Experiment`,
+  datasetName: 'names',
+  promptTemplate: template,
+  metrics: ['output_tone'],
+  projectName: 'my-test-project-5'
+});
+```
+
+You can also use an existing template and a dataset object:
+
+```js
+import {
+  getPromptTemplate,
+  getDataset,
+  runExperiment
+} from 'galileo-experimental';
+
+const template = await getPromptTemplate(
+  'my-test-project-5',
+  'Hello name prompt'
+);
+
+const dataset = await getDataset(undefined, 'names');
+
+await runExperiment({
+  name: `Test Experiment`,
+  dataset: dataset,
+  promptTemplate: template,
+  metrics: ['output_tone'],
+  projectName: 'my-test-project-5'
+});
+```
+
+You can also use a runner function to run an experiment with a dataset:
+
+```js
+import { runExperiment } from 'galileo-experimental';
+import { OpenAI } from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const runner = async (input) => {
+  const result = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ content: `Say hello ${input['name']}!`, role: 'user' }]
+  });
+  return result;
+};
+
+await runExperiment({
+  name: `Test Experiment`,
+  datasetName: 'names',
+  runner: runner,
+  metrics: ['output_tone'],
+  projectName: 'my-test-project-5'
+});
+```
+
+Here's how you can use a locally generated dataset with a runner function:
+
+```js
+import { runExperiment } from 'galileo-experimental';
+import { OpenAI } from 'openai';
+
+const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
+
+const dataset = [
+  { name: 'John' },
+  { name: 'Jane' },
+  { name: 'Bob' },
+  { name: 'Alice' }
+];
+
+const runner = async (input) => {
+  const result = await openai.chat.completions.create({
+    model: 'gpt-3.5-turbo',
+    messages: [{ content: `Say hello ${input['name']}!`, role: 'user' }]
+  });
+  return result;
+};
+
+await runExperiment({
+  name: `Test Experiment`,
+  dataset: dataset,
+  runner: runner,
+  metrics: ['output_tone'],
+  projectName: 'my-test-project-5'
+});
+```
+
+## Making changes
+
+When updating the code, only modify the `*.ts` files in `src` and then run:
+
+- `npm run build`
+
+## Examples Setup
+
+In the root directory, run:
+
+- `npm i`
+- `npm link`
+
+In the examples directory, run:
+
+- `npm i`
+- `npm link @rungalileo/galileo`
+
+Use `node` to run examples, e.g. `node examples/logger/workflow.js`.

--- a/README_G20.md
+++ b/README_G20.md
@@ -8,12 +8,6 @@ Note: This library is in pre-release mode and may not be stable.
 
 ### Installation
 
-Without optional dependencies
-
-`npm i galileo-experimental --no-optional`
-
-With optional dependencies
-
 `npm i galileo-experimental`
 
 ### Setup

--- a/src/api-client/base-client.ts
+++ b/src/api-client/base-client.ts
@@ -124,6 +124,20 @@ export class BaseClient {
       .replace(
         '{dataset_id}',
         params && 'dataset_id' in params ? (params.dataset_id as string) : ''
+      )
+      .replace(
+        '{experiment_id}',
+        params && 'experiment_id' in params
+          ? (params.experiment_id as string)
+          : ''
+      )
+      .replace(
+        '{template_id}',
+        params && 'template_id' in params ? (params.template_id as string) : ''
+      )
+      .replace(
+        '{version}',
+        params && 'version' in params ? (params.version as string) : ''
       )}`;
 
     const config: AxiosRequestConfig = {

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -147,7 +147,8 @@ export class GalileoApiClient extends BaseClient {
         this.apiUrl,
         this.token,
         this.projectId,
-        this.logStreamId
+        this.logStreamId,
+        this.experimentId
       );
 
       this.promptTemplateService = new PromptTemplateService(

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -155,6 +155,11 @@ export class GalileoApiClient extends BaseClient {
         this.token,
         this.projectId
       );
+      this.experimentService = new ExperimentService(
+        this.apiUrl,
+        this.token,
+        this.projectId
+      );
     }
   }
 

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -9,6 +9,11 @@ import { PromptTemplateService } from './services/prompt-template-service';
 import { DatasetService, DatasetAppendRow } from './services/dataset-service';
 import { TraceService } from './services/trace-service';
 import { ExperimentService } from './services/experiment-service';
+import {
+  CreateJobResponse,
+  PromptRunSettings
+} from '../types/experiment.types';
+import { Message } from '../types/message.types';
 
 export class GalileoApiClientParams {
   public projectType: ProjectTypes = ProjectTypes.genAI;
@@ -246,15 +251,28 @@ export class GalileoApiClient extends BaseClient {
     return this.promptTemplateService!.getPromptTemplates();
   }
 
-  public async createPromptTemplate(
-    template: string,
-    version: string,
-    name: string
-  ) {
+  public async getPromptTemplate(id: string) {
+    this.ensureService(this.promptTemplateService);
+    return this.promptTemplateService!.getPromptTemplate(id);
+  }
+
+  public async getPromptTemplateVersion(id: string, version: number) {
+    this.ensureService(this.promptTemplateService);
+    return this.promptTemplateService!.getPromptTemplateVersion(id, version);
+  }
+
+  public async getPromptTemplateVersionByName(name: string, version?: number) {
+    this.ensureService(this.promptTemplateService);
+    return this.promptTemplateService!.getPromptTemplateVersionByName(
+      name,
+      version
+    );
+  }
+
+  public async createPromptTemplate(template: Message[], name: string) {
     this.ensureService(this.promptTemplateService);
     return this.promptTemplateService!.createPromptTemplate({
       template,
-      version,
       name
     });
   }
@@ -290,6 +308,25 @@ export class GalileoApiClient extends BaseClient {
       experimentId,
       projectId,
       scorers
+    );
+  }
+
+  public async createPromptRunJob(
+    experimentId: string,
+    projectId: string,
+    promptTemplateVersionId: string,
+    datasetId: string,
+    scorers?: Scorer[],
+    promptSettings?: PromptRunSettings
+  ): Promise<CreateJobResponse> {
+    this.ensureService(this.experimentService);
+    return this.experimentService!.createPromptRunJob(
+      experimentId,
+      projectId,
+      promptTemplateVersionId,
+      datasetId,
+      scorers,
+      promptSettings
     );
   }
 

--- a/src/api-client/services/experiment-service.ts
+++ b/src/api-client/services/experiment-service.ts
@@ -2,7 +2,11 @@ import { BaseClient, RequestMethod } from '../base-client';
 import { Routes } from '../../types/routes.types';
 import { Scorer } from '../../types/scorer.types';
 import { ScorerTypes } from '../../types/scorer.types';
-import { Experiment } from '../../types/experiment.types';
+import {
+  Experiment,
+  PromptRunSettings,
+  CreateJobResponse
+} from '../../types/experiment.types';
 
 export class ExperimentService extends BaseClient {
   private projectId: string;
@@ -81,6 +85,30 @@ export class ExperimentService extends BaseClient {
       {
         project_id: projectId,
         experiment_id: experimentId
+      }
+    );
+  };
+
+  public createPromptRunJob = async (
+    experimentId: string,
+    projectId: string,
+    promptTemplateVersionId: string,
+    datasetId: string,
+    scorers?: Scorer[],
+    promptSettings?: PromptRunSettings
+  ): Promise<CreateJobResponse> => {
+    return await this.makeRequest<CreateJobResponse>(
+      RequestMethod.POST,
+      Routes.jobs,
+      {
+        name: 'prompt_run',
+        project_id: projectId,
+        run_id: experimentId,
+        prompt_template_id: promptTemplateVersionId,
+        prompt_settings: promptSettings || null,
+        dataset_id: datasetId,
+        scorers: scorers || null,
+        task_type: 16
       }
     );
   };

--- a/src/api-client/services/prompt-template-service.ts
+++ b/src/api-client/services/prompt-template-service.ts
@@ -1,11 +1,11 @@
 import { BaseClient, RequestMethod } from '../base-client';
 import { Routes } from '../../types/routes.types';
-import { components } from '../../types/api.types';
+import {
+  PromptTemplate,
+  PromptTemplateVersion
+} from '../../types/prompt-template.types';
+import { Message } from '../../types/message.types';
 
-export type PromptTemplate =
-  components['schemas']['BasePromptTemplateResponse'];
-export type PromptTemplateVersion =
-  components['schemas']['BasePromptTemplateVersionResponse'];
 type ListTemplatesResponse = PromptTemplate[];
 
 export class PromptTemplateService extends BaseClient {
@@ -27,19 +27,50 @@ export class PromptTemplateService extends BaseClient {
     );
   };
 
+  public getPromptTemplate = async (id: string): Promise<PromptTemplate> => {
+    return await this.makeRequest<PromptTemplate>(
+      RequestMethod.GET,
+      Routes.promptTemplate,
+      null,
+      { project_id: this.projectId, template_id: id }
+    );
+  };
+
+  public getPromptTemplateVersion = async (
+    id: string,
+    version: number
+  ): Promise<PromptTemplateVersion> => {
+    return await this.makeRequest<PromptTemplateVersion>(
+      RequestMethod.GET,
+      Routes.promptTemplateVersion,
+      null,
+      { project_id: this.projectId, template_id: id, version }
+    );
+  };
+
+  public getPromptTemplateVersionByName = async (
+    name: string,
+    version?: number
+  ): Promise<PromptTemplateVersion> => {
+    return await this.makeRequest<PromptTemplateVersion>(
+      RequestMethod.GET,
+      Routes.promptTemplateVersions,
+      { template_name: name, version: version ?? null },
+      { project_id: this.projectId }
+    );
+  };
+
   public createPromptTemplate = async ({
     template,
-    version,
     name
   }: {
-    template: string;
-    version: string;
+    template: Message[];
     name: string;
   }): Promise<PromptTemplate> => {
     return await this.makeRequest<PromptTemplate>(
       RequestMethod.POST,
       Routes.promptTemplates,
-      { template, version, name },
+      { template, name },
       { project_id: this.projectId }
     );
   };

--- a/src/api-client/services/trace-service.ts
+++ b/src/api-client/services/trace-service.ts
@@ -4,37 +4,54 @@ import { Trace } from '../../types/log.types';
 
 export class TraceService extends BaseClient {
   private projectId: string;
-  private logStreamId: string;
+  private logStreamId: string | undefined;
+  private experimentId: string | undefined;
 
   constructor(
     apiUrl: string,
     token: string,
     projectId: string,
-    logStreamId: string
+    logStreamId?: string,
+    experimentId?: string
   ) {
     super();
     this.apiUrl = apiUrl;
     this.token = token;
     this.projectId = projectId;
     this.logStreamId = logStreamId;
+    this.experimentId = experimentId;
     this.initializeClient();
   }
 
   public async ingestTraces(traces: Trace[]): Promise<void> {
-    if (!this.projectId || !this.logStreamId) {
-      throw new Error('Project ID and Log Stream ID must be set');
+    if (!this.projectId) {
+      throw new Error('Project not initialized');
+    }
+
+    if (!this.logStreamId && !this.experimentId) {
+      throw new Error('Log stream or experiment not initialized');
     }
 
     await this.makeRequest<void>(
       RequestMethod.POST,
       Routes.traces,
-      { traces, log_stream_id: this.logStreamId },
+      {
+        traces,
+        ...(this.experimentId && {
+          experiment_id: this.experimentId
+        }),
+        ...(!this.experimentId &&
+          this.logStreamId && {
+            log_stream_id: this.logStreamId
+          })
+      },
       { project_id: this.projectId }
     );
-
     // eslint-disable-next-line no-console
     console.log(
       `🚀 ${traces.length} Traces ingested for project ${this.projectId}.`
     );
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(traces, null, 2));
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,8 @@ import {
 } from './utils/datasets';
 import {
   createPromptTemplate,
-  getPromptTemplates
+  getPromptTemplates,
+  getPromptTemplate
 } from './utils/prompt-templates';
 import { getProjects, createProject, getProject } from './utils/projects';
 import {
@@ -48,6 +49,7 @@ export {
   getDataset,
   // Prompt templates
   getPromptTemplates,
+  getPromptTemplate,
   createPromptTemplate,
   // Experiments
   getExperiments,

--- a/src/types/experiment.types.ts
+++ b/src/types/experiment.types.ts
@@ -11,3 +11,5 @@ export interface Experiment {
 type PromptRunSettingsInput = components['schemas']['PromptRunSettings-Input'];
 
 export interface PromptRunSettings extends PromptRunSettingsInput {}
+
+export type CreateJobResponse = components['schemas']['CreateJobResponse'];

--- a/src/types/prompt-template.types.ts
+++ b/src/types/prompt-template.types.ts
@@ -1,0 +1,6 @@
+import { components } from './api.types';
+
+export type PromptTemplate =
+  components['schemas']['BasePromptTemplateResponse'];
+export type PromptTemplateVersion =
+  components['schemas']['BasePromptTemplateVersionResponse'];

--- a/src/types/routes.types.ts
+++ b/src/types/routes.types.ts
@@ -24,5 +24,8 @@ export enum Routes {
   scorers = 'scorers/list',
   runScorerSettings = 'projects/{project_id}/runs/{experiment_id}/scorer-settings',
   promptTemplates = 'projects/{project_id}/templates',
-  promptTemplateVersions = 'projects/{project_id}/templates/versions'
+  promptTemplate = 'projects/{project_id}/templates/{template_id}',
+  promptTemplateVersions = 'projects/{project_id}/templates/versions',
+  promptTemplateVersion = 'projects/{project_id}/templates/{template_id}/versions/{version}',
+  jobs = 'jobs'
 }

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -203,16 +203,6 @@ const runExperimentWithFunction = async <T extends Record<string, unknown>>(
 ): Promise<string[]> => {
   const outputs: string[] = [];
 
-  // const apiClient = new GalileoApiClient();
-  // await apiClient.init({ projectName });
-  // const projectId = apiClient.projectId;
-
-  // apiClient.experimentId = experiment.id;
-
-  // if (metrics.length > 0) {
-  //   await createRunScorerSettings(experiment.id, projectId, metrics);
-  // }
-
   // Initialize the singleton logger
   init({ experimentId: experiment.id, projectName });
 

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -253,22 +253,34 @@ const getLinkToExperimentResults = (
  * // Run an experiment with a runner function
  * const results = await runExperiment({
  *   name: 'my-experiment',
- *   dataset: [{ id: 1, name: 'test' }],
+ *   dataset: [{ country: 'France'}],
  *   function: async (input) => {
- *     return `The capital of ${input["country"]} is ${input["capital"]}`;
- *   },
+        const response = await openai.chat.completions.create({
+          model: 'gpt-4o-mini',
+          messages: [
+            {
+              role: 'user',
+              content: `What is the capital of ${input['country']}?`
+            }
+          ]
+        });
+        return response.choices[0].message.content;
+      },
  *   metrics: ['accuracy'],
  *   projectName: 'my-project'
  * });
  *
  * // Run an experiment with a prompt template
+ * const promptTemplate = await createPromptTemplate({
+ *   template: [{ role: 'user', content: 'What is the capital of {{ country }}?' }],
+ *   name: 'my-prompt-template',
+ *   projectName: 'my-project'
+ * });
+ *
  * const results = await runExperiment({
  *   name: 'my-experiment',
- *   dataset: [{ id: 1, name: 'test' }],
- *   promptTemplate: {
- *     template: 'What is the capital of {{ country }}?',
- *     parameters: ['country']
- *   },
+ *   dataset: [{ country: 'France' }],
+ *   promptTemplate
  *   metrics: ['accuracy'],
  *   projectName: 'my-project'
  * });

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -345,7 +345,6 @@ class GalileoLogger {
         console.warn('No traces to flush.');
         return [];
       }
-      console.log('🚀 ~ GalileoLogger ~ flush ~ this.traces:', this.traces);
 
       await this.client.init({
         projectType: ProjectTypes.genAI,

--- a/src/utils/scorers.ts
+++ b/src/utils/scorers.ts
@@ -8,12 +8,27 @@ export const getScorers = async (type?: ScorerTypes): Promise<Scorer[]> => {
   return await client.getScorers(type);
 };
 
-export const createRunScorerSettings = async (
-  experimentId: string,
-  projectId: string,
-  scorers: Scorer[]
-): Promise<void> => {
+export const createRunScorerSettings = async ({
+  experimentId,
+  projectId,
+  projectName,
+  scorers
+}: {
+  experimentId: string;
+  projectId?: string;
+  projectName?: string;
+  scorers: Scorer[];
+}): Promise<void> => {
+  if (!projectId && !projectName) {
+    throw new Error(
+      'To create run scorer settings, either projectId or projectName must be provided'
+    );
+  }
   const client = new GalileoApiClient();
-  await client.init();
-  await client.createRunScorerSettings(experimentId, projectId, scorers);
+  await client.init({ projectName, projectId });
+  await client.createRunScorerSettings(
+    experimentId,
+    projectId || client.projectId,
+    scorers
+  );
 };


### PR DESCRIPTION
Adding the ability to run experiments using prompt templates:

```js
import { createPromptTemplate, runExperiment } from 'galileo-experimental';

const template = await createPromptTemplate({
  template: [{ role: 'user', content: 'Say "Hello, {name}"!' }],
  projectName: 'my-test-project-5',
  name: `Hello name prompt`
});

// Run the experiment. You'll receive a URL to view the results.
await runExperiment({
  name: `Test Experiment`,
  datasetName: 'names',
  promptTemplate: template,
  metrics: ['output_tone'],
  projectName: 'my-test-project-5'
});
```