### PR TITLE
feat: making it easier to import types using "galileo/types"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galileo",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galileo",
-      "version": "1.5.1",
+      "version": "1.6.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,18 @@
   "description": "JS client for Galileo",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./types": {
+      "import": "./dist/types/index.js",
+      "require": "./dist/types/index.js",
+      "types": "./dist/types/index.d.ts"
+    }
+  },
   "scripts": {
     "build": "npm run format && npm run lint && tsc",
     "test": "jest --detectOpenHandles --forceExit --silent",

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,11 @@
+// Re-export types from selected individual type files
+export * from './message.types';
+export * from './document.types';
+export * from './log.types';
+export * from './prompt-template.types';
+export * from './dataset.types';
+export * from './experiment.types';
+export * from './project.types';
+export * from './log-stream.types';
+export * from './models.types';
+export * from './scorer.types';


### PR DESCRIPTION
Before:
```
import { Message, MessageRole } from "galileo/dist/types/message.types";
```

After:
```
import { Message, MessageRole } from "galileo/types";
```

https://app.shortcut.com/galileo/story/27311/typescript-sdk-it-should-be-easier-to-import-messagerole