### PR TITLE
fix: Changing SHA to main in github links

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -36,7 +36,7 @@ jobs:
       # Create a branch in the docs-official repo using the current branch name
       - name: Create a branch
         working-directory: ./docs-official
-        run: git checkout -b feat/update-docs-${GITHUB_REF_NAME}
+        run: git checkout -b feat/update-docs-${GITHUB_REF_NAME}-${{ github.run_id }}
 
       # Copy the generated docs from the TypeScript SDK repo to the docs repo
       - name: Update SDK docs
@@ -51,8 +51,8 @@ jobs:
           git config --global user.email "info@galileo.com"
           git config --global user.name "Galileo"
           git add .
-          git commit -m "Updating docs from ${GITHUB_REF_NAME}"
-          git push -u origin feat/update-docs-${GITHUB_REF_NAME}
+          git commit -m "Updating docs from ${GITHUB_REF_NAME}-${{ github.run_id }}"
+          git push -u origin feat/update-docs-${GITHUB_REF_NAME}-${{ github.run_id }}
 
       # Create a PR against the docs repo with the new changes
       - name: Create PR

--- a/local-plugins/format-for-galileo.mjs
+++ b/local-plugins/format-for-galileo.mjs
@@ -93,6 +93,20 @@ function fix_paths(line, page) {
     }
   }
 
+  // Some lines have the file location in GitHub with a sha. Replace these with the main branch to reduce the size of the
+  // PRs! We don't need to review every line
+  // This is the format: https://github.com/rungalileo/galileo-js/blob/c528f23c1c57652accf00d6c9afe71a289cabe7d/src/handlers/langchain.ts#L62
+  // The SHA needs to be replaced with the main branch name
+  const shaRegex =
+    /https:\/\/github\.com\/rungalileo\/galileo-js\/blob\/[a-z0-9]+/;
+  if (shaRegex.test(line)) {
+    // Replace the SHA with the main branch name
+    line = line.replace(
+      shaRegex,
+      'https://github.com/rungalileo/galileo-js/blob/main'
+    );
+  }
+
   // otherwise return the line unchanged
   return line;
 }


### PR DESCRIPTION
Our generated docs contain a link with a sha of the release branch. This means docs PRs contain lots of noise as these links change a lot.

E.g.: https://github.com/rungalileo/docs-official/pull/264/files#diff-98c677dba8aea178cf837bf252b5d44b9b625450f117991320149f57e6e7c829 - 117 files changed, most are just the SHA changing.

To simplify, these are now mapped to main. As the docs should be up to date with main, this should rarely lead to a broken link.