### PR TITLE
feat(core): Write temp dataset file as JSONL to avoid escaping issues

### DIFF
--- a/src/utils/datasets.ts
+++ b/src/utils/datasets.ts
@@ -56,18 +56,14 @@ function parseDataset(dataset: DatasetType): [PathLike, DatasetFormat] {
     const datasetRows = transposeDictToRows(
       dataset as Record<string, string[]>
     );
-    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.CSV}`);
-    const header = Object.keys(datasetRows[0]).join(',') + '\n';
-    const rows = datasetRows
-      .map((row) => Object.values(row).join(','))
-      .join('\n');
-    writeFileSync(tempFilePath, header + rows, { encoding: 'utf-8' });
+    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.JSONL}`);
+    const rows = datasetRows.map((row) => JSON.stringify(row)).join('\n');
+    writeFileSync(tempFilePath, rows, { encoding: 'utf-8' });
     datasetPath = tempFilePath;
   } else if (Array.isArray(dataset)) {
-    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.CSV}`);
-    const header = Object.keys(dataset[0]).join(',') + '\n';
-    const rows = dataset.map((row) => Object.values(row).join(',')).join('\n');
-    writeFileSync(tempFilePath, header + rows, { encoding: 'utf-8' });
+    const tempFilePath = join(tmpdir(), `temp.${DatasetFormat.JSONL}`);
+    const rows = dataset.map((row) => JSON.stringify(row)).join('\n');
+    writeFileSync(tempFilePath, rows, { encoding: 'utf-8' });
     datasetPath = tempFilePath;
   } else {
     throw new Error(


### PR DESCRIPTION
When creating a dataset we first save it to a temporary file. If the
content is JSON strings then they need to be escaped properly with
double quotes, which isn't a very good UX. This changes the logic to
save the data as a temporary JSONL file instead, which doesn't require
any special escaping logic.

---
To upload a dataset like this (with valid JSON)...
![image](https://github.com/user-attachments/assets/5a8de1e3-0832-4bd7-b11b-3fe690164361)

You previously had to do this:
```typescript
let input1 = JSON.stringify({"virtue": "benevolence", "voice": "Oprah Winfrey"}).replace(/"/g, '""');
input1 = `"${input1}"`;

let input2 = JSON.stringify({"virtue": "trustworthiness", "voice": "Barack Obama"}).replace(/"/g, '""');
input2 = `"${input2}"`;

const dataset = await createDataset(
    {
        input: [input1, input2],
    },
    "My data"
);
```

And with this change you just need to do this:

```typescript
let input1 = JSON.stringify({"virtue": "benevolence", "voice": "Oprah Winfrey"});
let input2 = JSON.stringify({"virtue": "trustworthiness", "voice": "Barack Obama"});

const dataset = await createDataset(
    {
        input: [input1, input2],
    },
    "My data"
);
```