### PR TITLE
feat: Turn off logging by setting the GALILEO_LOGGING_DISABLED env var

### DIFF
--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -104,32 +104,32 @@ class GalileoLogger {
 
     this.startTrace = skipIfDisabled(
       this.startTrace,
-      (args) => new Trace(emptySpanData)
+      () => new Trace(emptySpanData)
     );
 
     this.addSingleLlmSpanTrace = skipIfDisabled(
       this.addSingleLlmSpanTrace,
-      (args) => new Trace(emptySpanData)
+      () => new Trace(emptySpanData)
     );
 
     this.addLlmSpan = skipIfDisabled(
       this.addLlmSpan,
-      (args) => new LlmSpan(emptySpanData)
+      () => new LlmSpan(emptySpanData)
     );
 
     this.addRetrieverSpan = skipIfDisabled(
       this.addRetrieverSpan,
-      (args) => new RetrieverSpan(emptySpanData)
+      () => new RetrieverSpan(emptySpanData)
     );
 
     this.addToolSpan = skipIfDisabled(
       this.addToolSpan,
-      (args) => new ToolSpan(emptySpanData)
+      () => new ToolSpan(emptySpanData)
     );
 
     this.addWorkflowSpan = skipIfDisabled(
       this.addWorkflowSpan,
-      (args) => new WorkflowSpan(emptySpanData)
+      () => new WorkflowSpan(emptySpanData)
     );
 
     this.conclude = skipIfDisabled(this.conclude, () => undefined);

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -71,14 +71,12 @@ class GalileoLogger {
     this.experimentId = config.experimentId;
     try {
       // Logging is disabled if GALILEO_DISABLE_LOGGING is defined, is not an empty string, and not set to '0' or 'false'
-      const disableLoggingValue = process?.env?.GALILEO_DISABLE_LOGGING
-        ? process.env.GALILEO_DISABLE_LOGGING.trim()
-        : undefined;
+      const disableLoggingValue =
+        process?.env?.GALILEO_DISABLE_LOGGING?.trim() ?? undefined;
 
-      this.loggingDisabled =
-        disableLoggingValue !== undefined &&
-        disableLoggingValue !== '0' &&
-        disableLoggingValue.toLowerCase() !== 'false';
+      this.loggingDisabled = !['', '0', 'false'].includes(
+        disableLoggingValue?.toLowerCase() ?? ''
+      );
     } catch (error) {
       console.error(
         'Error checking if logging is disabled; GALILEO_DISABLE_LOGGING environment variable is not set correctly:',

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -153,9 +153,6 @@ class GalileoLogger {
   }
 
   addChildSpanToParent(span: Span): void {
-    // Skip if logging is disabled
-    if (this.loggingDisabled) return;
-
     const currentParent = this.currentParent();
     if (currentParent === undefined) {
       throw new Error('A trace needs to be created in order to add a span.');

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -180,11 +180,6 @@ class GalileoLogger {
     metadata?: Record<string, string>;
     tags?: string[];
   }): Trace {
-    // Return an empty trace when logging is disabled
-    if (this.loggingDisabled) {
-      return new Trace({ input, output: output || '' });
-    }
-
     if (this.currentParent() !== undefined) {
       throw new Error(
         'You must conclude the existing trace before adding a new one.'
@@ -239,11 +234,6 @@ class GalileoLogger {
     temperature?: number;
     statusCode?: number;
   }): Trace {
-    // Return an empty trace when logging is disabled
-    if (this.loggingDisabled) {
-      return new Trace({ input, output });
-    }
-
     /**
      * Create a new trace with a single span and add it to the list of traces.
      */
@@ -321,11 +311,6 @@ class GalileoLogger {
     temperature?: number;
     statusCode?: number;
   }): LlmSpan {
-    // Return an empty LlmSpan when logging is disabled
-    if (this.loggingDisabled) {
-      return new LlmSpan({ input, output });
-    }
-
     /**
      * Add a new llm span to the current parent.
      */
@@ -370,11 +355,6 @@ class GalileoLogger {
     tags?: string[];
     statusCode?: number;
   }): RetrieverSpan {
-    // Return an empty RetrieverSpan when logging is disabled
-    if (this.loggingDisabled) {
-      return new RetrieverSpan({ input, output });
-    }
-
     /**
      * Add a new retriever span to the current parent.
      */
@@ -414,11 +394,6 @@ class GalileoLogger {
     statusCode?: number;
     toolCallId?: string;
   }): ToolSpan {
-    // Return an empty ToolSpan when logging is disabled
-    if (this.loggingDisabled) {
-      return new ToolSpan({ input, output });
-    }
-
     /**
      * Add a new tool span to the current parent.
      */
@@ -455,11 +430,6 @@ class GalileoLogger {
     metadata?: Record<string, string>;
     tags?: string[];
   }): WorkflowSpan {
-    // Return an empty WorkflowSpan when logging is disabled
-    if (this.loggingDisabled) {
-      return new WorkflowSpan({ input, output });
-    }
-
     /**
      * Add a workflow span to the current parent. This is useful when you want to create a nested workflow span
      * within the trace or current workflow span. The next span you add will be a child of the current parent. To
@@ -489,9 +459,6 @@ class GalileoLogger {
     durationNs?: number;
     statusCode?: number;
   }): StepWithChildSpans | undefined {
-    // Skip if logging is disabled
-    if (this.loggingDisabled) return undefined;
-
     /**
      * Conclude the current trace or workflow span by setting the output of the current node. In the case of nested
      * workflow spans, this will point the workflow back to the parent of the current workflow span.
@@ -520,11 +487,6 @@ class GalileoLogger {
   }
 
   async flush(): Promise<Trace[]> {
-    // Skip if logging is disabled
-    if (this.loggingDisabled) {
-      return [];
-    }
-
     try {
       if (!this.traces.length) {
         console.warn('No traces to flush.');
@@ -554,9 +516,6 @@ class GalileoLogger {
   }
 
   async terminate(): Promise<void> {
-    // Skip if logging is disabled
-    if (this.loggingDisabled) return;
-
     try {
       await this.flush();
     } catch (error) {

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -71,12 +71,9 @@ class GalileoLogger {
     this.experimentId = config.experimentId;
     try {
       // Logging is disabled if GALILEO_DISABLE_LOGGING is defined, is not an empty string, and not set to '0' or 'false'
-      const disableLoggingValue =
-        typeof process !== 'undefined' && typeof process.env !== 'undefined'
-          ? process.env.GALILEO_DISABLE_LOGGING
-            ? process.env.GALILEO_DISABLE_LOGGING.trim()
-            : undefined
-          : undefined;
+      const disableLoggingValue = process?.env?.GALILEO_DISABLE_LOGGING
+        ? process.env.GALILEO_DISABLE_LOGGING.trim()
+        : undefined;
 
       this.loggingDisabled =
         disableLoggingValue !== undefined &&

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -69,6 +69,194 @@ describe('GalileoLogger', () => {
     });
   });
 
+  describe('GALILEO_DISABLE_LOGGING Environment Variable', () => {
+    beforeEach(() => {
+      delete process.env.GALILEO_DISABLE_LOGGING;
+    });
+
+    it('should enable logging by default when GALILEO_DISABLE_LOGGING is undefined', () => {
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeFalsy();
+    });
+
+    it('should enable logging when GALILEO_DISABLE_LOGGING is set to "0"', () => {
+      process.env.GALILEO_DISABLE_LOGGING = '0';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeFalsy();
+    });
+
+    it('should enable logging when GALILEO_DISABLE_LOGGING is set to "false"', () => {
+      process.env.GALILEO_DISABLE_LOGGING = 'false';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeFalsy();
+    });
+
+    it('should enable logging when GALILEO_DISABLE_LOGGING is set to "FALSE" (case insensitive)', () => {
+      process.env.GALILEO_DISABLE_LOGGING = 'FALSE';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeFalsy();
+    });
+
+    it('should disable logging when GALILEO_DISABLE_LOGGING is set to "1"', () => {
+      process.env.GALILEO_DISABLE_LOGGING = '1';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeTruthy();
+    });
+
+    it('should disable logging when GALILEO_DISABLE_LOGGING is set to "true"', () => {
+      process.env.GALILEO_DISABLE_LOGGING = 'true';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeTruthy();
+    });
+
+    it('should not disable logging when GALILEO_DISABLE_LOGGING is set to an empty string', () => {
+      process.env.GALILEO_DISABLE_LOGGING = '';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeFalsy();
+    });
+
+    it('should disable logging when GALILEO_DISABLE_LOGGING is set to any other string', () => {
+      process.env.GALILEO_DISABLE_LOGGING = 'yes';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeTruthy();
+    });
+  });
+
+  describe('Logger behavior when logging is disabled', () => {
+    beforeEach(() => {
+      process.env.GALILEO_DISABLE_LOGGING = 'true';
+      logger = new GalileoLogger();
+    });
+
+    it('should return empty objects for startTrace when logging is disabled', () => {
+      const trace = logger.startTrace({ input: 'test input' });
+      expect(trace).toBeInstanceOf(Trace);
+      expect(trace.input).toBe('');
+      expect(logger['traces'].length).toBe(0); // Verify no trace was added
+    });
+
+    it('should return empty objects for addSingleLlmSpanTrace when logging is disabled', () => {
+      const trace = logger.addSingleLlmSpanTrace({
+        input: 'test input',
+        output: 'test output',
+        model: 'gpt-4'
+      });
+      expect(trace).toBeInstanceOf(Trace);
+      expect(trace.input).toBe('');
+      expect(logger['traces'].length).toBe(0); // Verify no trace was added
+    });
+
+    it('should return empty objects for addLlmSpan when logging is disabled', () => {
+      // First create a trace (which will be a no-op due to disabled logging)
+      logger.startTrace({ input: 'test input' });
+
+      const span = logger.addLlmSpan({
+        input: 'test input',
+        output: 'test output',
+        model: 'gpt-4'
+      });
+
+      expect(span).toBeInstanceOf(LlmSpan);
+      expect(span.input).toStrictEqual([
+        { content: '', role: 'user' } as Message
+      ]);
+      expect(span.output).toStrictEqual({
+        content: '',
+        role: 'assistant'
+      } as Message);
+    });
+
+    it('should return empty objects for addRetrieverSpan when logging is disabled', () => {
+      // First create a trace (which will be a no-op due to disabled logging)
+      logger.startTrace({ input: 'test input' });
+
+      const span = logger.addRetrieverSpan({
+        input: 'test input',
+        output: []
+      });
+
+      expect(span).toBeInstanceOf(RetrieverSpan);
+      expect(span.input).toBe('');
+    });
+
+    it('should return empty objects for addToolSpan when logging is disabled', () => {
+      // First create a trace (which will be a no-op due to disabled logging)
+      logger.startTrace({ input: 'test input' });
+
+      const span = logger.addToolSpan({
+        input: 'test input',
+        output: 'test output'
+      });
+
+      expect(span).toBeInstanceOf(ToolSpan);
+      expect(span.input).toBe('');
+    });
+
+    it('should return empty objects for addWorkflowSpan when logging is disabled', () => {
+      // First create a trace (which will be a no-op due to disabled logging)
+      logger.startTrace({ input: 'test input' });
+
+      const span = logger.addWorkflowSpan({
+        input: 'test input',
+        output: 'test output'
+      });
+
+      expect(span).toBeInstanceOf(WorkflowSpan);
+      expect(span.input).toBe('');
+    });
+
+    it('should return undefined for conclude when logging is disabled', () => {
+      // First create a trace (which will be a no-op due to disabled logging)
+      logger.startTrace({ input: 'test input' });
+
+      const result = logger.conclude({ output: 'test output' });
+      expect(result).toBeUndefined();
+    });
+
+    it('should return empty array for flush when logging is disabled', async () => {
+      const result = await logger.flush();
+      expect(result).toEqual([]);
+    });
+
+    it('should not throw error for terminate when logging is disabled', async () => {
+      await expect(logger.terminate()).resolves.toBeUndefined();
+    });
+  });
+
+  describe('Logger behavior when logging is enabled', () => {
+    beforeEach(() => {
+      process.env.GALILEO_DISABLE_LOGGING = 'false'; // Explicitly enable logging
+      logger = new GalileoLogger();
+    });
+
+    it('should properly create and store traces when logging is enabled', () => {
+      const trace = logger.startTrace({ input: 'test input' });
+      expect(trace).toBeInstanceOf(Trace);
+      expect(trace.input).toBe('test input');
+      expect(logger['traces'].length).toBe(1); // Verify trace was added
+    });
+
+    it('should properly create and store LLM spans when logging is enabled', () => {
+      logger.startTrace({ input: 'test input' });
+
+      const span = logger.addLlmSpan({
+        input: 'test input',
+        output: 'test output',
+        model: 'gpt-4'
+      });
+
+      expect(span).toBeInstanceOf(LlmSpan);
+      expect(span.input).toStrictEqual([
+        { content: 'test input', role: 'user' } as Message
+      ]);
+      expect(span.output).toStrictEqual({
+        content: 'test output',
+        role: 'assistant'
+      } as Message);
+      expect(span.model).toBe('gpt-4');
+    });
+  });
+
   describe('Trace and Span Management', () => {
     beforeEach(() => {
       logger = new GalileoLogger();

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -115,6 +115,12 @@ describe('GalileoLogger', () => {
       expect(logger.isLoggingDisabled()).toBeFalsy();
     });
 
+    it('should not disable logging when GALILEO_DISABLE_LOGGING is set to whitespace string', () => {
+      process.env.GALILEO_DISABLE_LOGGING = ' ';
+      logger = new GalileoLogger();
+      expect(logger.isLoggingDisabled()).toBeFalsy();
+    });
+
     it('should disable logging when GALILEO_DISABLE_LOGGING is set to any other string', () => {
       process.env.GALILEO_DISABLE_LOGGING = 'yes';
       logger = new GalileoLogger();


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/26366/g2-0-ts-sdk-add-a-way-to-turn-off-logging

Mirroring the functionality in the Python client library