### PR TITLE
fix: Moving duration and tokens to metrics to make them work

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,6 @@ In the root directory, run:
 In the examples directory, run:
 
 - `npm i`
-- `npm link @rungalileo/galileo`
+- `npm link galileo`
 
 Use `node` to run examples, e.g. `node examples/logger/workflow.js`.

--- a/examples/logger/logger.js
+++ b/examples/logger/logger.js
@@ -51,6 +51,10 @@ logger.addLlmSpan({
   model: 'gpt-3.5-turbo', // model name
   name: 'Chat Completion', // name
   durationNs: 1000000000, // durationNs (1s)
+  numInputTokens: 10, // number of input tokens
+  numOutputTokens: 20, // number of output tokens
+  totalTokens: 30, // total tokens
+  timeToFirstTokenNs: 500000000, // time to first token in nanoseconds
   userMetadata: { temperature: '0.7' }, // userMetadata
   tags: ['llm', 'chat'] // tags
 });

--- a/src/types/log.types.ts
+++ b/src/types/log.types.ts
@@ -270,18 +270,20 @@ export class LlmSpan extends BaseStep {
   toJSON(): Record<string, any> {
     return {
       ...super.toJSON(),
-      input_tokens: this.inputTokens,
-      output_tokens: this.outputTokens,
-      total_tokens: this.totalTokens,
+      metrics: {
+        num_input_tokens: this.inputTokens,
+        num_output_tokens: this.outputTokens,
+        num_total_tokens: this.totalTokens,
+        duration_ns: this.durationNs,
+        time_to_first_token_ns: this.timeToFirstTokenNs
+      },
       temperature: this.temperature,
-      time_to_first_token_ns: this.timeToFirstTokenNs,
       model: this.model,
       tools: this.tools,
       type: this.type,
       input: this.input,
       output: this.output,
-      name: this.name,
-      duration_ns: this.durationNs
+      name: this.name
     };
   }
 }

--- a/src/types/step.types.ts
+++ b/src/types/step.types.ts
@@ -110,7 +110,9 @@ export class BaseStep {
       output: this.output,
       name: this.name,
       created_at_ns: this.createdAtNs,
-      duration_ns: this.durationNs,
+      metrics: {
+        duration_ns: this.durationNs
+      },
       user_metadata: this.userMetadata,
       status_code: this.statusCode,
       ground_truth: this.groundTruth,

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -807,7 +807,7 @@ describe('GalileoLogger', () => {
         metadata: { test: 'trace test' },
         tags: ['trace test']
       });
-      
+
       const llmSpan = logger.addLlmSpan({
         input: 'llm input',
         output: 'llm output',
@@ -828,11 +828,11 @@ describe('GalileoLogger', () => {
       logger.conclude({ output: 'trace output', statusCode: 200 });
 
       const serializedSpan = llmSpan.toJSON();
-      expect(serializedSpan["metrics"]["num_input_tokens"]).toBe(1);
-      expect(serializedSpan["metrics"]["num_output_tokens"]).toBe(1);
-      expect(serializedSpan["metrics"]["num_total_tokens"]).toBe(2);
-      expect(serializedSpan["metrics"]["time_to_first_token_ns"]).toBe(1000);
-      expect(serializedSpan["metrics"]["duration_ns"]).toBe(1000);
+      expect(serializedSpan['metrics']['num_input_tokens']).toBe(1);
+      expect(serializedSpan['metrics']['num_output_tokens']).toBe(1);
+      expect(serializedSpan['metrics']['num_total_tokens']).toBe(2);
+      expect(serializedSpan['metrics']['time_to_first_token_ns']).toBe(1000);
+      expect(serializedSpan['metrics']['duration_ns']).toBe(1000);
     });
 
 
@@ -852,58 +852,58 @@ describe('GalileoLogger', () => {
         input: 'workflow input',
         name: 'workflow span',
         createdAt,
-        durationNs: 1000,
+        durationNs: 1000
       });
-      
+
       const agentSpan = logger.addAgentSpan({
         input: 'agent input',
         output: 'agent output',
         name: 'agent span',
         createdAt,
-        durationNs: 2000,
+        durationNs: 2000
       });
-      
+
       const llmSpan = logger.addLlmSpan({
         input: 'llm input',
         output: 'llm output',
         name: 'llm span',
         createdAt,
-        durationNs: 3000,
+        durationNs: 3000
       });
-      
+
       const retrieverSpan = logger.addRetrieverSpan({
         input: 'retriever input',
         output: 'retriever output',
         name: 'retriever span',
         createdAt,
-        durationNs: 4000,
+        durationNs: 4000
       });
-      
+
       const toolSpan = logger.addToolSpan({
         input: 'tool input',
         output: 'tool output',
         name: 'tool span',
         createdAt,
-        durationNs: 5000,
+        durationNs: 5000
       });
 
       logger.conclude({ output: 'Workflow span output', statusCode: 200 });
       logger.conclude({ output: 'trace output', statusCode: 200 });
 
       const serializedWorkflowSpan = workflowSpan.toJSON();
-      expect(serializedWorkflowSpan["metrics"]["duration_ns"]).toBe(1000);
+      expect(serializedWorkflowSpan['metrics']['duration_ns']).toBe(1000);
 
       const serializedAgentSpan = agentSpan.toJSON();
-      expect(serializedAgentSpan["metrics"]["duration_ns"]).toBe(2000);
+      expect(serializedAgentSpan['metrics']['duration_ns']).toBe(2000);
 
       const serializedLlmSpan = llmSpan.toJSON();
-      expect(serializedLlmSpan["metrics"]["duration_ns"]).toBe(3000);
+      expect(serializedLlmSpan['metrics']['duration_ns']).toBe(3000);
 
       const serializedRetrieverSpan = retrieverSpan.toJSON();
-      expect(serializedRetrieverSpan["metrics"]["duration_ns"]).toBe(4000);
+      expect(serializedRetrieverSpan['metrics']['duration_ns']).toBe(4000);
 
       const serializedToolSpan = toolSpan.toJSON();
-      expect(serializedToolSpan["metrics"]["duration_ns"]).toBe(5000);
+      expect(serializedToolSpan['metrics']['duration_ns']).toBe(5000);
     });
   });
 

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -835,7 +835,6 @@ describe('GalileoLogger', () => {
       expect(serializedSpan['metrics']['duration_ns']).toBe(1000);
     });
 
-
     it('should serialize duration values correctly', () => {
       const createdAt = Date.now() * 1000000;
 


### PR DESCRIPTION
Currently the TypeScript SDK is not sending durations or token counts to the API. This is because the JSON objects being created have the wrong structure, and are not typechecked against the OpenAPI spec.

This fix moves these metrics to the right JSON format, but going forward we should be creating strongly typed objects from the OpenAI spec to ensure that this can't happen.

This fixes:

[SC-30381](https://app.shortcut.com/galileo/story/30381/typescript-openai-wrapper-doesn-t-capture-system-metrics)