### PR TITLE
fix: adding tools to Langchain llm nodes and more...

### DIFF
--- a/src/api-client/services/trace-service.ts
+++ b/src/api-client/services/trace-service.ts
@@ -50,7 +50,5 @@ export class TraceService extends BaseClient {
     console.log(
       `🚀 ${traces.length} Traces ingested for project ${this.projectId}.`
     );
-    // eslint-disable-next-line no-console
-    console.log(JSON.stringify(traces, null, 2));
   }
 }

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -172,6 +172,7 @@ export class GalileoCallback
         output,
         model: node.spanParams.model,
         temperature: node.spanParams.temperature,
+        tools: 'tools' in node.spanParams ? node.spanParams.tools : undefined,
         name,
         metadata,
         tags,

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -18,7 +18,7 @@ type PromptTemplateType = PromptTemplate | PromptTemplateVersion;
 type DatasetWithFunction<T extends Record<string, unknown>> = {
   name: string;
   dataset: DatasetType;
-  function: (input: T, metadata?: Record<string, string>) => Promise<unknown[]>;
+  function: (input: T, metadata?: Record<string, string>) => Promise<unknown>;
   metrics?: string[];
   projectName: string;
 };
@@ -26,7 +26,7 @@ type DatasetWithFunction<T extends Record<string, unknown>> = {
 type DatasetIdWithFunction<T extends Record<string, unknown>> = {
   name: string;
   datasetId: string;
-  function: (input: T, metadata?: Record<string, string>) => Promise<unknown[]>;
+  function: (input: T, metadata?: Record<string, string>) => Promise<unknown>;
   metrics?: string[];
   projectName: string;
 };
@@ -34,7 +34,7 @@ type DatasetIdWithFunction<T extends Record<string, unknown>> = {
 type DatasetNameWithFunction<T extends Record<string, unknown>> = {
   name: string;
   datasetName: string;
-  function: (input: T, metadata?: Record<string, string>) => Promise<unknown[]>;
+  function: (input: T, metadata?: Record<string, string>) => Promise<unknown>;
   metrics?: string[];
   projectName: string;
 };
@@ -151,7 +151,7 @@ export const getExperiment = async ({
  */
 const processRow = async <T extends Record<string, unknown>>(
   row: T,
-  processFn: (input: T, metadata?: Record<string, string>) => Promise<unknown[]>
+  processFn: (input: T, metadata?: Record<string, string>) => Promise<unknown>
 ): Promise<string> => {
   const metadata: Record<string, string> = {
     timestamp: new Date().toISOString()
@@ -198,7 +198,7 @@ const runExperimentWithFunction = async <T extends Record<string, unknown>>(
   experiment: Experiment,
   projectName: string,
   datasetContent: Record<string, unknown>[],
-  processFn: (input: T, metadata?: Record<string, string>) => Promise<unknown[]>
+  processFn: (input: T, metadata?: Record<string, string>) => Promise<unknown>
 ): Promise<string[]> => {
   const outputs: string[] = [];
 

--- a/tests/utils/serialization.test.ts
+++ b/tests/utils/serialization.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { extractParamsInfo, argsToDict } from '../../src/utils/serialization';
 
 describe('Extract Function Parameters', () => {

--- a/tests/utils/serialization.test.ts
+++ b/tests/utils/serialization.test.ts
@@ -1,0 +1,55 @@
+import { extractParamsInfo, argsToDict } from '../../src/utils/serialization';
+
+describe('Extract Function Parameters', () => {
+  it('should extract parameters and default values', () => {
+    const fn = async (a: number, b: string = 'default', c?: boolean) => {};
+    const paramsInfo = extractParamsInfo(fn);
+    expect(paramsInfo).toEqual([
+      { name: 'a', defaultValue: undefined },
+      { name: 'b', defaultValue: 'default' },
+      { name: 'c', defaultValue: undefined }
+    ]);
+  });
+
+  it('should handle empty parameters', () => {
+    const fn = async () => {};
+    const paramsInfo = extractParamsInfo(fn);
+    expect(paramsInfo).toEqual([]);
+  });
+
+  it('should handle parameters with no default values', () => {
+    const fn = async (a: number, b: string, c?: boolean) => {};
+    const paramsInfo = extractParamsInfo(fn);
+    expect(paramsInfo).toEqual([
+      { name: 'a', defaultValue: undefined },
+      { name: 'b', defaultValue: undefined },
+      { name: 'c', defaultValue: undefined }
+    ]);
+  });
+});
+
+describe('Convert Arguments to Dictionary', () => {
+  it('should convert arguments to dictionary', () => {
+    const fn = async (a: number, b: string = 'default', c?: boolean) => {};
+    const paramsInfo = extractParamsInfo(fn);
+    const args = [1, 'test'];
+    const dict = argsToDict(paramsInfo, args);
+    expect(dict).toEqual({
+      a: '1',
+      b: 'test',
+      c: undefined
+    });
+  });
+
+  it('should handle empty arguments', () => {
+    const fn = async (a: number, b: string = 'default', c?: boolean) => {};
+    const paramsInfo = extractParamsInfo(fn);
+    const args: unknown[] = [];
+    const dict = argsToDict(paramsInfo, args);
+    expect(dict).toEqual({
+      a: undefined,
+      b: 'default',
+      c: undefined
+    });
+  });
+});


### PR DESCRIPTION
- Removing trace outputs from the flush function
- Relaxing the runner function output type
- Adding unit tests for serialization methods

Tickets:
https://app.shortcut.com/galileo/story/27574/g2-0-typescript-sdk-function-decorator-is-not-parsing-input-params
https://app.shortcut.com/galileo/story/27071/the-quickstart-typescript-app-prints-the-entire-trace-json
https://app.shortcut.com/galileo/story/27310/experiments-runner-is-expecting-an-array-but-in-many-cases-this-isn-t-needed
https://app.shortcut.com/galileo/story/27232/langchain-integration-doesn-t-log-tools