### PR TITLE
feat: Adding a getLogger() method to access the singleton logger

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {
   runExperiment
 } from './utils/experiments';
 import { GalileoLogger } from './utils/galileo-logger';
-import { init, flush } from './singleton';
+import { init, flush, getLogger } from './singleton';
 import { log } from './wrappers';
 import { wrapOpenAI } from './openai';
 import { GalileoCallback } from './handlers/langchain';
@@ -70,5 +70,6 @@ export {
   // Logging
   log,
   init,
-  flush
+  flush,
+  getLogger
 };

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -67,7 +67,48 @@ export const init = (
 
 /*
  * Uploads all captured traces to the Galileo platform
+ *
+ * Example:
+ *
+ * ```typescript
+ * import { init, flush } from 'galileo';
+ *
+ * // Initialize the global context
+ * // If you have GALILEO_PROJECT and GALILEO_LOG_STREAM environment variables set, you can skip this step
+ * init({
+ *   projectName: 'my-project',
+ *   logStreamName: 'my-log-stream'
+ * });
+ *
+ * // Your application logging code here
+ *
+ * // Upload all captured traces
+ * await flush();
+ * ```
  */
 export const flush = async () => {
   await GalileoSingleton.getInstance().getClient().flush();
+};
+
+/*
+ * Returns the singleton client logger
+ *
+ * Example:
+ *
+ * ```typescript
+ * import { init,getLogger } from 'galileo';
+ *
+ * // Initialize the global context
+ * // If you have GALILEO_PROJECT and GALILEO_LOG_STREAM environment variables set, you can skip this step
+ * init({
+ *   projectName: 'my-project',
+ *   logStreamName: 'my-log-stream'
+ * });
+ *
+ * const logger = getLogger();
+ * logger.info('Hello, world!');
+ * ```
+ */
+export const getLogger = () => {
+  return GalileoSingleton.getInstance().getClient();
 };


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/28601/typescript-sdk-using-openai-wrapper-logs-every-llm-step-as-a-different-trace-unless-workflow-is-used

This will allow users to access singleton logger and start a trace that can be added to in wrapped calls:

```
import { wrapOpenAI, flush, init, getLogger, wrapOpenAI } from 'galileo';
import { OpenAI } from 'openai';

const openai = wrapOpenAI(
  new OpenAI({ apiKey: process.env.OPENAI_API_KEY })
);

await init({
  projectName: 'my-test-project-4',
  logStreamName: 'my-test-log-stream'
});

// Get the singleton logger instance
const logger = await getLogger();

logger.startTrace(...);

const result1 = await openai.chat.completions.create({
  model: 'gpt-4o',
  messages: [{ content: 'Say hello world!', role: 'user' }]
});

const result2 = await openai.chat.completions.create({
  model: 'gpt-4o',
  messages: [{ content: 'Say hello world!', role: 'user' }]
});

logger.conclude(...);

await flush();
```