### PR TITLE
feat(scorers): Add output type to createCustomLlmMetric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galileo",
-  "version": "1.24.0",
+  "version": "1.24.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galileo",
-      "version": "1.24.0",
+      "version": "1.24.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -6,7 +6,8 @@ import {
   ScorerTypes,
   ScorerVersion,
   ModelType,
-  ChainPollTemplate
+  ChainPollTemplate,
+  OutputType
 } from '../types/scorer.types';
 import { ProjectTypes } from '../types/project.types';
 import { BaseClient } from './base-client';
@@ -485,7 +486,8 @@ export class GalileoApiClient extends BaseClient {
     scoreableNodeTypes?: StepType[],
     cotEnabled?: boolean,
     modelName?: string,
-    numJudges?: number
+    numJudges?: number,
+    outputType?: OutputType
   ): Promise<ScorerVersion> {
     this.ensureService(this.scorerService);
     return this.scorerService!.createLLMScorerVersion(
@@ -496,7 +498,8 @@ export class GalileoApiClient extends BaseClient {
       scoreableNodeTypes,
       cotEnabled,
       modelName,
-      numJudges
+      numJudges,
+      outputType
     );
   }
 

--- a/src/api-client/services/scorer-service.ts
+++ b/src/api-client/services/scorer-service.ts
@@ -3,6 +3,7 @@ import { Routes } from '../../types/routes.types';
 import {
   ChainPollTemplate,
   ModelType,
+  OutputType,
   Scorer,
   ScorerDefaults,
   ScorerVersion
@@ -134,6 +135,7 @@ export class ScorerService extends BaseClient {
    * @param cotEnabled - (Optional) Whether chain of thought is enabled. Defaults to
    * @param modelName - (Optional) The model name to use.
    * @param numJudges - (Optional) The number of judges to use.
+   * @param outputType - (Optional) The output type for the scorer version.
    * @returns A promise that resolves to the created {@link ScorerVersion}.
    */
   public createLLMScorerVersion = async (
@@ -144,7 +146,8 @@ export class ScorerService extends BaseClient {
     scoreableNodeTypes?: StepType[],
     cotEnabled?: boolean,
     modelName?: string,
-    numJudges?: number
+    numJudges?: number,
+    outputType?: OutputType
   ): Promise<ScorerVersion> => {
     const scorerVersionPayload: {
       model_name?: string;
@@ -154,6 +157,7 @@ export class ScorerService extends BaseClient {
       user_prompt?: string;
       scoreable_node_types?: StepType[];
       cot_enabled?: boolean;
+      output_type?: OutputType;
     } = {};
 
     if (modelName !== undefined && modelName !== null) {
@@ -176,6 +180,9 @@ export class ScorerService extends BaseClient {
     }
     if (cotEnabled !== undefined && cotEnabled !== null) {
       scorerVersionPayload.cot_enabled = cotEnabled;
+    }
+    if (outputType !== undefined && outputType !== null) {
+      scorerVersionPayload.output_type = outputType;
     }
 
     const path = Routes.llmScorerVersion.replace('{scorer_id}', scorerId);

--- a/src/types/scorer.types.ts
+++ b/src/types/scorer.types.ts
@@ -69,10 +69,10 @@ export interface Scorer {
 }
 
 export enum OutputType {
-  BOOLEAN = "boolean",
-  CATEGORICAL = "categorical",
-  COUNT = "count",
-  DISCRETE = "discrete",
-  FREEFORM = "freeform",
-  PERCENTAGE = "percentage"
+  BOOLEAN = 'boolean',
+  CATEGORICAL = 'categorical',
+  COUNT = 'count',
+  DISCRETE = 'discrete',
+  FREEFORM = 'freeform',
+  PERCENTAGE = 'percentage'
 }

--- a/src/types/scorer.types.ts
+++ b/src/types/scorer.types.ts
@@ -67,3 +67,12 @@ export interface Scorer {
   scorer_type: ScorerTypes;
   defaults?: ScorerDefaults;
 }
+
+export enum OutputType {
+  BOOLEAN = "boolean",
+  CATEGORICAL = "categorical",
+  COUNT = "count",
+  DISCRETE = "discrete",
+  FREEFORM = "freeform",
+  PERCENTAGE = "percentage"
+}

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -1,4 +1,4 @@
-import { ScorerTypes, ScorerVersion, StepType } from '../types';
+import { OutputType, ScorerTypes, ScorerVersion, StepType } from '../types';
 import {
   createScorer,
   createLlmScorerVersion,
@@ -10,12 +10,14 @@ import {
  * Creates a custom LLM metric.
  *
  * @param name - The name of the custom metric.
- * @param instructions - Instructions for the LLM scorer version.
- * @param chainPollTemplate - The chain poll template for the scorer version.
- * @param modelName - (Optional) The model name to use. Defaults to 'GPT-4o'.
+ * @param userPrompt - The user prompt for the metric.
+ * @param nodeLevel - (Optional) The node level for the metric, i.e. StepType.llm, StepType.trace. Defaults to StepType.llm.
+ * @param cotEnabled - (Optional) Whether chain of thought is enabled. Defaults to true.
+ * @param modelName - (Optional) The model name to use. Defaults to 'gpt-4.1-mini'.
  * @param numJudges - (Optional) The number of judges to use. Defaults to 3.
  * @param description - (Optional) A description for the metric.
  * @param tags - (Optional) Tags to associate with the metric.
+ * @param outputType - (Optional) The output type for the metric. Defaults to OutputType.BOOLEAN.
  * @returns A promise that resolves when the metric is created.
  */
 export const createCustomLlmMetric = async (
@@ -23,10 +25,11 @@ export const createCustomLlmMetric = async (
   userPrompt: string,
   nodeLevel: StepType = StepType.llm,
   cotEnabled: boolean = true,
-  modelName: string = 'GPT-4o',
+  modelName: string = 'gpt-4.1-mini',
   numJudges: number = 3,
   description: string = '',
-  tags: string[] = []
+  tags: string[] = [],
+  outputType: OutputType = OutputType.BOOLEAN
 ): Promise<ScorerVersion> => {
   const scorer = await createScorer(
     name,
@@ -50,7 +53,8 @@ export const createCustomLlmMetric = async (
     scoreableNodeTypes,
     cotEnabled,
     modelName,
-    numJudges
+    numJudges,
+    outputType
   );
 };
 

--- a/src/utils/scorers.ts
+++ b/src/utils/scorers.ts
@@ -1,6 +1,7 @@
 import {
   ChainPollTemplate,
   ModelType,
+  OutputType,
   Scorer,
   ScorerConfig,
   ScorerVersion
@@ -120,6 +121,7 @@ export const createScorer = async (
  * @param cotEnabled - (Optional) Whether chain of thought is enabled. Defaults to true
  * @param modelName - (Optional) The model name to use.
  * @param numJudges - (Optional) The number of judges to use.
+ * @param outputType - (Optional) The output type for the scorer version. Defaults to OutputType.BOOLEAN.
  * @returns A promise that resolves to the created {@link ScorerVersion}.
  */
 export const createLlmScorerVersion = async (
@@ -130,7 +132,8 @@ export const createLlmScorerVersion = async (
   scoreableNodeTypes?: StepType[],
   cotEnabled?: boolean,
   modelName?: string,
-  numJudges?: number
+  numJudges?: number,
+  outputType?: OutputType
 ): Promise<ScorerVersion> => {
   const client = new GalileoApiClient();
   await client.init();
@@ -143,7 +146,8 @@ export const createLlmScorerVersion = async (
     scoreableNodeTypes,
     cotEnabled,
     modelName,
-    numJudges
+    numJudges,
+    outputType
   );
 };
 

--- a/tests/utils/scorers.test.ts
+++ b/tests/utils/scorers.test.ts
@@ -8,7 +8,8 @@ import {
 import {
   Scorer,
   ScorerVersion,
-  ScorerTypes
+  ScorerTypes,
+  OutputType
 } from '../../src/types/scorer.types';
 import { StepType } from '../../src/types';
 
@@ -161,7 +162,8 @@ describe('scorers utility', () => {
         [StepType.trace], // scoreableNodeTypes
         true, // cotEnabled
         'gpt-4',
-        3
+        3,
+        OutputType.CATEGORICAL
       );
       expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
         'scorer-uuid',
@@ -171,7 +173,8 @@ describe('scorers utility', () => {
         [StepType.trace], // scoreableNodeTypes
         true, // cotEnabled
         'gpt-4',
-        3
+        3,
+        OutputType.CATEGORICAL
       );
     });
 
@@ -203,7 +206,8 @@ describe('scorers utility', () => {
         [StepType.session],
         false,
         'gpt-4',
-        3
+        3,
+        OutputType.CATEGORICAL
       );
       expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
         'scorer-uuid',
@@ -213,7 +217,8 @@ describe('scorers utility', () => {
         [StepType.session],
         false,
         'gpt-4',
-        3
+        3,
+        OutputType.CATEGORICAL
       );
     });
 


### PR DESCRIPTION
https://app.shortcut.com/galileo/story/35903/ts-sdk-add-output-type-to-createcustomllmmetric