### PR TITLE
fix: Relax the input type constraint on MessageRole

### DIFF
--- a/examples/prompts/createprompt.js
+++ b/examples/prompts/createprompt.js
@@ -1,9 +1,9 @@
 import 'dotenv/config';
-import { createPromptTemplate} from 'galileo';
+import { createPromptTemplate } from 'galileo';
 
 const template = await createPromptTemplate({
-    template: "Hi Andrii!",
-    projectName: 'my-test-project-5',
-    name: `Hello name prompt`
+  template: 'Hi Andrii!',
+  projectName: 'my-test-project-5',
+  name: `Hello name prompt`
 });
 console.log(template);

--- a/examples/prompts/createprompt.js
+++ b/examples/prompts/createprompt.js
@@ -1,0 +1,9 @@
+import 'dotenv/config';
+import { createPromptTemplate} from 'galileo';
+
+const template = await createPromptTemplate({
+    template: "Hi Andrii!",
+    projectName: 'my-test-project-5',
+    name: `Hello name prompt`
+});
+console.log(template);

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "lint": "eslint .",
     "lint-fix": "eslint . --fix",
     "format": "prettier --config .prettierrc.js 'src/**/*.ts' --write",
+    "format-examples": "prettier --config .prettierrc.js 'examples/**/*.js' --write",
     "fetch-api-types": "npx openapi-typescript https://api.galileo.ai/client/openapi.json --default-non-nullable=false --output src/types/api.types.ts"
   },
   "author": "Galileo Technologies Inc. <team@galileo.ai>",

--- a/src/utils/prompt-templates.ts
+++ b/src/utils/prompt-templates.ts
@@ -1,5 +1,5 @@
 import { GalileoApiClient } from '../api-client';
-import { Message } from '../types/message.types';
+import { Message, MessageRole } from '../types/message.types';
 import {
   PromptTemplate,
   PromptTemplateVersion
@@ -52,13 +52,19 @@ export const createPromptTemplate = async ({
   name,
   projectName
 }: {
-  template: Message[];
+  template: Message[] | string;
   name: string;
   projectName: string;
 }): Promise<PromptTemplate> => {
   const apiClient = new GalileoApiClient();
   await apiClient.init({ projectName });
+  let tmp: Message[];
 
-  const createdTemplate = await apiClient.createPromptTemplate(template, name);
+  if (typeof template === 'string') {
+    tmp = [{ content: template, role: MessageRole.user }];
+  } else {
+    tmp = template;
+  }
+  const createdTemplate = await apiClient.createPromptTemplate(tmp, name);
   return createdTemplate;
 };


### PR DESCRIPTION
This PR solves https://app.shortcut.com/galileo/story/26800/g2-0-typescript-sdk-relax-the-input-type-constraint-on-messagerole

## How to test:

```
➜  galileo-js git:(relax-the-input-type-constraint) ✗ node examples/prompts/createprompt.js
{
  name: 'Hello name prompt!',
  id: '1656acc7-6c9f-4819-8484-36ef46641c57',
  template: 'Hi Andrii!',
  selected_version: {
    template: 'Hi Andrii!',
    version: 0,
    id: 'd43ddfee-2f97-4a30-becd-1e8205aea242'
  },
  selected_version_id: 'd43ddfee-2f97-4a30-becd-1e8205aea242',
  all_versions: [
    {
      template: 'Hi Andrii!',
      version: 0,
      id: 'd43ddfee-2f97-4a30-becd-1e8205aea242'
    }
  ],
  all_available_versions: [ 0 ],
  total_versions: 1,
  max_version: 0
}

```