### PR TITLE
fix: Scorer retrieval by filtering with metric names in createMetricConfigs

### DIFF
--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -153,7 +153,8 @@ export const createMetricConfigs = async (
   // Process server-side metrics
   const scorers: ScorerConfig[] = [];
   if (scorerNameVersions.length > 0) {
-    const allScorers = await getScorers();
+    const metricNames = scorerNameVersions.map(([name]) => name);
+    const allScorers = await getScorers({ names: metricNames });
     const knownMetrics = new Map(allScorers.map((s) => [s.name, s]));
     const unknownMetrics: string[] = [];
 


### PR DESCRIPTION
_Fix regression error / No ticket_

**Description:**

Scorer retrieval by filtering with metric names in createMetricConfigs