### PR TITLE
feat: Add `addRowsToDataset` function

### DIFF
--- a/examples/datasets/datasets.js
+++ b/examples/datasets/datasets.js
@@ -2,14 +2,15 @@ import 'dotenv/config';
 import {
   getDatasets,
   createDataset,
-  getDatasetContent
+  getDatasetContent,
+  addRowsToDataset
 } from '../../dist/index.js';
 
 // Create a dataset
 const dataset = await createDataset(
   {
-    col1: [1, 2, 3],
-    col2: ['a', 'b', 'c']
+    input: [1, 2, 3],
+    output: ['a', 'b', 'c']
   },
   'My dataset'
 );
@@ -23,3 +24,6 @@ datasets.forEach((dataset) => console.log(dataset));
 // Get dataset content
 const content = await getDatasetContent({ datasetId: dataset.id });
 console.log('Dataset content:', content);
+
+// Add a new row to the dataset
+await addRowsToDataset(dataset.id, [{ input: 4, output: 'd' }]);

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -258,6 +258,11 @@ export class GalileoApiClient extends BaseClient {
     return this.datasetService!.getDataset(id);
   }
 
+  public async getDatasetEtag(id: string) {
+    this.ensureService(this.datasetService);
+    return this.datasetService!.getDatasetEtag(id);
+  }
+
   public async getDatasetByName(name: string) {
     this.ensureService(this.datasetService);
     return this.datasetService!.getDatasetByName(name);
@@ -280,10 +285,15 @@ export class GalileoApiClient extends BaseClient {
 
   public async appendRowsToDatasetContent(
     datasetId: string,
+    etag: string,
     rows: DatasetAppendRow[]
   ): Promise<void> {
     this.ensureService(this.datasetService);
-    return this.datasetService!.appendRowsToDatasetContent(datasetId, rows);
+    return this.datasetService!.appendRowsToDatasetContent(
+      datasetId,
+      etag,
+      rows
+    );
   }
 
   // Trace methods - delegate to TraceService

--- a/src/api-client/services/dataset-service.ts
+++ b/src/api-client/services/dataset-service.ts
@@ -78,6 +78,16 @@ export class DatasetService extends BaseClient {
     );
   };
 
+  public getDatasetEtag = async (id: string): Promise<string> => {
+    const response = await this.makeRequestRaw<Dataset>(
+      RequestMethod.GET,
+      Routes.datasetContent,
+      null,
+      { dataset_id: id, limit: 1 }
+    );
+    return response.headers['etag'];
+  };
+
   public getDatasetByName = async (name: string): Promise<Dataset> => {
     const { datasets } = await this.makeRequest<{ datasets: Dataset[] }>(
       RequestMethod.POST,
@@ -154,17 +164,23 @@ export class DatasetService extends BaseClient {
 
   public async appendRowsToDatasetContent(
     datasetId: string,
+    etag: string,
     rows: DatasetAppendRow[]
   ): Promise<void> {
     if (!this.client) {
       throw new Error('Client not initialized');
     }
 
+    const extraHeaders = {
+      'If-Match': etag
+    };
+
     await this.makeRequest<void>(
-      RequestMethod.POST,
+      RequestMethod.PATCH,
       Routes.datasetContent,
-      { rows },
-      { dataset_id: datasetId }
+      { edits: rows },
+      { dataset_id: datasetId },
+      extraHeaders
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,8 @@ import {
   createDataset,
   getDatasetContent,
   getDataset,
-  deleteDataset
+  deleteDataset,
+  addRowsToDataset
 } from './utils/datasets';
 import { createCustomLlmMetric, deleteMetric } from './utils/metrics';
 import {
@@ -59,6 +60,7 @@ export {
   getDatasetContent,
   getDataset,
   deleteDataset,
+  addRowsToDataset,
   // Prompt templates
   getPromptTemplate,
   getPromptTemplates,

--- a/src/types/dataset.types.ts
+++ b/src/types/dataset.types.ts
@@ -14,8 +14,4 @@ export interface Dataset {
   draft: boolean;
 }
 
-export interface DatasetAppendRow {
-  [key: string]: string | number | null;
-}
-
 export type DatasetRow = components['schemas']['DatasetRow'];


### PR DESCRIPTION
The existing function was not exported and had a few issues. This
modifies it to call the correct endpoint, pass the etag in the header,
and stringify JSON values.
