### PR TITLE
feat: Associate a dataset with an experiment on run

### DIFF
--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -23,6 +23,7 @@ import { ExperimentService } from './services/experiment-service';
 import { ScorerService } from './services/scorer-service';
 import {
   CreateJobResponse,
+  ExperimentDatasetRequest,
   PromptRunSettings
 } from '../types/experiment.types';
 import { Message } from '../types/message.types';
@@ -402,9 +403,12 @@ export class GalileoApiClient extends BaseClient {
     return this.experimentService!.getExperiment(id);
   }
 
-  public async createExperiment(name: string) {
+  public async createExperiment(
+    name: string,
+    dataset?: ExperimentDatasetRequest | null
+  ) {
     this.ensureService(this.experimentService);
-    return this.experimentService!.createExperiment(name);
+    return this.experimentService!.createExperiment(name, dataset);
   }
 
   public async getScorers(type?: ScorerTypes): Promise<Scorer[]> {

--- a/src/api-client/services/experiment-service.ts
+++ b/src/api-client/services/experiment-service.ts
@@ -4,7 +4,8 @@ import { ScorerConfig } from '../../types/scorer.types';
 import {
   Experiment,
   PromptRunSettings,
-  CreateJobResponse
+  CreateJobResponse,
+  ExperimentDatasetRequest
 } from '../../types/experiment.types';
 
 export class ExperimentService extends BaseClient {
@@ -39,13 +40,17 @@ export class ExperimentService extends BaseClient {
     );
   };
 
-  public createExperiment = async (name: string): Promise<Experiment> => {
+  public createExperiment = async (
+    name: string,
+    dataset?: ExperimentDatasetRequest | null
+  ): Promise<Experiment> => {
     return await this.makeRequest<Experiment>(
       RequestMethod.POST,
       Routes.experiments,
       {
         name,
-        task_type: 16
+        task_type: 16,
+        dataset
       },
       {
         project_id: this.projectId

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,8 @@ import {
   deserializeInputFromString,
   getDatasets,
   getDatasetContent,
-  getDataset
+  getDataset,
+  loadDataset
 } from './utils/datasets';
 import { createCustomLlmMetric, deleteMetric } from './utils/metrics';
 import {
@@ -65,6 +66,7 @@ export {
   addRowsToDataset,
   createDatasetRecord,
   deserializeInputFromString,
+  loadDataset,
   // Prompt templates
   getPromptTemplate,
   getPromptTemplates,

--- a/src/types/experiment.types.ts
+++ b/src/types/experiment.types.ts
@@ -13,3 +13,6 @@ type PromptRunSettingsInput = components['schemas']['PromptRunSettings'];
 export interface PromptRunSettings extends PromptRunSettingsInput {}
 
 export type CreateJobResponse = components['schemas']['CreateJobResponse'];
+
+export type ExperimentDatasetRequest =
+  components['schemas']['ExperimentDatasetRequest'];

--- a/src/utils/datasets.ts
+++ b/src/utils/datasets.ts
@@ -7,6 +7,7 @@ import {
 import { existsSync, PathLike, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { RunExperimentParams } from './experiments';
 
 export const getDatasets = async (): Promise<Dataset[]> => {
   const apiClient = new GalileoApiClient();
@@ -402,4 +403,23 @@ export const deleteDataset = async ({
   }
 
   await apiClient.deleteDataset(id!);
+};
+
+export const loadDataset = async <T extends Record<string, unknown>>(
+  params: RunExperimentParams<T>,
+  projectName: string
+): Promise<Dataset | undefined> => {
+  if ('dataset' in params && params.dataset) {
+    if (!(params.dataset instanceof Array)) {
+      return params.dataset as Dataset;
+    }
+  } else if ('datasetId' in params) {
+    const apiClient = new GalileoApiClient();
+    await apiClient.init({ projectName });
+    return await apiClient.getDataset(params.datasetId);
+  } else if ('datasetName' in params) {
+    const apiClient = new GalileoApiClient();
+    await apiClient.init({ projectName });
+    return await apiClient.getDatasetByName(params.datasetName);
+  }
 };

--- a/tests/utils/experiments.test.ts
+++ b/tests/utils/experiments.test.ts
@@ -299,12 +299,27 @@ describe('experiments utility', () => {
       const result = await createExperiment('Test Experiment', projectName);
 
       // Verify the correct method was called with the right name
-      expect(mockCreateExperiment).toHaveBeenCalledWith('Test Experiment');
+      expect(mockCreateExperiment).toHaveBeenCalledWith(
+        'Test Experiment',
+        undefined
+      );
       expect(result).toEqual(mockExperiment);
     });
     it('should throw an error if name is empty', async () => {
       await expect(createExperiment('', projectName)).rejects.toThrow(
         'A valid `name` must be provided to create an experiment'
+      );
+    });
+
+    it('should pass the dataset to the api client', async () => {
+      const dataset = {
+        dataset_id: 'dataset-id',
+        version_index: 1
+      };
+      await createExperiment('Test Experiment', projectName, dataset);
+      expect(mockCreateExperiment).toHaveBeenCalledWith(
+        'Test Experiment',
+        dataset
       );
     });
   });
@@ -321,7 +336,10 @@ describe('experiments utility', () => {
         'message',
         promptRunJobCreatedSuccessMessage
       );
-      expect(mockCreateExperiment).toHaveBeenCalled();
+      expect(mockCreateExperiment).toHaveBeenCalledWith('Test Experiment', {
+        dataset_id: 'test-dataset-id',
+        version_index: 1
+      });
       expect(mockCreatePromptRunJob).toHaveBeenCalled();
     });
 
@@ -354,7 +372,10 @@ describe('experiments utility', () => {
         'message',
         promptRunJobCreatedSuccessMessage
       );
-      expect(mockCreateExperiment).toHaveBeenCalled();
+      expect(mockCreateExperiment).toHaveBeenCalledWith('Test Experiment', {
+        dataset_id: 'test-dataset-id',
+        version_index: 1
+      });
       expect(mockGetDatasetByName).toHaveBeenCalled();
       expect(mockCreatePromptRunJob).toHaveBeenCalled();
     });
@@ -370,7 +391,10 @@ describe('experiments utility', () => {
         'message',
         promptRunJobCreatedSuccessMessage
       );
-      expect(mockCreateExperiment).toHaveBeenCalled();
+      expect(mockCreateExperiment).toHaveBeenCalledWith('Test Experiment', {
+        dataset_id: 'test-dataset-id',
+        version_index: 1
+      });
       expect(mockCreatePromptRunJob).toHaveBeenCalled();
     });
   });


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/39178/dataset-not-assigned-to-experiment-when-created-via-ts-sdk [sc-39178]

**description:** Dataset not assigned to experiment when created via TS SDK
