### PR TITLE
fix: adding user_metadata and tags to the traces ingest request data

### DIFF
--- a/src/types/step.types.ts
+++ b/src/types/step.types.ts
@@ -111,11 +111,12 @@ export class BaseStep {
       name: this.name,
       created_at_ns: this.createdAtNs,
       duration_ns: this.durationNs,
-      userMetadata: this.userMetadata,
+      user_metadata: this.userMetadata,
       status_code: this.statusCode,
       ground_truth: this.groundTruth,
       external_id: this.externalId,
-      step_number: this.stepNumber
+      step_number: this.stepNumber,
+      tags: this.tags
     };
   }
 }


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/34651/galileo-2-0-ui-not-getting-metadata-and-tags-values-from-the-typescript-sdk-logger