### PR TITLE
fix: min node engine version

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "galileo",
-  "version": "1.24.1",
+  "version": "1.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "galileo",
-      "version": "1.24.1",
+      "version": "1.25.0",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",
@@ -35,6 +35,9 @@
         "typedoc": "^0.28.5",
         "typedoc-plugin-markdown": "^4.6.4",
         "typescript": "^5.8.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       },
       "optionalDependencies": {
         "@langchain/core": "^0.3.13",

--- a/package.json
+++ b/package.json
@@ -69,5 +69,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/rungalileo/galileo-js.git"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   }
 }


### PR DESCRIPTION
## Problem

Running the command `npm run build` using node v18.17.1 causes a build error

✖ 53 problems (0 errors, 53 warnings)

```
src/api-client/services/dataset-service.ts:127:34 - error TS2322: Type 'Buffer<ArrayBufferLike>' is not assignable to type 'BlobPart'.
  Type 'Buffer<ArrayBufferLike>' is not assignable to type 'ArrayBufferView<ArrayBuffer>'.
    Types of property 'buffer' are incompatible.
      Type 'ArrayBufferLike' is not assignable to type 'ArrayBuffer'.
        Type 'SharedArrayBuffer' is not assignable to type 'ArrayBuffer'.
          Types of property '[Symbol.toStringTag]' are incompatible.
            Type '"SharedArrayBuffer"' is not assignable to type '"ArrayBuffer"'.
127     const blob: Blob = new Blob([fileBuffer]);
                                     ~~~~~~~~~
Found 1 error in src/api-client/services/dataset-service.ts:127
```

Add a min engine into `pacakge.json` to change the error description and avoid user frustration


```
npm ERR! code EBADENGINE
npm ERR! engine Unsupported engine
npm ERR! engine Not compatible with your version of node/npm: galileo@1.25.0
npm ERR! notsup Not compatible with your version of node/npm: galileo@1.25.0
npm ERR! notsup Required: {"node":">=20.0.0"}
npm ERR! notsup Actual:   {"npm":"9.6.7","node":"v18.17.1"}
```
