### PR TITLE
createCustomLlmMetric takes parameters rather than a parameter object

### DIFF
--- a/src/types/metrics.types.ts
+++ b/src/types/metrics.types.ts
@@ -90,3 +90,17 @@ export interface Metric {
   name: string;
   version?: number;
 }
+
+import { OutputType, StepType } from '.';
+
+export interface CreateCustomLlmMetricParams {
+  name: string;
+  userPrompt: string;
+  nodeLevel?: StepType;
+  cotEnabled?: boolean;
+  modelName?: string;
+  numJudges?: number;
+  description?: string;
+  tags?: string[];
+  outputType?: OutputType;
+}

--- a/src/types/scorer.types.ts
+++ b/src/types/scorer.types.ts
@@ -76,3 +76,17 @@ export enum OutputType {
   FREEFORM = 'freeform',
   PERCENTAGE = 'percentage'
 }
+
+import { StepType } from './logging/step.types';
+
+export interface CreateLlmScorerVersionParams {
+  scorerId: string;
+  instructions?: string;
+  chainPollTemplate?: ChainPollTemplate;
+  userPrompt?: string;
+  scoreableNodeTypes?: StepType[];
+  cotEnabled?: boolean;
+  modelName?: string;
+  numJudges?: number;
+  outputType?: OutputType;
+}

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -1,4 +1,10 @@
-import { OutputType, ScorerTypes, ScorerVersion, StepType } from '../types';
+import {
+  CreateCustomLlmMetricParams,
+  OutputType,
+  ScorerTypes,
+  ScorerVersion,
+  StepType
+} from '../types';
 import {
   createScorer,
   createLlmScorerVersion,
@@ -9,28 +15,20 @@ import {
 /**
  * Creates a custom LLM metric.
  *
- * @param name - The name of the custom metric.
- * @param userPrompt - The user prompt for the metric.
- * @param nodeLevel - (Optional) The node level for the metric, i.e. StepType.llm, StepType.trace. Defaults to StepType.llm.
- * @param cotEnabled - (Optional) Whether chain of thought is enabled. Defaults to true.
- * @param modelName - (Optional) The model name to use. Defaults to 'gpt-4.1-mini'.
- * @param numJudges - (Optional) The number of judges to use. Defaults to 3.
- * @param description - (Optional) A description for the metric.
- * @param tags - (Optional) Tags to associate with the metric.
- * @param outputType - (Optional) The output type for the metric. Defaults to OutputType.BOOLEAN.
+ * @param params - The parameters for creating the custom LLM metric.
  * @returns A promise that resolves when the metric is created.
  */
-export const createCustomLlmMetric = async (
-  name: string,
-  userPrompt: string,
-  nodeLevel: StepType = StepType.llm,
-  cotEnabled: boolean = true,
-  modelName: string = 'gpt-4.1-mini',
-  numJudges: number = 3,
-  description: string = '',
-  tags: string[] = [],
-  outputType: OutputType = OutputType.BOOLEAN
-): Promise<ScorerVersion> => {
+export const createCustomLlmMetric = async ({
+  name,
+  userPrompt,
+  nodeLevel = StepType.llm,
+  cotEnabled = true,
+  modelName = 'gpt-4.1-mini',
+  numJudges = 3,
+  description = '',
+  tags = [],
+  outputType = OutputType.BOOLEAN
+}: CreateCustomLlmMetricParams): Promise<ScorerVersion> => {
   const scorer = await createScorer(
     name,
     ScorerTypes.llm,
@@ -45,17 +43,15 @@ export const createCustomLlmMetric = async (
   );
 
   const scoreableNodeTypes = [nodeLevel];
-  return await createLlmScorerVersion(
-    scorer.id,
-    undefined,
-    undefined,
+  return await createLlmScorerVersion({
+    scorerId: scorer.id,
     userPrompt,
     scoreableNodeTypes,
     cotEnabled,
     modelName,
     numJudges,
     outputType
-  );
+  });
 };
 
 /**

--- a/src/utils/scorers.ts
+++ b/src/utils/scorers.ts
@@ -1,5 +1,6 @@
 import {
   ChainPollTemplate,
+  CreateLlmScorerVersionParams,
   ModelType,
   OutputType,
   Scorer,
@@ -113,28 +114,20 @@ export const createScorer = async (
 /**
  * Creates a new LLM scorer version for a given scorer.
  *
- * @param scorerId - The unique identifier of the scorer.
- * @param instructions - (Optional) Instructions for the scorer version.
- * @param chainPollTemplate - (Optional) The chain poll template for the scorer version.
- * @param userPrompt - (Optional) The user prompt for the scorer version.
- * @param scoreableNodeTypes - (Optional) The node level for the scorer version. Defaults to ['llm'].
- * @param cotEnabled - (Optional) Whether chain of thought is enabled. Defaults to true
- * @param modelName - (Optional) The model name to use.
- * @param numJudges - (Optional) The number of judges to use.
- * @param outputType - (Optional) The output type for the scorer version. Defaults to OutputType.BOOLEAN.
+ * @param params - The parameters for creating the LLM scorer version.
  * @returns A promise that resolves to the created {@link ScorerVersion}.
  */
-export const createLlmScorerVersion = async (
-  scorerId: string,
-  instructions?: string,
-  chainPollTemplate?: ChainPollTemplate,
-  userPrompt?: string,
-  scoreableNodeTypes?: StepType[],
-  cotEnabled?: boolean,
-  modelName?: string,
-  numJudges?: number,
-  outputType?: OutputType
-): Promise<ScorerVersion> => {
+export const createLlmScorerVersion = async ({
+  scorerId,
+  instructions,
+  chainPollTemplate,
+  userPrompt,
+  scoreableNodeTypes,
+  cotEnabled,
+  modelName,
+  numJudges,
+  outputType
+}: CreateLlmScorerVersionParams): Promise<ScorerVersion> => {
   const client = new GalileoApiClient();
   await client.init();
 

--- a/tests/utils/metrics.test.ts
+++ b/tests/utils/metrics.test.ts
@@ -1,0 +1,90 @@
+import { createCustomLlmMetric } from '../../src/utils/metrics';
+import { createScorer, createLlmScorerVersion } from '../../src/utils/scorers';
+import {
+  OutputType,
+  ScorerTypes,
+  ScorerVersion,
+  StepType
+} from '../../src/types';
+
+jest.mock('../../src/utils/scorers', () => ({
+  createScorer: jest.fn(),
+  createLlmScorerVersion: jest.fn()
+}));
+
+describe('createCustomLlmMetric', () => {
+  const mockScorer = { id: 'scorer-123' };
+  const mockScorerVersion: ScorerVersion = {
+    id: 'version-456',
+    version: 1
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (createScorer as jest.Mock).mockResolvedValue(mockScorer);
+    (createLlmScorerVersion as jest.Mock).mockResolvedValue(mockScorerVersion);
+  });
+
+  it('should call createScorer with the correct parameters', async () => {
+    await createCustomLlmMetric({
+      name: 'Test Metric',
+      userPrompt: 'Test prompt'
+    });
+
+    expect(createScorer).toHaveBeenCalledWith(
+      'Test Metric',
+      ScorerTypes.llm,
+      '',
+      [],
+      {
+        model_name: 'gpt-4.1-mini',
+        num_judges: 3
+      },
+      undefined,
+      undefined
+    );
+  });
+
+  it('should call createLlmScorerVersion with the correct parameters', async () => {
+    await createCustomLlmMetric({
+      name: 'Test Metric',
+      userPrompt: 'Test prompt',
+      nodeLevel: StepType.trace,
+      cotEnabled: false,
+      modelName: 'gpt-4',
+      numJudges: 5,
+      outputType: OutputType.CATEGORICAL
+    });
+
+    expect(createLlmScorerVersion).toHaveBeenCalledWith({
+      scorerId: mockScorer.id,
+      userPrompt: 'Test prompt',
+      scoreableNodeTypes: [StepType.trace],
+      cotEnabled: false,
+      modelName: 'gpt-4',
+      numJudges: 5,
+      outputType: OutputType.CATEGORICAL
+    });
+  });
+
+  it('should return the created scorer version', async () => {
+    const result = await createCustomLlmMetric({
+      name: 'Test Metric',
+      userPrompt: 'Test prompt'
+    });
+
+    expect(result).toEqual(mockScorerVersion);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    const apiError = new Error('API error');
+    (createScorer as jest.Mock).mockRejectedValue(apiError);
+
+    await expect(
+      createCustomLlmMetric({
+        name: 'Test Metric',
+        userPrompt: 'Test prompt'
+      })
+    ).rejects.toThrow(apiError);
+  });
+});

--- a/tests/utils/scorers.test.ts
+++ b/tests/utils/scorers.test.ts
@@ -147,24 +147,25 @@ describe('scorers utility', () => {
     });
 
     it('should initialize the API client', async () => {
-      await createLlmScorerVersion('scorer-uuid', 'instructions', {
-        template: 'foo'
+      await createLlmScorerVersion({
+        scorerId: 'scorer-uuid',
+        instructions: 'instructions',
+        chainPollTemplate: { template: 'foo' }
       });
       expect(mockInit).toHaveBeenCalled();
     });
 
     it('should call createLlmScorerVersion with correct parameters', async () => {
-      await createLlmScorerVersion(
-        'scorer-uuid',
-        'instructions',
-        { template: 'foo' },
-        undefined, // userPrompt
-        [StepType.trace], // scoreableNodeTypes
-        true, // cotEnabled
-        'gpt-4',
-        3,
-        OutputType.CATEGORICAL
-      );
+      await createLlmScorerVersion({
+        scorerId: 'scorer-uuid',
+        instructions: 'instructions',
+        chainPollTemplate: { template: 'foo' },
+        scoreableNodeTypes: [StepType.trace],
+        cotEnabled: true,
+        modelName: 'gpt-4',
+        numJudges: 3,
+        outputType: OutputType.CATEGORICAL
+      });
       expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
         'scorer-uuid',
         'instructions',
@@ -179,11 +180,11 @@ describe('scorers utility', () => {
     });
 
     it('should return the created scorer version', async () => {
-      const result = await createLlmScorerVersion(
-        'scorer-uuid',
-        'instructions',
-        { template: 'foo' }
-      );
+      const result = await createLlmScorerVersion({
+        scorerId: 'scorer-uuid',
+        instructions: 'instructions',
+        chainPollTemplate: { template: 'foo' }
+      });
       expect(result).toEqual(mockVersion);
     });
 
@@ -191,24 +192,24 @@ describe('scorers utility', () => {
       const apiError = new Error('API error');
       mockCreateLlmScorerVersion.mockRejectedValueOnce(apiError);
       await expect(
-        createLlmScorerVersion('scorer-uuid', 'instructions', {
-          template: 'foo'
+        createLlmScorerVersion({
+          scorerId: 'scorer-uuid',
+          instructions: 'instructions',
+          chainPollTemplate: { template: 'foo' }
         })
       ).rejects.toThrow(apiError);
     });
 
     it('should call createLlmScorerVersion with userPrompt instead of instructions/chainPollTemplate', async () => {
-      await createLlmScorerVersion(
-        'scorer-uuid',
-        undefined, // instructions
-        undefined, // chainPollTemplate
-        'custom user prompt', // userPrompt
-        [StepType.session],
-        false,
-        'gpt-4',
-        3,
-        OutputType.CATEGORICAL
-      );
+      await createLlmScorerVersion({
+        scorerId: 'scorer-uuid',
+        userPrompt: 'custom user prompt',
+        scoreableNodeTypes: [StepType.session],
+        cotEnabled: false,
+        modelName: 'gpt-4',
+        numJudges: 3,
+        outputType: OutputType.CATEGORICAL
+      });
       expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
         'scorer-uuid',
         undefined, // instructions
@@ -223,12 +224,10 @@ describe('scorers utility', () => {
     });
 
     it('should return the created scorer version when using userPrompt', async () => {
-      const result = await createLlmScorerVersion(
-        'scorer-uuid',
-        undefined, // instructions
-        undefined, // chainPollTemplate
-        'custom user prompt' // userPrompt
-      );
+      const result = await createLlmScorerVersion({
+        scorerId: 'scorer-uuid',
+        userPrompt: 'custom user prompt'
+      });
       expect(result).toEqual(mockVersion);
     });
   });


### PR DESCRIPTION
**shortcut:** https://app.shortcut.com/galileo/story/40923/typescript-sdk-createcustomllmmetric-takes-parameters-rather-than-a-parameter-object

**description:** Make createCustomLlmMetric take a parameter object instead of parameters