### PR TITLE
fix: Use structuredClone for LLM input/output in LlmSpan class

### DIFF
--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -204,8 +204,11 @@ export class LlmSpan extends BaseStep {
     tags?: string[];
   }) {
     super({ ...data, type: NodeType.llm });
-    this.input = convertLlmInputOutput(data.input);
-    this.output = convertLlmInputOutput(data.output, MessageRole.assistant)[0];
+    this.input = convertLlmInputOutput(structuredClone(data.input));
+    this.output = convertLlmInputOutput(
+      structuredClone(data.output),
+      MessageRole.assistant
+    )[0];
     this.tools = data.tools;
     this.model = data.model;
     this.inputTokens = data.inputTokens;


### PR DESCRIPTION
**Ticket:**

- [sc-28067](https://app.shortcut.com/galileo/story/28067/typescript-sdk-llm-span-input-logs-entire-conversation-chat-history-at-every-step)

**Description:**

This pull request includes changes to ensure message history integrity of LLM spans. The most important changes involve modifying how input and output data are processed and adding a new test case to validate the integrity of message history when LLM spans are added.

**Tests:**
- [x] CI
- [x] Manual