### PR TITLE
standardize getPrompt and createPrompt return types

### DIFF
--- a/src/utils/prompt-templates.ts
+++ b/src/utils/prompt-templates.ts
@@ -20,36 +20,25 @@ export const getPrompts = async ({
 
 export const getPrompt = async ({
   id,
-  name,
-  version
+  name
 }: {
   id?: string;
   name?: string;
-  version?: number;
-}): Promise<PromptTemplateVersion> => {
+}): Promise<PromptTemplate> => {
   if (!id && !name) {
     throw new Error('Either id or name must be provided');
   }
   const apiClient = new GalileoApiClient();
   await apiClient.init({ projectScoped: false });
   if (id) {
-    if (version) {
-      return await apiClient.getGlobalPromptTemplateVersion(id, version);
-    } else {
-      const template = await apiClient.getGlobalPromptTemplate(id);
-      version = template.selected_version.version;
-      return await apiClient.getGlobalPromptTemplateVersion(id, version);
-    }
+    return await apiClient.getGlobalPromptTemplate(id);
   } else {
     // lookup by name
     const templates = await getPrompts({
       name: name!
     });
     if (templates.length > 0) {
-      const template = templates[0];
-      version = template.selected_version.version;
-      id = template.id;
-      return await apiClient.getGlobalPromptTemplateVersion(id, version);
+      return templates[0];
     }
     throw new Error(`Prompt template with name '${name}' not found`);
   }

--- a/tests/utils/prompt-templates.test.ts
+++ b/tests/utils/prompt-templates.test.ts
@@ -166,17 +166,16 @@ test('test get prompt template by id', async () => {
   const template = await getPrompt({
     id: EXAMPLE_PROMPT_TEMPLATE.id
   });
-  expect(template).toEqual(EXAMPLE_PROMPT_TEMPLATE_VERSION);
-  expect(getGlobalPromptTemplateVersionHandler).toHaveBeenCalled();
+  expect(template).toEqual(EXAMPLE_PROMPT_TEMPLATE);
+  expect(getGlobalPromptTemplateHandler).toHaveBeenCalled();
 });
 
 test('test get prompt template by name', async () => {
   const template = await getPrompt({
     name: 'My Dataset'
   });
-  expect(template).toEqual(EXAMPLE_PROMPT_TEMPLATE_VERSION);
+  expect(template).toEqual(EXAMPLE_PROMPT_TEMPLATE);
   expect(listGlobalPromptTemplatesHandler).toHaveBeenCalled();
-  expect(getGlobalPromptTemplateVersionHandler).toHaveBeenCalled();
 });
 
 test('test delete prompt template by id', async () => {
@@ -185,15 +184,6 @@ test('test delete prompt template by id', async () => {
   });
   expect(response).toEqual({ success: true });
   expect(deleteGlobalPromptTemplateHandler).toHaveBeenCalled();
-});
-
-test('test get prompt template by id and version', async () => {
-  const templateVersion = await getPrompt({
-    id: EXAMPLE_PROMPT_TEMPLATE.id,
-    version: EXAMPLE_PROMPT_TEMPLATE_VERSION.version
-  });
-  expect(templateVersion).toEqual(EXAMPLE_PROMPT_TEMPLATE_VERSION);
-  expect(getGlobalPromptTemplateVersionHandler).toHaveBeenCalled();
 });
 
 test('test delete prompt template by name', async () => {


### PR DESCRIPTION
shortcut: https://app.shortcut.com/galileo/story/40147/createprompt-and-getprompt-should-return-the-same-type