### PR TITLE
feat: Implement extendDataset functionality

### DIFF
--- a/examples/datasets/datasets.js
+++ b/examples/datasets/datasets.js
@@ -1,10 +1,12 @@
-import 'dotenv/config';
-import {
+const dotenv = await import('dotenv/config');
+
+const {
   getDatasets,
   createDataset,
   getDatasetContent,
-  addRowsToDataset
-} from '../../dist/index.js';
+  addRowsToDataset,
+  extendDataset
+} = await import('../../dist/index.js');
 
 // Create a dataset
 const dataset = await createDataset(
@@ -30,3 +32,18 @@ await addRowsToDataset({
   datasetId: dataset.id,
   rows: [{ input: 4, output: 'd' }]
 });
+
+// Extend dataset
+const extended_dataset = await extendDataset({
+  prompt_settings: {
+    model_alias: 'GPT-4o mini'
+  },
+  prompt:
+    'Financial planning assistant that helps clients design an investment strategy.',
+  instructions:
+    'You are a financial planning assistant that helps clients design an investment strategy.',
+  examples: ['I want to invest $1000 per month.'],
+  data_types: ['Prompt Injection'],
+  count: 3
+});
+console.log('Extended dataset:', extended_dataset);

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -18,7 +18,13 @@ import {
   PromptTemplateService,
   GlobalPromptTemplateService
 } from './services/prompt-template-service';
-import { DatasetService, DatasetAppendRow } from './services/dataset-service';
+import {
+  DatasetService,
+  DatasetAppendRow,
+  SyntheticDatasetExtensionRequest,
+  SyntheticDatasetExtensionResponse,
+  JobProgress
+} from './services/dataset-service';
 import { TraceService } from './services/trace-service';
 import { ExperimentService } from './services/experiment-service';
 import { ScorerService } from './services/scorer-service';
@@ -296,6 +302,18 @@ export class GalileoApiClient extends BaseClient {
       etag,
       rows
     );
+  }
+
+  public async extendDataset(
+    params: SyntheticDatasetExtensionRequest
+  ): Promise<SyntheticDatasetExtensionResponse> {
+    this.ensureService(this.datasetService);
+    return this.datasetService!.extendDataset(params);
+  }
+
+  public async getExtendDatasetStatus(datasetId: string): Promise<JobProgress> {
+    this.ensureService(this.datasetService);
+    return this.datasetService!.getExtendDatasetStatus(datasetId);
   }
 
   // Trace methods - delegate to TraceService

--- a/src/api-client/index.ts
+++ b/src/api-client/index.ts
@@ -10,7 +10,9 @@ export {
   DatasetContent,
   Dataset,
   DatasetFormat,
-  ListDatasetResponse
+  ListDatasetResponse,
+  SyntheticDatasetExtensionRequest,
+  JobProgress
 } from './services/dataset-service';
 export { TraceService } from './services/trace-service';
 export { ExperimentService } from './services/experiment-service';

--- a/src/api-client/services/dataset-service.ts
+++ b/src/api-client/services/dataset-service.ts
@@ -9,6 +9,11 @@ export type DatasetContent = components['schemas']['DatasetContent'];
 export type Dataset = components['schemas']['DatasetDB'];
 export type DatasetRow = components['schemas']['DatasetRow'];
 export type DatasetAppendRow = components['schemas']['DatasetAppendRow'];
+export type SyntheticDatasetExtensionRequest =
+  components['schemas']['SyntheticDatasetExtensionRequest'];
+export type SyntheticDatasetExtensionResponse =
+  components['schemas']['SyntheticDatasetExtensionResponse'];
+export type JobProgress = components['schemas']['JobProgress'];
 
 type CollectionPaths =
   | paths['/datasets']
@@ -205,4 +210,25 @@ export class DatasetService extends BaseClient {
 
     await this.makeRequest<void>(RequestMethod.DELETE, path as Routes);
   }
+
+  public async extendDataset(
+    params: SyntheticDatasetExtensionRequest
+  ): Promise<SyntheticDatasetExtensionResponse> {
+    return this.makeRequest<SyntheticDatasetExtensionResponse>(
+      RequestMethod.POST,
+      Routes.datasetExtend,
+      params
+    );
+  }
+
+  public getExtendDatasetStatus = async (
+    datasetId: string
+  ): Promise<JobProgress> => {
+    return await this.makeRequest<JobProgress>(
+      RequestMethod.GET,
+      Routes.datasetExtendStatus,
+      null,
+      { dataset_id: datasetId }
+    );
+  };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ import {
   deserializeInputFromString,
   getDatasets,
   getDatasetContent,
-  getDataset
+  getDataset,
+  extendDataset
 } from './utils/datasets';
 import { createCustomLlmMetric, deleteMetric } from './utils/metrics';
 import {
@@ -65,6 +66,7 @@ export {
   addRowsToDataset,
   createDatasetRecord,
   deserializeInputFromString,
+  extendDataset,
   // Prompt templates
   getPromptTemplate,
   getPromptTemplates,

--- a/src/types/routes.types.ts
+++ b/src/types/routes.types.ts
@@ -20,6 +20,8 @@ export enum Routes {
   datasetsQuery = 'datasets/query',
   dataset = 'datasets/{dataset_id}',
   datasetContent = 'datasets/{dataset_id}/content',
+  datasetExtend = 'datasets/extend',
+  datasetExtendStatus = 'datasets/extend/{dataset_id}',
   traces = 'projects/{project_id}/traces',
   sessions = 'projects/{project_id}/sessions',
   scorers = 'scorers/list',

--- a/src/utils/datasets.ts
+++ b/src/utils/datasets.ts
@@ -1,4 +1,8 @@
-import { DatasetRow, GalileoApiClient } from '../api-client';
+import {
+  GalileoApiClient,
+  DatasetRow,
+  SyntheticDatasetExtensionRequest
+} from '../api-client';
 import {
   Dataset,
   DatasetRecord,
@@ -402,4 +406,66 @@ export const deleteDataset = async ({
   }
 
   await apiClient.deleteDataset(id!);
+};
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Extends a dataset with synthetically generated data based on the provided parameters.
+ *
+ * This function initiates a dataset extension job, waits for it to complete by polling its status,
+ * and then returns the content of the extended dataset.
+ *
+ * @param {object} params - The parameters for the synthetic dataset extension request.
+ * @param {object} params.prompt_settings - Settings for the prompt generation.
+ * @param {string} params.prompt_settings.model_alias - The model to use for generation (e.g., 'GPT-4o mini').
+ * @param {string} params.prompt - A description of the assistant's role.
+ * @param {string} params.instructions - Instructions for the assistant.
+ * @param {string[]} params.examples - Examples of user prompts.
+ * @param {string[]} params.data_types - The types of data to generate. Possible values are: 'General Query', 'Prompt Injection', 'Off-Topic Query', 'Toxic Content in Query', 'Multiple Questions in Query', 'Sexist Content in Query'.
+ * @param {number} params.count - The number of synthetic examples to generate.
+ * @returns {Promise<DatasetRow[]>} A promise that resolves with the rows of the extended dataset.
+ *
+ * @example
+ * ```javascript
+ * const extended_dataset = await extendDataset({
+ *   prompt_settings: {
+ *     model_alias: 'GPT-4o mini'
+ *   },
+ *   prompt:
+ *     'Financial planning assistant that helps clients design an investment strategy.',
+ *   instructions:
+ *     'You are a financial planning assistant that helps clients design an investment strategy.',
+ *   examples: ['I want to invest $1000 per month.'],
+ *   data_types: ['Prompt Injection'],
+ *   count: 3
+ * });
+ * console.log('Extended dataset:', extended_dataset);
+ * ```
+ */
+export const extendDataset = async (
+  params: SyntheticDatasetExtensionRequest
+): Promise<DatasetRow[]> => {
+  const apiClient = new GalileoApiClient();
+  await apiClient.init({ projectScoped: false });
+
+  const { dataset_id } = await apiClient.extendDataset(params);
+
+  let job;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    // Wait for job to finish
+    job = await apiClient.getExtendDatasetStatus(dataset_id);
+    if (job.steps_completed === job.steps_total) {
+      break;
+    }
+    // eslint-disable-next-line no-console
+    console.log(
+      `(${job.steps_completed}/${job.steps_total}) ${job.progress_message}`
+    );
+    await sleep(1000);
+  }
+
+  return apiClient.getDatasetContent(dataset_id);
 };

--- a/tests/utils/datasets.test.ts
+++ b/tests/utils/datasets.test.ts
@@ -6,11 +6,17 @@ import {
   createDatasetRecord,
   deleteDataset,
   deserializeInputFromString,
+  extendDataset,
   getDatasetContent,
   getDatasets
 } from '../../src';
 import { commonHandlers, TEST_HOST } from '../common';
-import { Dataset, DatasetContent, DatasetRow } from '../../src/api-client';
+import {
+  Dataset,
+  DatasetContent,
+  DatasetRow,
+  JobProgress
+} from '../../src/api-client';
 import { DatasetType } from '../../src/utils/datasets';
 
 const EXAMPLE_DATASET: Dataset = {
@@ -31,6 +37,16 @@ const EXAMPLE_DATASET_ROW: DatasetRow = {
   row_id: 'ae4dcadf-a0a2-475e-91e4-7bd03fdf5de8',
   values: ['John', 'Doe'],
   values_dict: { firstName: 'John', lastName: 'Doe' },
+  metadata: null
+};
+
+const EXTENDED_DATASET_ID = 'a8b3d8e0-5e0b-4b0f-8b3a-3b9f4b3d3b3a';
+
+const EXTENDED_DATASET_ROW: DatasetRow = {
+  index: 0,
+  row_id: 'be4dcadf-a0a2-475e-91e4-7bd03fdf5de8',
+  values: ['Extended', 'Row'],
+  values_dict: { col1: 'Extended', col2: 'Row' },
   metadata: null
 };
 
@@ -67,6 +83,45 @@ const addRowsToDatasetHandler = jest.fn().mockImplementation(() => {
   return new HttpResponse(null, { status: 204 });
 });
 
+const extendDatasetHandler = jest.fn().mockImplementation(() => {
+  return HttpResponse.json({ dataset_id: EXTENDED_DATASET_ID });
+});
+
+const getExtendDatasetStatusHandler = jest
+  .fn()
+  .mockImplementationOnce(() => {
+    const response: JobProgress = {
+      steps_completed: 1,
+      steps_total: 3,
+      progress_message: 'Processing'
+    };
+    return HttpResponse.json(response);
+  })
+  .mockImplementationOnce(() => {
+    const response: JobProgress = {
+      steps_completed: 2,
+      steps_total: 3,
+      progress_message: 'Still processing'
+    };
+    return HttpResponse.json(response);
+  })
+  .mockImplementation(() => {
+    const response: JobProgress = {
+      steps_completed: 3,
+      steps_total: 3,
+      progress_message: 'Done'
+    };
+    return HttpResponse.json(response);
+  });
+
+const getExtendedDatasetContentHandler = jest.fn().mockImplementation(() => {
+  const response: DatasetContent = {
+    rows: [EXTENDED_DATASET_ROW]
+  };
+
+  return HttpResponse.json(response);
+});
+
 export const handlers = [
   ...commonHandlers,
   http.post(`${TEST_HOST}/datasets`, postDatasetsHandler),
@@ -83,6 +138,15 @@ export const handlers = [
   http.patch(
     `${TEST_HOST}/datasets/${EXAMPLE_DATASET.id}/content`,
     addRowsToDatasetHandler
+  ),
+  http.post(`${TEST_HOST}/datasets/extend`, extendDatasetHandler),
+  http.get(
+    `${TEST_HOST}/datasets/extend/${EXTENDED_DATASET_ID}`,
+    getExtendDatasetStatusHandler
+  ),
+  http.get(
+    `${TEST_HOST}/datasets/${EXTENDED_DATASET_ID}/content`,
+    getExtendedDatasetContentHandler
   )
 ];
 
@@ -92,11 +156,20 @@ beforeAll(() => {
   process.env.GALILEO_CONSOLE_URL = TEST_HOST;
   process.env.GALILEO_API_KEY = 'placeholder';
   server.listen();
+  jest.useFakeTimers();
+  jest.spyOn(console, 'log').mockImplementation(() => {});
 });
 
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  jest.clearAllTimers();
+});
 
-afterAll(() => server.close());
+afterAll(() => {
+  server.close();
+  jest.useRealTimers();
+  jest.mocked(console.log).mockRestore();
+});
 
 const createDatasetCases: DatasetType[] = [
   { col1: ['val1', 'val2'] }, // column with strings
@@ -275,4 +348,31 @@ describe('datasets utils', () => {
       expect(result).toEqual({ value: 'plain string' });
     });
   });
+});
+
+test('extend dataset', async () => {
+  const extendPromise = extendDataset({
+    prompt_settings: {
+      model_alias: 'GPT-4o mini',
+      response_format: { type: 'json_object' }
+    },
+    prompt:
+      'Financial planning assistant that helps clients design an investment strategy.',
+    instructions:
+      'You are a financial planning assistant that helps clients design an investment strategy.',
+    examples: ['I want to invest $1000 per month.'],
+    data_types: ['Prompt Injection'],
+    count: 3
+  });
+
+  // The loop runs twice before completing
+  await jest.advanceTimersByTimeAsync(1000);
+  await jest.advanceTimersByTimeAsync(1000);
+
+  const result = await extendPromise;
+
+  expect(result).toEqual([EXTENDED_DATASET_ROW]);
+  expect(extendDatasetHandler).toHaveBeenCalled();
+  expect(getExtendDatasetStatusHandler).toHaveBeenCalledTimes(3);
+  expect(getExtendedDatasetContentHandler).toHaveBeenCalled();
 });


### PR DESCRIPTION
**Shortcut:**

- [sc-32753 - [Javascript SDK] Add MVP synthetic dataset functionality](https://app.shortcut.com/galileo/story/32753/javascript-sdk-add-mvp-synthetic-dataset-functionality)

**Description:**

This PR adds the extendDataset function to the Javascript SDK:

**Pending improvements:**

- Just get a model alias instead of PromptSettings.
- Adapt the interface for "source_dataset" example.

### `extendDataset({ prompt_settings, prompt, instructions, examples, data_types, count })`

Extends a synthetic dataset based on the provided prompt and configuration.

- This function starts a background job to generate synthetic data and waits for its completion.
- Not scoped to any project.

**Parameters:**

| Name              | Type                                      | Description                                                  |
|-------------------|-------------------------------------------|--------------------------------------------------------------|
| `prompt_settings` | `PromptSettings`                          | Settings for the model (e.g., alias, response format).       |
| `prompt`          | `string`                                  | The main prompt to use for data generation.                  |
| `instructions`    | `string`                                  | System message or guiding instructions.                      |
| `examples`        | `string[]`                                | Example inputs to guide the model.                           |
| `data_types`      | `string[]`                                | Labels describing the input type or risk category.           |
| `count`           | `number`                                  | Number of synthetic examples to generate.                    |

**Returns:** `Promise<DatasetRow[]>`

---

### Example:

```ts
const extended_dataset = await extendDataset({
  prompt_settings: {
    model_alias: 'GPT-4o mini',
    response_format: { type: 'json_object' }
  },
  prompt: 'Financial planning assistant that helps clients design an investment strategy.',
  instructions: 'You are a financial planning assistant that helps clients design an investment strategy.',
  examples: ['I want to invest $1000 per month.'],
  data_types: ['Prompt Injection'],
  count: 3
});

console.log('Extended dataset:', extended_dataset);
```

**Tests:**

- [x] Unit Tests Added
- [ ] E2E Test Added
