### PR TITLE
feat: Support alternative forms of token usage returned by LLM output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "galileo",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "galileo",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "JS client for Galileo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/observe/callback.ts
+++ b/src/observe/callback.ts
@@ -188,10 +188,17 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
 
     if (output.llmOutput) {
       const usage =
-        (output.llmOutput.tokenUsage as Record<string, unknown>) ?? {};
+        (output.llmOutput.tokenUsage as Record<string, unknown>) ??
+        (output.llmOutput.usage as Record<string, unknown>) ??
+        (output.llmOutput.estimatedTokenUsage as Record<string, unknown>) ??
+        {};
 
-      num_input_tokens = usage.promptTokens as number | undefined;
-      num_output_tokens = usage.completionTokens as number | undefined;
+      num_input_tokens = (usage.promptTokens ?? usage.inputTokens) as
+        | number
+        | undefined;
+      num_output_tokens = (usage.completionTokens ?? usage.outputTokens) as
+        | number
+        | undefined;
       num_total_tokens = usage.totalTokens as number | undefined;
     } else {
       try {


### PR DESCRIPTION
Tiny update to the token usage counter to pull from `llmOutput.usage` or `llmOutput.estimatedTokenUsage` if `llmOutput.tokenUsage` is not available.