### PR TITLE
fix: bump node version in ci workflows

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
           registry-url: https://registry.npmjs.org/
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,6 @@ jobs:
       matrix:
         # based on https://nodejs.org/en/about/previous-releases
         node-version: [
-            18,
             20,
             22, #LTS
             24


### PR DESCRIPTION
## Problem

Based on this PR https://github.com/rungalileo/galileo-js/pull/277
The node 18v doesnt properly build the project when running `npm run build`

Bump the node version in the workflow to reflect the min supported version
