### PR TITLE
ci: Test on multiple nodeJS versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,13 +8,18 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18,20,22,24]
+      fail-fast: false
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         # based on https://nodejs.org/en/about/previous-releases
         node-version: [
-          18,
-          20,
-          22, #LTS
-          24
-        ]
+            18,
+            20,
+            22, #LTS
+            24
+          ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,7 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18,20,22,24]
+        # based on https://nodejs.org/en/about/previous-releases
+        node-version: [
+          18,
+          20,
+          22, #LTS
+          24
+        ]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
This PR resolves https://app.shortcut.com/galileo/story/29239/g2-0-typescript-sdk-enable-testing-multi-nodejs-version-on-ci