### PR TITLE
feat: Enable metrics for LogStream

### DIFF
--- a/examples/metrics/metrics.js
+++ b/examples/metrics/metrics.js
@@ -1,0 +1,48 @@
+const dotenv = await import('dotenv/config');
+
+const { enableMetrics, GalileoScorers } = await import('../../dist/index.js');
+
+// Enable metric for a specific log stream and project
+await enableMetrics({
+  projectName: 'js-project',
+  logStreamName: 'js-log-stream',
+  metrics: [
+    GalileoScorers.Correctness,
+    GalileoScorers.Completeness,
+    'context_relevance',
+    'instruction_adherence'
+  ]
+});
+
+// -------------------------------------
+// Local metric with custom scorer function
+// -------------------------------------
+
+// Custom scorer function
+function responseLengthScorer(traceOrSpan) {
+  if (traceOrSpan.output) {
+    // Normalize response length to 0-1 scale
+    return Math.min(traceOrSpan.output.length / 100.0, 1.0);
+  }
+  return 0.0;
+}
+
+// Enable custom and local metrics
+const localMetrics = await enableMetrics({
+  projectName: 'js-project',
+  logStreamName: 'js-log-stream',
+  metrics: [
+    // Built-in metrics
+    GalileoScorers.Correctness,
+    'completeness',
+    // Custom metric with specific version
+    { name: 'my_custom_metric', version: 2 },
+    // Local custom metric
+    {
+      name: 'response_length',
+      scorerFn: responseLengthScorer,
+      scorableTypes: ['llm'],
+      aggregatableTypes: ['trace']
+    }
+  ]
+});

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -19,7 +19,7 @@
     },
     "..": {
       "name": "galileo",
-      "version": "1.22.0",
+      "version": "1.26.1",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^1.8.2",
@@ -1173,9 +1173,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "18.19.68",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.68.tgz",
-      "integrity": "sha512-QGtpFH1vB99ZmTa63K4/FU8twThj4fuVSBkGddTp7uIL/cuoLWIUSL2RcOaigBhfR+hg5pgGkBnkoOxrTVBMKw==",
+      "version": "18.19.129",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.129.tgz",
+      "integrity": "sha512-hrmi5jWt2w60ayox3iIXwpMEnfUvOLJCRtrOPbHtH15nTjvO7uhnelvrdAs0dO0/zl5DZ3ZbahiaXEVb54ca/A==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -1259,14 +1259,14 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
-      "integrity": "sha512-DukmaFRnY6AzAALSH4J2M3k6PkaC+MfaAGdEERRWcC9q3/TWQwLpHR8ZRLKTdQ3aBDL64EdluRDjJqKw+BPZEw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1308,6 +1308,19 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause",
       "peer": true
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/camelcase": {
       "version": "6.3.0",
@@ -1455,6 +1468,20 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1463,6 +1490,51 @@
       "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/event-target-shim": {
@@ -1542,13 +1614,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
-      "integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
         "mime-types": "^2.1.12"
       },
       "engines": {
@@ -1589,6 +1663,103 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/humanize-ms": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -1599,22 +1770,22 @@
       }
     },
     "node_modules/ibm-cloud-sdk-core": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.1.0.tgz",
-      "integrity": "sha512-KJCbPz3tiXB1NGAD7cL4JtwpWV8yd/C7jsaHsxvedMo2ZblNG8emMyvSpGhiKAQVZmi3c0ujz6eJdy22NHuUWQ==",
+      "version": "5.4.3",
+      "resolved": "https://registry.npmjs.org/ibm-cloud-sdk-core/-/ibm-cloud-sdk-core-5.4.3.tgz",
+      "integrity": "sha512-D0lvClcoCp/HXyaFlCbOT4aTYgGyeIb4ncxZpxRuiuw7Eo79C6c49W53+8WJRD9nxzT5vrIdaky3NBcTdBtaEg==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
         "@types/debug": "^4.1.12",
-        "@types/node": "~10.14.19",
+        "@types/node": "^18.19.80",
         "@types/tough-cookie": "^4.0.0",
-        "axios": "1.7.4",
+        "axios": "^1.12.2",
         "camelcase": "^6.3.0",
         "debug": "^4.3.4",
         "dotenv": "^16.4.5",
         "extend": "3.0.2",
         "file-type": "16.5.4",
-        "form-data": "4.0.0",
+        "form-data": "^4.0.4",
         "isstream": "0.1.2",
         "jsonwebtoken": "^9.0.2",
         "mime-types": "2.1.35",
@@ -1623,28 +1794,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/ibm-cloud-sdk-core/node_modules/@types/node": {
-      "version": "10.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
-      "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
-      "license": "MIT",
-      "peer": true
-    },
-    "node_modules/ibm-cloud-sdk-core/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/ieee754": {
@@ -2155,6 +2304,15 @@
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.52.0",

--- a/src/api-client/galileo-client.ts
+++ b/src/api-client/galileo-client.ts
@@ -256,6 +256,14 @@ export class GalileoApiClient extends BaseClient {
     return this.logStreamService!.createLogStream(name);
   }
 
+  public async createLogStreamScorerSettings(
+    logStreamId: string,
+    scorers: ScorerConfig[]
+  ): Promise<void> {
+    this.ensureService(this.logStreamService);
+    return this.logStreamService!.createScorerSettings(logStreamId, scorers);
+  }
+
   // Dataset methods - delegate to DatasetService
   public async getDatasets() {
     this.ensureService(this.datasetService);

--- a/src/api-client/services/logstream-service.ts
+++ b/src/api-client/services/logstream-service.ts
@@ -1,6 +1,7 @@
 import { BaseClient, RequestMethod } from '../base-client';
 import { LogStream } from '../../types/log-stream.types';
 import { Routes } from '../../types/routes.types';
+import { ScorerConfig } from '../../types/scorer.types';
 
 export class LogStreamService extends BaseClient {
   private projectId: string;
@@ -60,6 +61,21 @@ export class LogStreamService extends BaseClient {
         name: logStreamName
       },
       { project_id: this.projectId }
+    );
+  }
+
+  public async createScorerSettings(
+    logStreamId: string,
+    scorers: ScorerConfig[]
+  ): Promise<void> {
+    return await this.makeRequest<void>(
+      RequestMethod.POST,
+      Routes.runScorerSettings,
+      { run_id: logStreamId, scorers },
+      {
+        project_id: this.projectId,
+        experiment_id: logStreamId
+      }
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,11 @@ import GalileoObserveApiClient from './observe/api-client';
 import GalileoObserveCallback from './observe/callback';
 import GalileoObserveWorkflow from './observe/workflow';
 import { GalileoApiClient } from './api-client';
-import { GalileoScorers } from './types/metrics.types';
+import {
+  GalileoScorers,
+  LocalMetricConfig,
+  Metric
+} from './types/metrics.types';
 import {
   addRowsToDataset,
   createDataset,
@@ -17,7 +21,11 @@ import {
   getDatasetMetadata,
   extendDataset
 } from './utils/datasets';
-import { createCustomLlmMetric, deleteMetric } from './utils/metrics';
+import {
+  createCustomLlmMetric,
+  deleteMetric,
+  createMetricConfigs
+} from './utils/metrics';
 import {
   getPromptTemplate,
   getPromptTemplates,
@@ -31,7 +39,8 @@ import { getProjects, createProject, getProject } from './utils/projects';
 import {
   getLogStreams,
   createLogStream,
-  getLogStream
+  getLogStream,
+  enableMetrics
 } from './utils/log-streams';
 import {
   getExperiments,
@@ -56,6 +65,8 @@ export {
   GalileoLogger,
   GalileoCallback,
   GalileoScorers,
+  Metric,
+  LocalMetricConfig,
   // OpenAI
   wrapOpenAI,
   // Datasets
@@ -90,6 +101,7 @@ export {
   getLogStreams,
   createLogStream,
   getLogStream,
+  enableMetrics,
   // Logging
   log,
   init,
@@ -97,5 +109,6 @@ export {
   getLogger,
   // Metrics
   createCustomLlmMetric,
-  deleteMetric
+  deleteMetric,
+  createMetricConfigs
 };

--- a/src/types/metrics.types.ts
+++ b/src/types/metrics.types.ts
@@ -110,3 +110,35 @@ export interface DeleteMetricParams {
   scorerName: string;
   scorerType: ScorerTypes;
 }
+
+/**
+ * Configuration for a local metric that is computed client-side.
+ *
+ * This interface defines metrics that are evaluated on the client rather than server-side.
+ * Local metrics are useful for custom scoring logic that needs to run in the client environment.
+ */
+export interface LocalMetricConfig {
+  /** The name of the metric */
+  name: string;
+  /**
+   * The scoring function that computes the metric value.
+   * Takes a trace or span and returns a metric value.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  scorerFn: (traceOrSpan: any) => MetricValueType;
+  /**
+   * Optional aggregator function to combine scores from child spans.
+   * Takes an array of metric values and returns an aggregated value.
+   */
+  aggregatorFn?: (scores: MetricValueType[]) => MetricValueType;
+  /**
+   * The step types that can be scored by this metric.
+   * Defaults to ['llm'] if not specified.
+   */
+  scorableTypes?: string[];
+  /**
+   * The step types that can have aggregated scores.
+   * Defaults to ['trace'] if not specified.
+   */
+  aggregatableTypes?: string[];
+}

--- a/src/utils/log-streams.ts
+++ b/src/utils/log-streams.ts
@@ -1,5 +1,12 @@
 import { LogStream } from '../types/log-stream.types';
 import { GalileoApiClient } from '../api-client';
+import {
+  GalileoScorers,
+  LocalMetricConfig,
+  Metric
+} from '../types/metrics.types';
+import { createMetricConfigs } from './metrics';
+import { getProject } from './projects';
 
 /*
  * Gets all log streams.
@@ -49,4 +56,94 @@ export const getLogStream = async ({
   }
 
   return await apiClient.getLogStreamByName(name!);
+};
+
+/**
+ * Enable metrics for a log stream.
+ *
+ * Supports explicit parameters or environment variables (GALILEO_PROJECT/GALILEO_LOG_STREAM).
+ *
+ * @param options - Configuration options
+ * @param options.logStreamName - Log stream name (overrides env var)
+ * @param options.projectName - Project name (overrides env var)
+ * @param options.metrics - Metrics to enable. Accepts:
+ *   - GalileoScorers enum (e.g., GalileoScorers.Correctness)
+ *   - String names (e.g., 'toxicity')
+ *   - Metric objects (e.g., { name: 'custom', version: 2 })
+ *   - LocalMetricConfig objects with scorerFn for client-side scoring
+ *
+ * @returns LocalMetricConfig[] - Client-side metrics that need local processing.
+ *          Server-side metrics are automatically registered.
+ *
+ * @throws Error if project/log stream not found or metrics don't exist
+ *
+ * @example
+ * ```typescript
+ * const localMetrics = await enableMetrics({
+ *   projectName: 'My Project',
+ *   logStreamName: 'Production',
+ *   metrics: [GalileoScorers.Correctness, 'toxicity']
+ * });
+ * ```
+ */
+export const enableMetrics = async ({
+  logStreamName,
+  projectName,
+  metrics
+}: {
+  logStreamName?: string;
+  projectName?: string;
+  metrics: (GalileoScorers | Metric | LocalMetricConfig | string)[];
+}): Promise<LocalMetricConfig[]> => {
+  // Validate metrics array
+  if (!metrics || metrics.length === 0) {
+    throw new Error('At least one metric must be provided');
+  }
+
+  // Apply environment variable fallbacks
+  const finalProjectName =
+    projectName ||
+    process.env.GALILEO_PROJECT ||
+    process.env.GALILEO_PROJECT_NAME;
+  const finalLogStreamName =
+    logStreamName ||
+    process.env.GALILEO_LOG_STREAM ||
+    process.env.GALILEO_LOG_STREAM_NAME;
+
+  if (!finalProjectName) {
+    throw new Error(
+      'Project name must be provided via projectName parameter or GALILEO_PROJECT/GALILEO_PROJECT_NAME environment variable'
+    );
+  }
+
+  if (!finalLogStreamName) {
+    throw new Error(
+      'Log stream name must be provided via logStreamName parameter or GALILEO_LOG_STREAM/GALILEO_LOG_STREAM_NAME environment variable'
+    );
+  }
+
+  // Get project
+  const project = await getProject({ name: finalProjectName });
+  if (!project || !project.id) {
+    throw new Error(`Project '${finalProjectName}' not found`);
+  }
+
+  // Get log stream
+  const logStream = await getLogStream({
+    name: finalLogStreamName,
+    projectName: finalProjectName
+  });
+  if (!logStream || !logStream.id) {
+    throw new Error(
+      `Log stream '${finalLogStreamName}' not found in project '${finalProjectName}'`
+    );
+  }
+
+  // Create metric configurations
+  const [, localMetrics] = await createMetricConfigs(
+    project.id,
+    logStream.id,
+    metrics
+  );
+  return localMetrics;
 };

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -10,8 +10,16 @@ import {
   createScorer,
   createLlmScorerVersion,
   deleteScorer,
-  getScorers
+  getScorers,
+  getScorerVersion
 } from './scorers';
+import {
+  GalileoScorers,
+  LocalMetricConfig,
+  Metric
+} from '../types/metrics.types';
+import { ScorerConfig } from '../types/scorer.types';
+import { GalileoApiClient } from '../api-client';
 
 /**
  * Creates a custom LLM metric.
@@ -68,8 +76,6 @@ export const deleteMetric = async (
 ): Promise<void> => {
   const { scorerName, scorerType } = params;
   const names: string[] = [scorerName];
-
-  console.log('Deleting metric with names:', names);
   const scorers = await getScorers({ type: scorerType, names: names });
   if (scorers.length === 0) {
     throw new Error(`Scorer with name ${scorerName} not found.`);
@@ -77,3 +83,146 @@ export const deleteMetric = async (
   const scorer = scorers[0]; // There should only ever be one here
   await deleteScorer(scorer.id);
 };
+
+/**
+ * Process metrics and create scorer configurations for log streams or experiments.
+ *
+ * This function categorizes metrics into server-side and client-side types,
+ * validates they exist, and registers server-side metrics with Galileo.
+ *
+ * @param projectId - The ID of the project
+ * @param runId - The ID of the run (can be experiment ID or log stream ID)
+ * @param metrics - List of metrics to configure
+ * @returns A promise that resolves to a tuple containing:
+ *          - Array of ScorerConfig objects for server-side metrics
+ *          - Array of LocalMetricConfig objects for client-side metrics
+ * @throws Error if any specified metrics are unknown or don't exist in Galileo
+ *
+ * @example
+ * ```typescript
+ * import { GalileoScorers } from '../types/metrics.types';
+ *
+ * const [scorerConfigs, localMetrics] = await createMetricConfigs(
+ *   'project-123',
+ *   'log-stream-456',
+ *   [
+ *     GalileoScorers.Correctness,
+ *     GalileoScorers.Completeness,
+ *     'toxicity',
+ *     { name: 'custom_metric', version: 2 },
+ *     {
+ *       name: 'local_scorer',
+ *       scorerFn: (span) => 0.85,
+ *       scorableTypes: ['llm']
+ *     }
+ *   ]
+ * );
+ * ```
+ */
+export const createMetricConfigs = async (
+  projectId: string,
+  runId: string,
+  metrics: (GalileoScorers | Metric | LocalMetricConfig | string)[]
+): Promise<[ScorerConfig[], LocalMetricConfig[]]> => {
+  const localMetricConfigs: LocalMetricConfig[] = [];
+  const scorerNameVersions: Array<[string, number | undefined]> = [];
+
+  // Categorize metrics by type
+  for (const metric of metrics) {
+    if (typeof metric === 'string') {
+      // Check if it's a GalileoScorers enum value
+      const enumValue = Object.values(GalileoScorers).find(
+        (val) => val === metric
+      );
+      if (enumValue) {
+        scorerNameVersions.push([enumValue, undefined]);
+      } else {
+        scorerNameVersions.push([metric, undefined]);
+      }
+    } else if (isMetric(metric)) {
+      scorerNameVersions.push([metric.name, metric.version]);
+    } else if (isLocalMetricConfig(metric)) {
+      localMetricConfigs.push(metric);
+    } else {
+      throw new Error(
+        `Invalid metric format. Expected string, GalileoScorers enum, Metric object with 'name' property, or LocalMetricConfig with 'name' and 'scorerFn'. Received: ${JSON.stringify(metric)}`
+      );
+    }
+  }
+
+  // Process server-side metrics
+  const scorers: ScorerConfig[] = [];
+  if (scorerNameVersions.length > 0) {
+    const allScorers = await getScorers();
+    const knownMetrics = new Map(allScorers.map((s) => [s.name, s]));
+    const unknownMetrics: string[] = [];
+
+    for (const [scorerName, scorerVersion] of scorerNameVersions) {
+      if (knownMetrics.has(scorerName)) {
+        const scorer = knownMetrics.get(scorerName)!;
+        const scorerConfig: ScorerConfig = {
+          id: scorer.id,
+          name: scorer.name,
+          scorer_type: scorer.scorer_type
+        };
+
+        // Set the version on the ScorerConfig if provided
+        if (scorerVersion !== undefined) {
+          const rawVersion = await getScorerVersion(scorer.id, scorerVersion);
+          scorerConfig.scorer_version = rawVersion;
+        }
+
+        scorers.push(scorerConfig);
+      } else {
+        unknownMetrics.push(scorerName);
+      }
+    }
+
+    if (unknownMetrics.length > 0) {
+      throw new Error(
+        `One or more non-existent metrics are specified: ${unknownMetrics.map((m) => `'${m}'`).join(', ')}`
+      );
+    }
+
+    // Register server-side metrics with Galileo
+    if (scorers.length > 0) {
+      const apiClient = new GalileoApiClient();
+      await apiClient.init({ projectId });
+
+      // Use the run scorer settings endpoint (works for both experiments and log streams)
+      await apiClient.createRunScorerSettings(runId, projectId, scorers);
+    }
+  }
+
+  return [scorers, localMetricConfigs];
+};
+
+/**
+ * Type guard to check if a value is a Metric interface
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isMetric(value: any): value is Metric {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    typeof value.name === 'string' &&
+    (!('version' in value) || typeof value.version === 'number') &&
+    !('scorerFn' in value)
+  );
+}
+
+/**
+ * Type guard to check if a value is a LocalMetricConfig interface
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function isLocalMetricConfig(value: any): value is LocalMetricConfig {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'name' in value &&
+    'scorerFn' in value &&
+    typeof value.name === 'string' &&
+    typeof value.scorerFn === 'function'
+  );
+}

--- a/tests/utils/experiments.test.ts
+++ b/tests/utils/experiments.test.ts
@@ -552,8 +552,12 @@ describe('experiments utility', () => {
     });
 
     it('should handle multiple metrics with mixed formats', async () => {
-      mockGetScorers.mockImplementation(({ names }) => {
-        return (names || []).map((name: string) => ({
+      mockGetScorers.mockImplementation((options?: { names?: string[] }) => {
+        const names = options?.names || [];
+        // When called without names, return all available scorers
+        const availableScorers = ['correctness', 'toxicity'];
+        const scorersToReturn = names.length > 0 ? names : availableScorers;
+        return scorersToReturn.map((name: string) => ({
           id: `scorer-${name}`,
           name,
           scorer_type: ScorerTypes.preset

--- a/tests/utils/metrics.test.ts
+++ b/tests/utils/metrics.test.ts
@@ -1,131 +1,379 @@
 import { createCustomLlmMetric, deleteMetric } from '../../src/utils/metrics';
+import { enableMetrics } from '../../src/utils/log-streams';
 import {
-  deleteScorer,
-  createScorer,
-  createLlmScorerVersion,
-  getScorers
-} from '../../src/utils/scorers';
+  GalileoScorers,
+  LocalMetricConfig,
+  Metric
+} from '../../src/types/metrics.types';
 import {
-  OutputType,
   Scorer,
-  ScorerTypes,
   ScorerVersion,
-  StepType
-} from '../../src/types';
+  ScorerTypes,
+  OutputType
+} from '../../src/types/scorer.types';
+import { StepType } from '../../src/types';
+import { LogStream } from '../../src/types/log-stream.types';
+import { Project, ProjectTypes } from '../../src/types/project.types';
 
-jest.mock('../../src/utils/scorers', () => ({
-  createScorer: jest.fn(),
-  createLlmScorerVersion: jest.fn(),
-  deleteScorer: jest.fn(),
-  getScorers: jest.fn()
-}));
+// Create mock implementation functions
+const mockInit = jest.fn().mockResolvedValue(undefined);
+const mockCreateScorer = jest.fn();
+const mockCreateLlmScorerVersion = jest.fn();
+const mockDeleteScorer = jest.fn();
+const mockGetScorerVersion = jest.fn();
+const mockGetScorers = jest.fn();
+const mockCreateRunScorerSettings = jest.fn();
+const mockGetProject = jest.fn();
+const mockGetProjectByName = jest.fn();
+const mockGetLogStream = jest.fn();
+const mockGetLogStreamByName = jest.fn();
 
-describe('createCustomLlmMetric', () => {
-  const mockScorer = { id: 'scorer-123' };
-  const mockScorerVersion: ScorerVersion = {
-    id: 'version-456',
-    version: 1
+jest.mock('../../src/api-client', () => {
+  return {
+    GalileoApiClient: jest.fn().mockImplementation(() => {
+      return {
+        init: mockInit,
+        createScorer: mockCreateScorer,
+        createLlmScorerVersion: mockCreateLlmScorerVersion,
+        deleteScorer: mockDeleteScorer,
+        getScorerVersion: mockGetScorerVersion,
+        getScorers: mockGetScorers,
+        createRunScorerSettings: mockCreateRunScorerSettings,
+        getProject: mockGetProject,
+        getProjectByName: mockGetProjectByName,
+        getLogStream: mockGetLogStream,
+        getLogStreamByName: mockGetLogStreamByName
+      };
+    })
   };
-
-  beforeEach(() => {
-    jest.clearAllMocks();
-    (createScorer as jest.Mock).mockResolvedValue(mockScorer);
-    (createLlmScorerVersion as jest.Mock).mockResolvedValue(mockScorerVersion);
-  });
-
-  it('should call createScorer with the correct parameters', async () => {
-    await createCustomLlmMetric({
-      name: 'Test Metric',
-      userPrompt: 'Test prompt'
-    });
-
-    expect(createScorer).toHaveBeenCalledWith(
-      'Test Metric',
-      ScorerTypes.llm,
-      '',
-      [],
-      {
-        model_name: 'gpt-4.1-mini',
-        num_judges: 3
-      },
-      undefined,
-      undefined
-    );
-  });
-
-  it('should call createLlmScorerVersion with the correct parameters', async () => {
-    await createCustomLlmMetric({
-      name: 'Test Metric',
-      userPrompt: 'Test prompt',
-      nodeLevel: StepType.trace,
-      cotEnabled: false,
-      modelName: 'gpt-4',
-      numJudges: 5,
-      outputType: OutputType.CATEGORICAL
-    });
-
-    expect(createLlmScorerVersion).toHaveBeenCalledWith({
-      scorerId: mockScorer.id,
-      userPrompt: 'Test prompt',
-      scoreableNodeTypes: [StepType.trace],
-      cotEnabled: false,
-      modelName: 'gpt-4',
-      numJudges: 5,
-      outputType: OutputType.CATEGORICAL
-    });
-  });
-
-  it('should return the created scorer version', async () => {
-    const result = await createCustomLlmMetric({
-      name: 'Test Metric',
-      userPrompt: 'Test prompt'
-    });
-
-    expect(result).toEqual(mockScorerVersion);
-  });
-
-  it('should handle API errors gracefully', async () => {
-    const apiError = new Error('API error');
-    (createScorer as jest.Mock).mockRejectedValue(apiError);
-
-    await expect(
-      createCustomLlmMetric({
-        name: 'Test Metric',
-        userPrompt: 'Test prompt'
-      })
-    ).rejects.toThrow(apiError);
-  });
 });
 
-describe('deleteMetric', () => {
-  const mockScorer: Scorer = {
+describe('metrics utils', () => {
+  const EXAMPLE_SCORER: Scorer = {
     id: 'scorer-123',
-    name: 'Test Scorer',
+    name: 'correctness',
+    scorer_type: ScorerTypes.preset
+  };
+
+  const EXAMPLE_CUSTOM_SCORER: Scorer = {
+    id: 'custom-scorer-456',
+    name: 'custom_metric',
     scorer_type: ScorerTypes.llm
   };
 
+  const EXAMPLE_CUSTOM_SCORER_VERSION: ScorerVersion = {
+    id: 'custom-scorer-version-456',
+    version: 2
+  };
+
+  const EXAMPLE_PROJECT: Project = {
+    id: 'project-123',
+    name: 'test-project',
+    type: ProjectTypes.genAI
+  };
+
+  const EXAMPLE_LOG_STREAM: LogStream = {
+    id: 'log-stream-123',
+    name: 'test-log-stream',
+    project_id: 'project-123',
+    created_at: new Date('2024-01-01T00:00:00Z'),
+    updated_at: new Date('2024-01-01T00:00:00Z'),
+    created_by: null
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    (getScorers as jest.Mock).mockResolvedValue([mockScorer]);
+    mockInit.mockResolvedValue(undefined);
+    mockCreateScorer.mockResolvedValue(EXAMPLE_CUSTOM_SCORER);
+    mockCreateLlmScorerVersion.mockResolvedValue(EXAMPLE_CUSTOM_SCORER_VERSION);
+    mockGetScorerVersion.mockResolvedValue(EXAMPLE_CUSTOM_SCORER_VERSION);
+    mockGetScorers.mockResolvedValue([
+      EXAMPLE_SCORER,
+      EXAMPLE_CUSTOM_SCORER,
+      {
+        id: 'completeness-scorer',
+        name: 'completeness',
+        scorer_type: ScorerTypes.preset
+      },
+      {
+        id: 'toxicity-scorer',
+        name: 'toxicity',
+        scorer_type: ScorerTypes.preset
+      }
+    ]);
+    mockDeleteScorer.mockResolvedValue(undefined);
+    mockCreateRunScorerSettings.mockResolvedValue(undefined);
+    mockGetProject.mockResolvedValue(EXAMPLE_PROJECT);
+    mockGetProjectByName.mockResolvedValue(EXAMPLE_PROJECT);
+    mockGetLogStream.mockResolvedValue(EXAMPLE_LOG_STREAM);
+    mockGetLogStreamByName.mockResolvedValue(EXAMPLE_LOG_STREAM);
   });
 
-  it('should call deleteScorer with the correct scorer ID', async () => {
-    await deleteMetric({
-      scorerName: 'Test Scorer',
-      scorerType: ScorerTypes.llm
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createCustomLlmMetric', () => {
+    it('should create a custom LLM metric with default parameters', async () => {
+      const result = await createCustomLlmMetric({
+        name: 'custom_metric',
+        userPrompt: 'Is this response good?'
+      });
+
+      expect(result).toEqual(EXAMPLE_CUSTOM_SCORER_VERSION);
+      expect(mockCreateScorer).toHaveBeenCalled();
+      expect(mockCreateLlmScorerVersion).toHaveBeenCalled();
     });
 
-    expect(deleteScorer).toHaveBeenCalledWith(mockScorer.id);
+    it('should create a custom LLM metric with custom parameters', async () => {
+      const result = await createCustomLlmMetric({
+        name: 'custom_metric',
+        userPrompt: 'Is this response good?',
+        nodeLevel: StepType.trace,
+        cotEnabled: false,
+        modelName: 'gpt-4',
+        numJudges: 5,
+        description: 'Custom description',
+        tags: ['tag1', 'tag2'],
+        outputType: OutputType.CATEGORICAL
+      });
+
+      expect(result).toEqual(EXAMPLE_CUSTOM_SCORER_VERSION);
+      expect(mockCreateScorer).toHaveBeenCalledWith(
+        'custom_metric',
+        ScorerTypes.llm,
+        'Custom description',
+        ['tag1', 'tag2'],
+        { model_name: 'gpt-4', num_judges: 5 },
+        undefined,
+        undefined
+      );
+      expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
+        EXAMPLE_CUSTOM_SCORER.id,
+        undefined,
+        undefined,
+        'Is this response good?',
+        [StepType.trace],
+        false,
+        'gpt-4',
+        5,
+        OutputType.CATEGORICAL
+      );
+    });
+
+    it('should call createScorer with the correct parameters for object-based API', async () => {
+      await createCustomLlmMetric({
+        name: 'Test Metric',
+        userPrompt: 'Test prompt'
+      });
+
+      expect(mockCreateScorer).toHaveBeenCalledWith(
+        'Test Metric',
+        ScorerTypes.llm,
+        '',
+        [],
+        {
+          model_name: 'gpt-4.1-mini',
+          num_judges: 3
+        },
+        undefined,
+        undefined
+      );
+    });
+
+    it('should call createLlmScorerVersion with the correct parameters for object-based API', async () => {
+      await createCustomLlmMetric({
+        name: 'Test Metric',
+        userPrompt: 'Test prompt',
+        nodeLevel: StepType.trace,
+        cotEnabled: false,
+        modelName: 'gpt-4',
+        numJudges: 5,
+        outputType: OutputType.CATEGORICAL
+      });
+
+      expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
+        EXAMPLE_CUSTOM_SCORER.id,
+        undefined,
+        undefined,
+        'Test prompt',
+        [StepType.trace],
+        false,
+        'gpt-4',
+        5,
+        OutputType.CATEGORICAL
+      );
+    });
+
+    it('should return the created scorer version', async () => {
+      const result = await createCustomLlmMetric({
+        name: 'Test Metric',
+        userPrompt: 'Test prompt'
+      });
+
+      expect(result).toEqual(EXAMPLE_CUSTOM_SCORER_VERSION);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      const apiError = new Error('API error');
+      mockCreateScorer.mockRejectedValueOnce(apiError);
+
+      await expect(
+        createCustomLlmMetric({
+          name: 'Test Metric',
+          userPrompt: 'Test prompt'
+        })
+      ).rejects.toThrow(apiError);
+    });
   });
 
-  it('should throw an error if the scorer is not found', async () => {
-    (getScorers as jest.Mock).mockResolvedValue([]);
+  describe('deleteMetric', () => {
+    it('should delete a metric by name and type', async () => {
+      // Mock getScorers to return only the matching scorer
+      mockGetScorers.mockResolvedValueOnce([EXAMPLE_CUSTOM_SCORER]);
 
-    await expect(
-      deleteMetric({
+      await deleteMetric({
+        scorerName: 'custom_metric',
+        scorerType: ScorerTypes.llm
+      });
+
+      expect(mockGetScorers).toHaveBeenCalledWith({
+        type: ScorerTypes.llm,
+        names: ['custom_metric']
+      });
+      expect(mockDeleteScorer).toHaveBeenCalledWith(EXAMPLE_CUSTOM_SCORER.id);
+    });
+
+    it('should call deleteScorer with the correct scorer ID for object-based API', async () => {
+      const mockScorer: Scorer = {
+        id: 'scorer-123',
+        name: 'Test Scorer',
+        scorer_type: ScorerTypes.llm
+      };
+      mockGetScorers.mockResolvedValueOnce([mockScorer]);
+
+      await deleteMetric({
         scorerName: 'Test Scorer',
         scorerType: ScorerTypes.llm
-      })
-    ).rejects.toThrow('Scorer with name Test Scorer not found.');
+      });
+
+      expect(mockDeleteScorer).toHaveBeenCalledWith(mockScorer.id);
+    });
+
+    it('should throw error when metric is not found', async () => {
+      mockGetScorers.mockResolvedValueOnce([]);
+
+      await expect(
+        deleteMetric({
+          scorerName: 'nonexistent_metric',
+          scorerType: ScorerTypes.llm
+        })
+      ).rejects.toThrow('Scorer with name nonexistent_metric not found.');
+    });
+
+    it('should throw an error if the scorer is not found for object-based API', async () => {
+      mockGetScorers.mockResolvedValueOnce([]);
+
+      await expect(
+        deleteMetric({
+          scorerName: 'Test Scorer',
+          scorerType: ScorerTypes.llm
+        })
+      ).rejects.toThrow('Scorer with name Test Scorer not found.');
+    });
+  });
+
+  describe('enableMetrics', () => {
+    let originalEnv: Record<string, string | undefined>;
+
+    beforeEach(() => {
+      originalEnv = { ...process.env };
+      delete process.env.GALILEO_PROJECT;
+      delete process.env.GALILEO_PROJECT_NAME;
+      delete process.env.GALILEO_LOG_STREAM;
+      delete process.env.GALILEO_LOG_STREAM_NAME;
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('should return local metrics when configured', async () => {
+      const localMetric: LocalMetricConfig = {
+        name: 'response_length',
+        scorerFn: (traceOrSpan) => traceOrSpan.output?.length || 0,
+        scorableTypes: ['llm'],
+        aggregatableTypes: ['trace']
+      };
+
+      const localMetrics = await enableMetrics({
+        projectName: 'test-project',
+        logStreamName: 'test-log-stream',
+        metrics: [GalileoScorers.Correctness, localMetric]
+      });
+
+      expect(localMetrics).toHaveLength(1);
+      expect(localMetrics[0].name).toBe('response_length');
+    });
+
+    it('should throw error when no metrics provided', async () => {
+      await expect(
+        enableMetrics({
+          projectName: 'test-project',
+          logStreamName: 'test-log-stream',
+          metrics: []
+        })
+      ).rejects.toThrow('At least one metric must be provided');
+    });
+
+    it('should throw error when project is not found', async () => {
+      mockGetProjectByName.mockResolvedValueOnce(null);
+
+      await expect(
+        enableMetrics({
+          projectName: 'nonexistent-project',
+          logStreamName: 'test-log-stream',
+          metrics: [GalileoScorers.Correctness]
+        })
+      ).rejects.toThrow("Project 'nonexistent-project' not found");
+    });
+
+    it('should throw error when log stream is not found', async () => {
+      mockGetLogStreamByName.mockResolvedValueOnce(null);
+
+      await expect(
+        enableMetrics({
+          projectName: 'test-project',
+          logStreamName: 'nonexistent-log-stream',
+          metrics: [GalileoScorers.Correctness]
+        })
+      ).rejects.toThrow(
+        "Log stream 'nonexistent-log-stream' not found in project 'test-project'"
+      );
+    });
+
+    it('should handle multiple metrics types', async () => {
+      const metric: Metric = { name: 'custom_metric', version: 2 };
+      const localMetric: LocalMetricConfig = {
+        name: 'response_length',
+        scorerFn: (traceOrSpan) => traceOrSpan.output?.length || 0
+      };
+
+      const localMetrics = await enableMetrics({
+        projectName: 'test-project',
+        logStreamName: 'test-log-stream',
+        metrics: [
+          GalileoScorers.Correctness,
+          GalileoScorers.Completeness,
+          'toxicity',
+          metric,
+          localMetric
+        ]
+      });
+
+      expect(localMetrics).toHaveLength(1);
+      expect(localMetrics[0].name).toBe('response_length');
+      expect(mockCreateRunScorerSettings).toHaveBeenCalled();
+    });
   });
 });


### PR DESCRIPTION
**Shortcut:**

- [sc-39363 / Allow users to turn on a metric in the logstream from the getting started code snippet](https://app.shortcut.com/galileo/story/39363/allow-users-to-turn-on-a-metric-in-the-logstream-from-the-getting-started-code-snippet)
- [sc-41457 / Enable metrics is missing for TypeScript](https://app.shortcut.com/galileo/story/41457/enable-metrics-is-missing-for-typescript)

**Description:**

This PR exposes the **enableMetrics** function to allow users to register metrics for log streams and experiments. The function supports built-in Galileo scorers, custom metrics with versions, and local metrics with custom scorer functions. 

The experiment metrics implementation was refactored to align with the Python SDK architecture using a unified **createMetricConfigs** utility.

**Example:**

```js
import { enableMetrics, GalileoScorers } from 'galileo-js';

// Enable metrics for a project/log stream
await enableMetrics({
  projectName: 'my-project',
  logStreamName: 'my-log-stream',
  metrics: [
    GalileoScorers.Correctness,            // Built-in scorer
    'context_relevance',                   // String-based metric
    { name: 'custom_metric', version: 2 }, // Custom with version
    {                                      // Local metric with custom function
      name: 'response_length',
      scorerFn: (traceOrSpan) => Math.min(traceOrSpan.output.length / 100.0, 1.0),
      scorableTypes: ['llm'],
      aggregatableTypes: ['trace']
    }
  ]
});
```

**Tests:**

- [x] Unit Tests Added
- [ ] [E2E Test](https://github.com/rungalileo/e2e-testing) Added (if it's a user-facing feature, or fixing a bug)
