### PR TITLE
feat: adding Session management

### DIFF
--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -9,7 +9,7 @@ import { PromptTemplateService } from './services/prompt-template-service';
 import { DatasetService, DatasetAppendRow } from './services/dataset-service';
 import { TraceService } from './services/trace-service';
 import { ExperimentService } from './services/experiment-service';
-import { Session, SessionCreateResponse } from '../types/log.types';
+import { SessionCreateResponse } from '../types/log.types';
 import {
   CreateJobResponse,
   PromptRunSettings

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -24,6 +24,7 @@ export class GalileoApiClientParams {
   public runId?: string = undefined;
   public datasetId?: string = undefined;
   public experimentId?: string = undefined;
+  public sessionId?: string = undefined;
   public projectScoped: boolean = true;
 }
 
@@ -34,6 +35,7 @@ export class GalileoApiClient extends BaseClient {
   public runId: string = '';
   public datasetId: string = '';
   public experimentId: string = '';
+  public sessionId: string = '';
   public projectScoped: boolean = true;
 
   // Service instances
@@ -58,6 +60,7 @@ export class GalileoApiClient extends BaseClient {
       runId = defaultParams.runId,
       datasetId = defaultParams.datasetId,
       experimentId = defaultParams.experimentId,
+      sessionId = defaultParams.sessionId,
       projectScoped = defaultParams.projectScoped
     } = params;
 
@@ -147,12 +150,17 @@ export class GalileoApiClient extends BaseClient {
           }
         }
 
+        if (sessionId) {
+          this.sessionId = sessionId;
+        }
+
         this.traceService = new TraceService(
           this.apiUrl,
           this.token,
           this.projectId,
           this.logStreamId,
-          this.experimentId
+          this.experimentId,
+          this.sessionId
         );
 
         this.promptTemplateService = new PromptTemplateService(

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -260,9 +260,9 @@ export class GalileoApiClient extends BaseClient {
   }
 
   // Trace methods - delegate to TraceService
-  public async ingestTraces(traces: any[], sessionId?: string) {
+  public async ingestTraces(traces: any[]) {
     this.ensureService(this.traceService);
-    return this.traceService!.ingestTraces(traces, sessionId);
+    return this.traceService!.ingestTraces(traces);
   }
 
   public async createSession({

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -9,6 +9,7 @@ import { PromptTemplateService } from './services/prompt-template-service';
 import { DatasetService, DatasetAppendRow } from './services/dataset-service';
 import { TraceService } from './services/trace-service';
 import { ExperimentService } from './services/experiment-service';
+import { Session, SessionCreateResponse } from '../types/log.types';
 import {
   CreateJobResponse,
   PromptRunSettings
@@ -259,9 +260,26 @@ export class GalileoApiClient extends BaseClient {
   }
 
   // Trace methods - delegate to TraceService
-  public async ingestTraces(traces: any[]) {
+  public async ingestTraces(traces: any[], sessionId?: string) {
     this.ensureService(this.traceService);
-    return this.traceService!.ingestTraces(traces);
+    return this.traceService!.ingestTraces(traces, sessionId);
+  }
+
+  public async createSession({
+    name,
+    previousSessionId,
+    externalId
+  }: {
+    name?: string;
+    previousSessionId?: string;
+    externalId?: string;
+  }): Promise<SessionCreateResponse> {
+    this.ensureService(this.traceService);
+    return this.traceService!.createSession({
+      name,
+      previousSessionId,
+      externalId
+    });
   }
 
   // PromptTemplate methods - delegate to PromptTemplateService

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -36,7 +36,7 @@ export class GalileoApiClient extends BaseClient {
   public runId: string = '';
   public datasetId: string = '';
   public experimentId: string = '';
-  public sessionId: string = '';
+  public sessionId?: string = undefined;
   public projectScoped: boolean = true;
 
   // Service instances

--- a/src/api-client/services/trace-service.ts
+++ b/src/api-client/services/trace-service.ts
@@ -37,7 +37,7 @@ export class TraceService extends BaseClient {
   }): Promise<SessionCreateResponse> {
     return await this.makeRequest<SessionCreateResponse>(
       RequestMethod.POST,
-      Routes.traces,
+      Routes.sessions,
       {
         log_stream_id: this.logStreamId,
         name,
@@ -71,9 +71,7 @@ export class TraceService extends BaseClient {
         ...(!this.experimentId && {
           log_stream_id: this.logStreamId
         }),
-        ...(sessionId && {
-          session_id: sessionId
-        })
+        session_id: sessionId
       },
       { project_id: this.projectId }
     );

--- a/src/api-client/services/trace-service.ts
+++ b/src/api-client/services/trace-service.ts
@@ -1,6 +1,6 @@
 import { BaseClient, RequestMethod } from '../base-client';
 import { Routes } from '../../types/routes.types';
-import { Trace, Session } from '../../types/log.types';
+import { Trace, SessionCreateResponse } from '../../types/log.types';
 
 export class TraceService extends BaseClient {
   private projectId: string;
@@ -34,8 +34,8 @@ export class TraceService extends BaseClient {
     name?: string;
     previousSessionId?: string;
     externalId?: string;
-  }): Promise<Session> {
-    return await this.makeRequest<Session>(
+  }): Promise<SessionCreateResponse> {
+    return await this.makeRequest<SessionCreateResponse>(
       RequestMethod.POST,
       Routes.traces,
       {

--- a/src/api-client/services/trace-service.ts
+++ b/src/api-client/services/trace-service.ts
@@ -6,13 +6,15 @@ export class TraceService extends BaseClient {
   private projectId: string;
   private logStreamId: string | undefined;
   private experimentId: string | undefined;
+  private sessionId: string | undefined;
 
   constructor(
     apiUrl: string,
     token: string,
     projectId: string,
     logStreamId?: string,
-    experimentId?: string
+    experimentId?: string,
+    sessionId?: string
   ) {
     super();
     this.apiUrl = apiUrl;
@@ -20,6 +22,7 @@ export class TraceService extends BaseClient {
     this.projectId = projectId;
     this.logStreamId = logStreamId;
     this.experimentId = experimentId;
+    this.sessionId = sessionId;
     this.initializeClient();
   }
 
@@ -42,6 +45,9 @@ export class TraceService extends BaseClient {
         }),
         ...(!this.experimentId && {
           log_stream_id: this.logStreamId
+        }),
+        ...(this.sessionId && {
+          session_id: this.sessionId
         })
       },
       { project_id: this.projectId }

--- a/src/api-client/services/trace-service.ts
+++ b/src/api-client/services/trace-service.ts
@@ -48,10 +48,7 @@ export class TraceService extends BaseClient {
     );
   }
 
-  public async ingestTraces(
-    traces: Trace[],
-    sessionId?: string
-  ): Promise<void> {
+  public async ingestTraces(traces: Trace[]): Promise<void> {
     if (!this.projectId) {
       throw new Error('Project not initialized');
     }
@@ -71,7 +68,7 @@ export class TraceService extends BaseClient {
         ...(!this.experimentId && {
           log_stream_id: this.logStreamId
         }),
-        session_id: sessionId
+        session_id: this.sessionId
       },
       { project_id: this.projectId }
     );

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -25,22 +25,27 @@ export class GalileoSingleton {
     this.client = client;
   }
 
-  public init(options: {
+  public async init(options: {
     projectName?: string | undefined;
     logStreamName?: string | undefined;
     experimentId?: string | undefined;
-    sessionId?: string | undefined;
     startNewSession?: boolean | undefined;
+    sessionName?: string | undefined;
+    previousSessionId?: string | undefined;
+    externalId?: string | undefined;
   }) {
     this.client = new GalileoLogger({
       projectName: options.projectName,
       logStreamName: options.logStreamName,
-      experimentId: options.experimentId,
-      sessionId: options.sessionId
+      experimentId: options.experimentId
     });
 
     if (options.startNewSession) {
-      this.client.startSession();
+      this.client.startSession({
+        name: options.sessionName,
+        previousSessionId: options.previousSessionId,
+        externalId: options.externalId
+      });
     }
   }
 }
@@ -62,7 +67,7 @@ export class GalileoSingleton {
  * });
  * ```
  */
-export const init = (
+export const init = async (
   options: {
     projectName?: string | undefined;
     logStreamName?: string | undefined;
@@ -71,7 +76,7 @@ export const init = (
     startNewSession?: boolean | undefined;
   } = {}
 ) => {
-  GalileoSingleton.getInstance().init(options);
+  await GalileoSingleton.getInstance().init(options);
 };
 
 /*

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -29,12 +29,19 @@ export class GalileoSingleton {
     projectName?: string | undefined;
     logStreamName?: string | undefined;
     experimentId?: string | undefined;
+    sessionId?: string | undefined;
+    startNewSession?: boolean | undefined;
   }) {
     this.client = new GalileoLogger({
       projectName: options.projectName,
       logStreamName: options.logStreamName,
-      experimentId: options.experimentId
+      experimentId: options.experimentId,
+      sessionId: options.sessionId
     });
+
+    if (options.startNewSession) {
+      this.client.startSession();
+    }
   }
 }
 
@@ -60,6 +67,8 @@ export const init = (
     projectName?: string | undefined;
     logStreamName?: string | undefined;
     experimentId?: string | undefined;
+    sessionId?: string | undefined;
+    startNewSession?: boolean | undefined;
   } = {}
 ) => {
   GalileoSingleton.getInstance().init(options);

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -19,6 +19,17 @@ import {
 import { Message, MessageRole } from '../types/message.types';
 import { convertLlmInputOutput, convertRetrieverOutput } from '../utils/span';
 
+export interface Session {
+  id: string;
+  name: string;
+  externalId?: string;
+  previousSessionId?: string;
+  createdAtNs?: number;
+  updatedAtNs?: number;
+  statusCode?: number;
+  metadata?: Record<string, string>;
+}
+
 export class SpanWithParentStep extends BaseStep {
   parent?: StepWithChildSpans;
 

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -29,17 +29,6 @@ export interface SessionCreateResponse {
   external_id?: string;
 }
 
-export interface Session {
-  id: string;
-  name: string;
-  externalId?: string;
-  previousSessionId?: string;
-  createdAtNs?: number;
-  updatedAtNs?: number;
-  statusCode?: number;
-  metadata?: Record<string, string>;
-}
-
 export class SpanWithParentStep extends BaseStep {
   parent?: StepWithChildSpans;
 

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -19,6 +19,16 @@ import {
 import { Message, MessageRole } from '../types/message.types';
 import { convertLlmInputOutput, convertRetrieverOutput } from '../utils/span';
 
+// TODO: Remove this interface once the API is updated
+export interface SessionCreateResponse {
+  id: string;
+  name?: string;
+  project_id: string;
+  project_name: string;
+  previous_session_id?: string;
+  external_id?: string;
+}
+
 export interface Session {
   id: string;
   name: string;

--- a/src/types/routes.types.ts
+++ b/src/types/routes.types.ts
@@ -21,6 +21,7 @@ export enum Routes {
   dataset = 'datasets/{dataset_id}',
   datasetContent = 'datasets/{dataset_id}/content',
   traces = 'projects/{project_id}/traces',
+  sessions = 'projects/{project_id}/sessions',
   scorers = 'scorers/list',
   runScorerSettings = 'projects/{project_id}/runs/{experiment_id}/scorer-settings',
   promptTemplates = 'projects/{project_id}/templates',

--- a/src/types/step.types.ts
+++ b/src/types/step.types.ts
@@ -12,7 +12,8 @@ enum NodeType {
   tool = 'tool',
   agent = 'agent',
   workflow = 'workflow',
-  trace = 'trace'
+  trace = 'trace',
+  session = 'session'
 }
 
 // Type definitions
@@ -60,6 +61,7 @@ export class BaseStep {
   modelConfig?: Record<string, any>;
   tags?: string[];
   metrics: Metrics = {};
+  externalId?: string;
 
   constructor(data: {
     type?: NodeType;
@@ -72,6 +74,7 @@ export class BaseStep {
     statusCode?: number;
     groundTruth?: string;
     tags?: string[];
+    externalId?: string;
   }) {
     this.type = data.type || NodeType.workflow;
     this.input = data.input;
@@ -84,6 +87,7 @@ export class BaseStep {
     this.statusCode = data.statusCode;
     this.groundTruth = data.groundTruth;
     this.tags = data.tags || [];
+    this.externalId = data.externalId;
 
     // Validate serializable
     this.validateInputOutputSerializable(this.input);
@@ -106,7 +110,8 @@ export class BaseStep {
       duration_ns: this.durationNs,
       userMetadata: this.userMetadata,
       status_code: this.statusCode,
-      ground_truth: this.groundTruth
+      ground_truth: this.groundTruth,
+      external_id: this.externalId
     };
   }
 }

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -584,14 +584,15 @@ class GalileoLogger {
       await this.client.init({
         projectName: this.projectName,
         logStreamName: this.logStreamName,
-        experimentId: this.experimentId
+        experimentId: this.experimentId,
+        sessionId: this.sessionId
       });
 
       console.info(`Flushing ${this.traces.length} traces...`);
       const loggedTraces = [...this.traces];
 
       //// @ts-expect-error - FIXME: Type this
-      await this.client.ingestTraces(loggedTraces, this.sessionId);
+      await this.client.ingestTraces(loggedTraces);
 
       console.info(`Successfully flushed ${loggedTraces.length} traces.`);
       this.traces = []; // Clear after uploading

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -15,11 +15,13 @@ import {
   BaseStep
 } from '../types/step.types';
 import { toStringValue } from './serialization';
+import { v4 as uuidv4 } from 'uuid';
 
 class GalileoLoggerConfig {
   public projectName?: string;
   public logStreamName?: string;
   public experimentId?: string;
+  public sessionId?: string;
 }
 
 /**
@@ -62,6 +64,7 @@ class GalileoLogger {
   private projectName?: string;
   private logStreamName?: string;
   private experimentId?: string;
+  private sessionId?: string;
   private client = new GalileoApiClient();
   private parentStack: StepWithChildSpans[] = [];
   public traces: Trace[] = [];
@@ -71,6 +74,7 @@ class GalileoLogger {
     this.projectName = config.projectName;
     this.logStreamName = config.logStreamName;
     this.experimentId = config.experimentId;
+    this.sessionId = config.sessionId;
     try {
       // Logging is disabled if GALILEO_DISABLE_LOGGING is defined, is not an empty string, and not set to '0' or 'false'
       const disableLoggingValue =
@@ -167,12 +171,25 @@ class GalileoLogger {
       : undefined;
   }
 
+  currentSessionId(): string | undefined {
+    return this.sessionId;
+  }
+
   addChildSpanToParent(span: Span): void {
     const currentParent = this.currentParent();
     if (currentParent === undefined) {
       throw new Error('A trace needs to be created in order to add a span.');
     }
     currentParent.addChildSpan(span);
+  }
+
+  startSession(): void {
+    // TODO: Implement session creation via API
+    this.sessionId = uuidv4();
+  }
+
+  clearSession(): void {
+    this.sessionId = undefined;
   }
 
   startTrace({

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -15,7 +15,6 @@ import {
   BaseStep
 } from '../types/step.types';
 import { toStringValue } from './serialization';
-import { v4 as uuidv4 } from 'uuid';
 
 class GalileoLoggerConfig {
   public projectName?: string;
@@ -195,25 +194,29 @@ class GalileoLogger {
     previousSessionId?: string;
     externalId?: string;
   } = {}): Promise<void> {
-    await this.client.init({
-      projectName: this.projectName,
-      logStreamName: this.logStreamName,
-      experimentId: this.experimentId
-    });
+    try {
+      await this.client.init({
+        projectName: this.projectName,
+        logStreamName: this.logStreamName,
+        experimentId: this.experimentId
+      });
 
-    const session = await this.client?.createSession({
-      name,
-      previousSessionId,
-      externalId
-    });
+      const session = await this.client?.createSession({
+        name,
+        previousSessionId,
+        externalId
+      });
 
-    if (session) {
       this.sessionId = session.id;
+      console.log('Session started.');
+    } catch (error) {
+      console.error('Failed to create session:', error);
     }
   }
 
   clearSession(): void {
     this.sessionId = undefined;
+    console.log('Session cleared.');
   }
 
   startTrace({


### PR DESCRIPTION
Adding Session management to the GalileoLogger

```
await logger.startSession({
  name: 'test session',
  previousSessionId: '6c4e3f7e-4a9a-4e7e-8c1f-3a9a3a9a3a9d',
  externalId: 'appSessionID123'
});
    
...

logger.clearSession();
```

https://app.shortcut.com/galileo/story/29395/sdk-add-session-compatibility-to-the-galileologger-ts