### PR TITLE
feat(langchain): Initial push of new features.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ then:
 
 Note: if you would like to point to an environment other than app.galileo.ai, you'll need to set the GALILEO_CONSOLE_URL environment variable.
 
+### Optional Peer Dependencies
+
+Galileo integrates with several LLM frameworks via optional peer dependencies. Install only the ones you need:
+
+```bash
+# For LangChain integration
+npm install @langchain/core
+
+# For LangChain OpenAI models
+npm install @langchain/core @langchain/openai
+
+# For OpenAI direct integration
+npm install openai
+
+# For OpenAI Agents SDK
+npm install @openai/agents
+```
+
 ### Usage
 
 #### Logging
@@ -151,6 +169,28 @@ logger.conclude({
 // Upload the trace to Galileo. Since logger was used
 // directly, no additional config necessary for flush
 const flushedTraces = await logger.flush();
+```
+
+#### LangChain Integration
+
+Use `GalileoCallback` to automatically log LangChain traces. Requires `@langchain/core` as a peer dependency.
+
+```bash
+npm install @langchain/core @langchain/openai
+```
+
+```js
+import { GalileoCallback, init, flush } from 'galileo';
+import { ChatOpenAI } from '@langchain/openai';
+
+await init({ projectName: 'my-project' });
+
+const model = new ChatOpenAI({ model: 'gpt-4o' });
+const callback = new GalileoCallback();
+
+const response = await model.invoke('Say hello!', { callbacks: [callback] });
+
+await flush();
 ```
 
 #### Datasets

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
       },
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.88.0",
+        "@langchain/core": "^0.3.13",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/lodash": "^4.17.17",
@@ -633,9 +634,8 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.0.3.tgz",
       "integrity": "sha512-ZykIcDTVv5UNmKWSTLAs3VukO6NDJkkSKxrgUTDPBkAlORVT3H9n5DbRjRl8xIotklscHdbLIa0b9+y3mQq73g==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -1455,9 +1455,8 @@
       "version": "0.3.78",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
       "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -1948,9 +1947,8 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2667,6 +2665,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -2681,9 +2680,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -3183,9 +3180,8 @@
       "version": "2.14.6",
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
       "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "simple-wcswidth": "^1.0.1"
       }
@@ -3320,9 +3316,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4267,9 +4262,8 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -6464,9 +6458,8 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.15.tgz",
       "integrity": "sha512-65ruOWWXDEZHHbAo7EjOcNxOGasQKbL4Fq3jEr2xsCqSsoOo6VVSqzWQb6PRIqypFSDcma4jO90YP0w5X8qVXQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -6626,9 +6619,8 @@
       "version": "0.3.74",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.74.tgz",
       "integrity": "sha512-ZuW3Qawz8w88XcuCRH91yTp6lsdGuwzRqZ5J0Hf5q/AjMz7DwcSv0MkE6V5W+8hFMI850QZN2Wlxwm3R9lHlZg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "chalk": "^4.1.2",
@@ -7025,9 +7017,8 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -7456,9 +7447,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7499,9 +7489,8 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -7530,9 +7519,8 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+      "devOptional": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -8471,9 +8459,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -9394,13 +9381,12 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "devOptional": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9807,9 +9793,8 @@
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
       "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
+      "devOptional": true,
       "license": "ISC",
-      "optional": true,
-      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2.0.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@langchain/core": "^0.3.13",
         "@types/cli-progress": "^3.11.6",
         "axios": "^1.12.2",
         "cli-progress": "^3.12.0",
@@ -46,14 +45,21 @@
         "typescript": "^5.8.2"
       },
       "optionalDependencies": {
-        "@langchain/openai": "^0.3.11",
         "tiktoken": "^1.0.13"
       },
       "peerDependencies": {
+        "@langchain/core": ">=0.3.13",
+        "@langchain/openai": ">=0.3.11",
         "@openai/agents": ">=0.4.0",
         "openai": ">=4.0.0"
       },
       "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/openai": {
+          "optional": true
+        },
         "@openai/agents": {
           "optional": true
         },
@@ -627,7 +633,9 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.0.3.tgz",
       "integrity": "sha512-ZykIcDTVv5UNmKWSTLAs3VukO6NDJkkSKxrgUTDPBkAlORVT3H9n5DbRjRl8xIotklscHdbLIa0b9+y3mQq73g==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -1448,6 +1456,8 @@
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
       "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
         "ansi-styles": "^5.0.0",
@@ -1472,6 +1482,7 @@
       "integrity": "sha512-lNWjUo1tbvsss45IF7UQtMu1NJ6oUKvhgPYWXnX9f/d6OmuLu7D99HQ3Y88vLcUo9XjjOy417olYHignMduMjA==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "js-tiktoken": "^1.0.12",
         "openai": "^4.71.0",
@@ -1937,7 +1948,9 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.33",
@@ -2296,6 +2309,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2667,7 +2681,9 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
@@ -2903,6 +2919,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2936,6 +2953,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2952,6 +2970,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3085,6 +3104,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3097,6 +3117,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -3163,6 +3184,8 @@
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
       "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "simple-wcswidth": "^1.0.1"
       }
@@ -3298,6 +3321,8 @@
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4242,7 +4267,9 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -4942,6 +4969,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -6437,6 +6465,8 @@
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.15.tgz",
       "integrity": "sha512-65ruOWWXDEZHHbAo7EjOcNxOGasQKbL4Fq3jEr2xsCqSsoOo6VVSqzWQb6PRIqypFSDcma4jO90YP0w5X8qVXQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "base64-js": "^1.5.1"
       }
@@ -6597,6 +6627,8 @@
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.74.tgz",
       "integrity": "sha512-ZuW3Qawz8w88XcuCRH91yTp6lsdGuwzRqZ5J0Hf5q/AjMz7DwcSv0MkE6V5W+8hFMI850QZN2Wlxwm3R9lHlZg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "@types/uuid": "^10.0.0",
         "chalk": "^4.1.2",
@@ -6994,6 +7026,8 @@
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "mustache": "bin/mustache"
       }
@@ -7423,6 +7457,8 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -7464,6 +7500,8 @@
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "eventemitter3": "^4.0.4",
         "p-timeout": "^3.2.0"
@@ -7493,6 +7531,8 @@
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "p-finally": "^1.0.0"
       },
@@ -8431,7 +8471,9 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",
@@ -8698,6 +8740,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -9356,6 +9399,8 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -9763,6 +9808,8 @@
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
       "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "peerDependencies": {
         "zod": "^3.24.1"
       }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "license": "Apache-2.0",
   "homepage": "https://www.galileo.ai/",
   "dependencies": {
-    "@langchain/core": "^0.3.13",
     "@types/cli-progress": "^3.11.6",
     "axios": "^1.12.2",
     "cli-progress": "^3.12.0",
@@ -46,14 +45,21 @@
     "ts-case-convert": "^2.1.0"
   },
   "optionalDependencies": {
-    "@langchain/openai": "^0.3.11",
     "tiktoken": "^1.0.13"
   },
   "peerDependencies": {
+    "@langchain/core": ">=0.3.13",
+    "@langchain/openai": ">=0.3.11",
     "@openai/agents": ">=0.4.0",
     "openai": ">=4.0.0"
   },
   "peerDependenciesMeta": {
+    "@langchain/core": {
+      "optional": true
+    },
+    "@langchain/openai": {
+      "optional": true
+    },
     "@openai/agents": {
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     }
   },
   "devDependencies": {
+    "@langchain/core": "^0.3.13",
     "@hey-api/openapi-ts": "^0.88.0",
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.6",

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -172,7 +172,7 @@ export class GalileoCallback
     ) {
       const messages = (update as Record<string, unknown>)
         .messages as unknown[];
-      const last = messages[messages.length - 1];
+      const last = messages.length === 0 ? null : messages[messages.length - 1];
       if (last instanceof ToolMessage) return last;
     }
     return null;

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -1,12 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { AxiosError } from 'axios';
 import {
   BaseCallbackHandler,
   CallbackHandlerMethods,
   NewTokenIndices
 } from '@langchain/core/callbacks/base';
 import { LLMResult } from '@langchain/core/outputs';
-import { BaseMessage } from '@langchain/core/messages';
+import { BaseMessage, ToolMessage } from '@langchain/core/messages';
 import { ChainValues } from '@langchain/core/utils/types';
 import { AgentFinish } from '@langchain/core/agents';
 import { Document, DocumentInterface } from '@langchain/core/documents';
@@ -15,6 +14,7 @@ import { GalileoLogger } from '../utils/galileo-logger';
 import { toStringValue, toStringRecord } from '../utils/serialization';
 import { getSdkLogger } from 'galileo-generated';
 import { Serialized } from '@langchain/core/load/serializable.js';
+import type { LogTracesIngestRequest } from '../types/logging/trace.types';
 
 const sdkLogger = getSdkLogger();
 
@@ -27,7 +27,7 @@ type LANGCHAIN_NODE_TYPE =
   | 'tool';
 
 /**
- * A node in the Langchain trace.
+ * A node in the LangChain trace.
  */
 class Node {
   nodeType: LANGCHAIN_NODE_TYPE;
@@ -60,6 +60,28 @@ export const rootNodeContext = {
 };
 
 /**
+ * Retroactively upgrade a root-level chain node to agent type when any of its
+ * children carry langgraph_* metadata keys (Python: update_root_to_agent).
+ */
+function updateRootToAgent(
+  parentRunId: string | undefined,
+  metadata: Record<string, unknown> | undefined,
+  nodes: Record<string, Node>
+): void {
+  if (!parentRunId) return;
+  if (!metadata) return;
+  const hasLangGraphKey = Object.keys(metadata).some((k) =>
+    k.startsWith('langgraph_')
+  );
+  if (!hasLangGraphKey) return;
+  const parentNode = nodes[parentRunId];
+  if (!parentNode) return;
+  if (parentNode.nodeType === 'chain' && parentNode.parentRunId === undefined) {
+    parentNode.nodeType = 'agent';
+  }
+}
+
+/**
  * Langchain callback handler for logging traces to the Galileo platform.
  */
 export class GalileoCallback
@@ -76,17 +98,89 @@ export class GalileoCallback
   constructor(
     galileoLogger?: GalileoLogger,
     startNewTrace: boolean = true,
-    flushOnChainEnd: boolean = true
+    flushOnChainEnd: boolean = true,
+    ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void
   ) {
     super();
-    this._galileoLogger =
-      galileoLogger || GalileoSingleton.getInstance().getClient();
+    if (galileoLogger) {
+      this._galileoLogger = galileoLogger;
+    } else if (ingestionHook) {
+      this._galileoLogger = new GalileoLogger({ ingestionHook });
+    } else {
+      this._galileoLogger = GalileoSingleton.getInstance().getClient();
+    }
     this._startNewTrace = startNewTrace;
     this._flushOnChainEnd = flushOnChainEnd;
   }
 
   /**
+   * Shared name resolution helper (Python: _get_node_name).
+   * Resolution order: serialized.name → serialized.id[-1] → kwargs.name →
+   * kwargs.metadata.name → nodeType capitalised.
+   */
+  private static _getNodeName(
+    nodeType: string,
+    serialized?: Serialized | null,
+    kwargs?: Record<string, unknown>
+  ): string {
+    try {
+      if (serialized?.name && serialized.name.length > 0) {
+        return serialized.name;
+      }
+      const idArr = serialized?.id;
+      if (Array.isArray(idArr) && idArr.length > 0) {
+        return String(idArr[idArr.length - 1]);
+      }
+      const kwargsName = kwargs?.name;
+      if (typeof kwargsName === 'string' && kwargsName.length > 0) {
+        return kwargsName;
+      }
+      const metaName = (kwargs?.metadata as Record<string, unknown>)?.name;
+      if (typeof metaName === 'string' && metaName.length > 0) {
+        return metaName;
+      }
+      return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
+    } catch {
+      return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
+    }
+  }
+
+  /**
+   * Build a hierarchical agent name from the parent node (Python: get_agent_name).
+   */
+  private _getAgentName(
+    parentRunId: string | undefined,
+    defaultName: string
+  ): string {
+    if (parentRunId !== undefined && this._nodes[parentRunId]) {
+      return `${this._nodes[parentRunId].spanParams.name}:${defaultName}`;
+    }
+    return defaultName;
+  }
+
+  /**
+   * Detect a ToolMessage inside a tool output, including LangGraph Command objects
+   * that carry a messages array (Python: _find_tool_message).
+   */
+  private static _findToolMessage(output: unknown): ToolMessage | null {
+    if (output instanceof ToolMessage) return output;
+    const update = (output as Record<string, unknown>)?.update;
+    if (
+      typeof update === 'object' &&
+      update !== null &&
+      Array.isArray((update as Record<string, unknown>).messages)
+    ) {
+      const messages = (update as Record<string, unknown>)
+        .messages as unknown[];
+      const last = messages[messages.length - 1];
+      if (last instanceof ToolMessage) return last;
+    }
+    return null;
+  }
+
+  /**
    * Commit the nodes to the trace using the Galileo Logger. Optionally flush the trace.
+   * Uses try/finally to guarantee node state is always cleared even on error.
    */
   private async _commit(): Promise<void> {
     if (Object.keys(this._nodes).length === 0) {
@@ -106,32 +200,37 @@ export class GalileoCallback
       return;
     }
 
-    if (this._startNewTrace) {
-      this._galileoLogger.startTrace({
-        input: toStringValue(rootNode.spanParams.input || '')
-      });
+    try {
+      if (this._startNewTrace) {
+        this._galileoLogger.startTrace({
+          input: toStringValue(rootNode.spanParams.input || ''),
+          name: rootNode.spanParams.name as string | undefined,
+          metadata: rootNode.spanParams.metadata as
+            | Record<string, string>
+            | undefined
+        });
+      }
+
+      this._logNodeTree(rootNode);
+
+      // Conclude the trace with the root node's output
+      const rootOutput = rootNode.spanParams.output || '';
+
+      if (this._startNewTrace) {
+        this._galileoLogger.conclude({
+          output: toStringValue(rootOutput),
+          statusCode: rootNode.spanParams.statusCode as number | undefined
+        });
+      }
+
+      if (this._flushOnChainEnd) {
+        await this._galileoLogger.flush();
+      }
+    } finally {
+      // Always clear state, even if an exception occurs
+      this._nodes = {};
+      rootNodeContext.set(null);
     }
-
-    this._logNodeTree(rootNode);
-
-    // Conclude the trace with the root node's output
-    const rootOutput = rootNode.spanParams.output || '';
-
-    if (this._startNewTrace) {
-      // If a new trace was started, conclude it
-      this._galileoLogger.conclude({
-        output: toStringValue(rootOutput)
-      });
-    }
-
-    if (this._flushOnChainEnd) {
-      // Upload the trace to Galileo
-      await this._galileoLogger.flush();
-    }
-
-    // Clear nodes after successful commit
-    this._nodes = {};
-    rootNodeContext.set(null);
   }
 
   /**
@@ -147,6 +246,9 @@ export class GalileoCallback
       typeof output === 'string' ? output : toStringValue(output);
     const name = node.spanParams.name;
     const tags = node.spanParams.tags;
+    const durationNs = node.spanParams.durationNs as number | undefined;
+    const createdAt = node.spanParams.createdAt as Date | undefined;
+    const statusCode = node.spanParams.statusCode as number | undefined;
 
     let metadata: Record<string, string> | undefined = undefined;
     if (node.spanParams.metadata) {
@@ -182,13 +284,29 @@ export class GalileoCallback
     }
 
     // Log the current node based on its type
-    if (node.nodeType === 'agent' || node.nodeType === 'chain') {
+    if (node.nodeType === 'agent') {
+      this._galileoLogger.addAgentSpan({
+        input: inputAsString,
+        output: outputAsString,
+        name,
+        metadata,
+        tags,
+        durationNs,
+        createdAt,
+        statusCode,
+        stepNumber
+      });
+      isWorkflowSpan = true;
+    } else if (node.nodeType === 'chain') {
       this._galileoLogger.addWorkflowSpan({
         input: inputAsString,
         output: outputAsString,
         name,
         metadata,
         tags,
+        durationNs,
+        createdAt,
+        statusCode,
         stepNumber
       });
       isWorkflowSpan = true;
@@ -206,6 +324,9 @@ export class GalileoCallback
         numOutputTokens: node.spanParams.numOutputTokens,
         totalTokens: node.spanParams.totalTokens,
         timeToFirstTokenNs: node.spanParams.timeToFirstTokenNs,
+        durationNs,
+        createdAt,
+        statusCode,
         stepNumber
       });
     } else if (node.nodeType === 'retriever') {
@@ -215,17 +336,29 @@ export class GalileoCallback
         name,
         metadata,
         tags,
+        durationNs,
+        createdAt,
+        statusCode,
         stepNumber
       });
     } else if (node.nodeType === 'tool') {
-      this._galileoLogger.addToolSpan({
+      const toolSpan = this._galileoLogger.addToolSpan({
         input: inputAsString,
         output: outputAsString,
         name,
         metadata,
         tags,
+        toolCallId: node.spanParams.toolCallId as string | undefined,
+        durationNs,
+        createdAt,
+        statusCode,
         stepNumber
       });
+      if (node.children.length > 0) {
+        // Push tool span as parent so agent-as-tool child spans nest correctly
+        this._galileoLogger.pushParent(toolSpan);
+        isWorkflowSpan = true;
+      }
     } else {
       sdkLogger.warn(`Unknown node type: ${node.nodeType}`);
     }
@@ -242,18 +375,20 @@ export class GalileoCallback
       }
     }
 
-    // Conclude workflow span. Use the last child's output if necessary
+    // Conclude workflow/agent span. Use the last child's output if necessary
     if (isWorkflowSpan) {
       const finalOutput =
         output || (lastChild ? lastChild.spanParams.output || '' : '');
       this._galileoLogger.conclude({
-        output: toStringValue(finalOutput)
+        output: toStringValue(finalOutput),
+        statusCode
       });
     }
   }
 
   /**
    * Start a new node in the chain.
+   * Records startTime and createdAt for all nodes automatically.
    */
   private _startNode(
     nodeType: LANGCHAIN_NODE_TYPE,
@@ -270,8 +405,15 @@ export class GalileoCallback
       );
     }
 
+    // Always record startTime and createdAt for duration tracking.
+    const nodeParams: Record<string, any> = {
+      startTime: performance.now(),
+      createdAt: new Date(),
+      ...params
+    };
+
     // Create new node
-    const node = new Node(nodeType, params, runId, parentNodeId);
+    const node = new Node(nodeType, nodeParams, runId, parentNodeId);
     this._nodes[nodeId] = node;
 
     // Set as root node if needed
@@ -295,6 +437,7 @@ export class GalileoCallback
 
   /**
    * End a node in the chain. Commit the nodes to a trace if the run_id matches the root node.
+   * Automatically computes durationNs from the node's startTime.
    */
   private async _endNode(
     runId: string,
@@ -306,6 +449,12 @@ export class GalileoCallback
     if (!node) {
       sdkLogger.warn(`No node exists for run_id ${nodeId}`);
       return;
+    }
+
+    // Compute durationNs before merging params
+    if (node.spanParams.startTime !== undefined) {
+      node.spanParams.durationNs =
+        (performance.now() - (node.spanParams.startTime as number)) * 1e6;
     }
 
     // Update node parameters
@@ -328,19 +477,23 @@ export class GalileoCallback
     tags?: string[],
     metadata?: Record<string, any>
   ): Promise<void> {
-    let nodeType: LANGCHAIN_NODE_TYPE = 'chain';
-    let nodeName = chain?.name || 'Chain';
-    let nodeInput: unknown = {};
-
-    // If the name is LangGraph or agent, set the node type to agent
-    if (nodeName === 'LangGraph' || nodeName === 'agent') {
-      nodeType = 'agent';
-      nodeName = 'Agent';
-    }
-
     // If the node is tagged with hidden, don't log it
     if (tags && tags.includes('langsmith:hidden')) {
       return;
+    }
+
+    // Retroactively upgrade the parent to agent type if langgraph_* metadata present
+    updateRootToAgent(parentRunId, metadata, this._nodes);
+
+    let nodeType: LANGCHAIN_NODE_TYPE = 'chain';
+    let nodeName = GalileoCallback._getNodeName('chain', chain, metadata);
+    let nodeInput: unknown = {};
+
+    // Case-insensitive detection of LangGraph / agent nodes
+    const lowerName = nodeName.toLowerCase();
+    if (lowerName === 'langgraph' || lowerName === 'agent') {
+      nodeType = 'agent';
+      nodeName = this._getAgentName(parentRunId, 'Agent');
     }
 
     if (typeof inputs === 'string') {
@@ -373,10 +526,10 @@ export class GalileoCallback
     });
   }
 
-  public async handleChainError(err: AxiosError, runId: string): Promise<void> {
+  public async handleChainError(err: Error, runId: string): Promise<void> {
     await this._endNode(runId, {
-      output: `ERROR: ${err.message}`,
-      status_code: err.response?.status
+      output: `Error: ${err.name}: ${err.message}`,
+      statusCode: (err as any).response?.status ?? 400
     });
   }
 
@@ -395,6 +548,7 @@ export class GalileoCallback
     const input = kwargs?.inputs;
     await this._endNode(runId, {
       output: toStringValue(outputs),
+      statusCode: 200,
       ...(input !== undefined && { input: toStringValue(input) })
     });
   }
@@ -403,7 +557,10 @@ export class GalileoCallback
     finish: AgentFinish,
     runId: string
   ): Promise<void> {
-    await this._endNode(runId, { output: toStringValue(finish) });
+    await this._endNode(runId, {
+      output: toStringValue(finish),
+      statusCode: 200
+    });
   }
 
   public async handleLLMStart(
@@ -415,15 +572,15 @@ export class GalileoCallback
     tags?: string[],
     metadata?: Record<string, any>
   ): Promise<void> {
-    const invocation_params = extraParams?.invocation_params as Record<
-      string,
-      unknown
-    >;
-    const model = invocation_params?.model_name as string | undefined;
-    const temperature = invocation_params?.temperature as number | undefined;
+    const invocationParams = extraParams?.invocation_params as
+      | Record<string, unknown>
+      | undefined;
+    const model = invocationParams?.model_name as string | undefined;
+    const temperature = invocationParams?.temperature as number | undefined;
+    const name = GalileoCallback._getNodeName('llm', llm, extraParams);
 
     this._startNode('llm', parentRunId, runId, {
-      name: 'LLM',
+      name,
       input: prompts.map((p) => ({ content: p, role: 'user' })),
       tags,
       model,
@@ -433,15 +590,14 @@ export class GalileoCallback
             Object.entries(metadata).map(([k, v]) => [k, String(v)])
           )
         : undefined,
-      startTime: performance.now(),
       timeToFirstTokenNs: null
     });
   }
 
-  public async handleLLMError(err: AxiosError, runId: string): Promise<void> {
+  public async handleLLMError(err: Error, runId: string): Promise<void> {
     await this._endNode(runId, {
-      output: `ERROR: ${err.message}`,
-      status_code: err.response?.status
+      output: `Error: ${err.name}: ${err.message}`,
+      statusCode: (err as any).response?.status ?? 400
     });
   }
 
@@ -483,14 +639,25 @@ export class GalileoCallback
     const tools = invocationParams?.tools as
       | Record<string, unknown>[]
       | undefined;
+    const name = GalileoCallback._getNodeName('chat', llm, extraParams);
 
-    // Serialize messages safely
-    let serializedMessages: unknown;
+    // Serialize messages safely, preserving tool_calls when present
+    let serializedMessages;
     try {
-      const flattenedMessages = messages.flat().map((msg) => ({
-        content: msg.content,
-        role: msg.getType()
-      }));
+      const flattenedMessages = messages.flat().map((msg) => {
+        const serialized: Record<string, any> = {
+          content: msg.content,
+          role: msg.getType()
+        };
+        if (
+          'tool_calls' in msg &&
+          Array.isArray(msg.tool_calls) &&
+          msg.tool_calls.length > 0
+        ) {
+          serialized.tool_calls = msg.tool_calls;
+        }
+        return serialized;
+      });
       serializedMessages = flattenedMessages;
     } catch (e) {
       sdkLogger.warn(`Failed to serialize chat messages: ${e}`);
@@ -498,7 +665,7 @@ export class GalileoCallback
     }
 
     this._startNode('chat', parentRunId, runId, {
-      name: 'Chat Model',
+      name,
       input: serializedMessages,
       tags,
       tools,
@@ -514,9 +681,45 @@ export class GalileoCallback
   }
 
   public async handleLLMEnd(output: LLMResult, runId: string): Promise<void> {
-    const tokenUsage = output.llmOutput?.tokenUsage || {};
+    // Support OpenAI camelCase keys and Vertex AI / snake_case keys
+    const rawUsage =
+      output.llmOutput?.tokenUsage || output.llmOutput?.token_usage || {};
+    const tokenUsage = rawUsage as Record<string, unknown>;
 
-    let serializedOutput: unknown;
+    let numInputTokens: number | undefined = (tokenUsage.promptTokens ??
+      tokenUsage.prompt_tokens ??
+      tokenUsage.inputTokens ??
+      tokenUsage.input_tokens) as number | undefined;
+    let numOutputTokens: number | undefined = (tokenUsage.completionTokens ??
+      tokenUsage.completion_tokens ??
+      tokenUsage.outputTokens ??
+      tokenUsage.output_tokens) as number | undefined;
+    let totalTokens: number | undefined = (tokenUsage.totalTokens ??
+      tokenUsage.total_tokens) as number | undefined;
+
+    // Fallback: usage_metadata on the first generation message
+    if (
+      numInputTokens === undefined &&
+      numOutputTokens === undefined &&
+      totalTokens === undefined
+    ) {
+      const firstGen = output.generations?.flat()?.[0];
+      // ChatGeneration has a .message property with usage_metadata; plain Generation does not.
+      // Access via optional chaining on 'any' since the Generation type doesn't declare .message.
+      const usageMeta = (firstGen as any)?.message?.usage_metadata as
+        | Record<string, unknown>
+        | undefined;
+      if (usageMeta) {
+        numInputTokens = (usageMeta.input_tokens ?? usageMeta.prompt_tokens) as
+          | number
+          | undefined;
+        numOutputTokens = (usageMeta.output_tokens ??
+          usageMeta.completion_tokens) as number | undefined;
+        totalTokens = usageMeta.total_tokens as number | undefined;
+      }
+    }
+
+    let serializedOutput;
     try {
       const flattenedOutput = output.generations.flat().map((g) => ({
         text: g.text,
@@ -530,9 +733,10 @@ export class GalileoCallback
 
     await this._endNode(runId, {
       output: serializedOutput,
-      numInputTokens: tokenUsage.promptTokens,
-      numOutputTokens: tokenUsage.completionTokens,
-      totalTokens: tokenUsage.totalTokens
+      numInputTokens,
+      numOutputTokens,
+      totalTokens,
+      statusCode: 200
     });
   }
 
@@ -544,7 +748,12 @@ export class GalileoCallback
     tags?: string[],
     metadata?: Record<string, any>
   ): Promise<void> {
-    const name = tool?.name || 'Tool';
+    // Note: Python's on_tool_start checks kwargs["inputs"] for a structured dict
+    // and uses it over the flat input_str. The JS @langchain/core callback interface
+    // does not expose a kwargs/inputs parameter, so we always use the flat `input`
+    // string here. This is a known JS/Python divergence; revisit if a future
+    // @langchain/core version adds an `inputs` parameter.
+    const name = GalileoCallback._getNodeName('tool', tool, metadata);
     this._startNode('tool', parentRunId, runId, {
       name,
       input,
@@ -557,22 +766,53 @@ export class GalileoCallback
     });
   }
 
-  public async handleToolError(err: AxiosError, runId: string): Promise<void> {
+  public async handleToolError(err: Error, runId: string): Promise<void> {
     await this._endNode(runId, {
-      output: `ERROR: ${err.message}`,
-      status_code: err.response?.status
+      output: `Error: ${err.name}: ${err.message}`,
+      statusCode: (err as any).response?.status ?? 400
     });
   }
 
-  public async handleToolEnd(output: any, runId: string): Promise<void> {
+  public async handleToolEnd(output: unknown, runId: string): Promise<void> {
     let serializedOutput: string = '';
-    if (typeof output === 'object' && 'content' in output) {
+
+    // Check for ToolMessage (covers response_format="content_and_artifact" indirectly
+    // and LangGraph Command objects carrying a ToolMessage)
+    const toolMessage = GalileoCallback._findToolMessage(output);
+    if (toolMessage !== null) {
+      serializedOutput = toStringValue(toolMessage.content);
+      await this._endNode(runId, {
+        output: serializedOutput,
+        toolCallId: toolMessage.tool_call_id,
+        statusCode: 200
+      });
+      return;
+    }
+
+    // Handle [content, artifact] tuple outputs (response_format="content_and_artifact")
+    if (Array.isArray(output) && output.length >= 1) {
+      // Check if the first element is itself a ToolMessage
+      if (output[0] instanceof ToolMessage) {
+        serializedOutput = toStringValue(output[0].content);
+        await this._endNode(runId, {
+          output: serializedOutput,
+          toolCallId: output[0].tool_call_id,
+          statusCode: 200
+        });
+        return;
+      }
+      serializedOutput = toStringValue(output[0]);
+    } else if (
+      typeof output === 'object' &&
+      output !== null &&
+      'content' in output
+    ) {
       serializedOutput = toStringValue(output.content);
     } else {
       serializedOutput = toStringValue(output);
     }
 
-    await this._endNode(runId, { output: serializedOutput });
+    await this._endNode(runId, { output: serializedOutput, statusCode: 200 });
   }
 
   public async handleRetrieverStart(
@@ -583,21 +823,19 @@ export class GalileoCallback
     tags?: string[],
     metadata?: Record<string, any>
   ): Promise<void> {
+    const name = GalileoCallback._getNodeName('retriever', retriever, metadata);
     this._startNode('retriever', parentRunId, runId, {
-      name: 'Retriever',
+      name,
       input: query,
       tags,
       metadata
     });
   }
 
-  public async handleRetrieverError(
-    err: AxiosError,
-    runId: string
-  ): Promise<void> {
+  public async handleRetrieverError(err: Error, runId: string): Promise<void> {
     await this._endNode(runId, {
-      output: `ERROR: ${err.message}`,
-      status_code: err.response?.status
+      output: `Error: ${err.name}: ${err.message}`,
+      statusCode: (err as any).response?.status ?? 400
     });
   }
 
@@ -616,6 +854,6 @@ export class GalileoCallback
       serializedResponse = String(documents);
     }
 
-    await this._endNode(runId, { output: serializedResponse });
+    await this._endNode(runId, { output: serializedResponse, statusCode: 200 });
   }
 }

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -419,9 +419,9 @@ export class GalileoCallback
 
     // Always record startTime and createdAt for duration tracking.
     const nodeParams: Record<string, any> = {
+      ...params,
       startTime: performance.now(),
-      createdAt: new Date(),
-      ...params
+      createdAt: new Date()
     };
 
     // Create new node

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -114,14 +114,14 @@ export class GalileoCallback
   }
 
   /**
-   * Shared name resolution helper (Python: _get_node_name).
-   * Resolution order: serialized.name → serialized.id[-1] → params.name →
-   * params.metadata.name → nodeType capitalised.
+   * Resolve a node name from serialized data, runName, or metadata.
+   * Falls back to capitalised nodeType.
    */
   private static _getNodeName(
     nodeType: string,
     serialized?: Serialized | null,
-    params?: Record<string, unknown>
+    runName?: string,
+    metadata?: Record<string, unknown>
   ): string {
     try {
       if (serialized?.name && serialized.name.length > 0) {
@@ -131,11 +131,10 @@ export class GalileoCallback
       if (Array.isArray(idArr) && idArr.length > 0) {
         return String(idArr[idArr.length - 1]);
       }
-      const paramsName = params?.name;
-      if (typeof paramsName === 'string' && paramsName.length > 0) {
-        return paramsName;
+      if (typeof runName === 'string' && runName.length > 0) {
+        return runName;
       }
-      const metaName = (params?.metadata as Record<string, unknown>)?.name;
+      const metaName = metadata?.name;
       if (typeof metaName === 'string' && metaName.length > 0) {
         return metaName;
       }
@@ -507,7 +506,9 @@ export class GalileoCallback
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    runType?: string,
+    runName?: string
   ): Promise<void> {
     // If the node is tagged with hidden, don't log it
     if (tags && tags.includes('langsmith:hidden')) {
@@ -518,7 +519,12 @@ export class GalileoCallback
     updateRootToAgent(parentRunId, metadata, this._nodes);
 
     let nodeType: LANGCHAIN_NODE_TYPE = 'chain';
-    let nodeName = GalileoCallback._getNodeName('chain', chain, metadata);
+    let nodeName = GalileoCallback._getNodeName(
+      'chain',
+      chain,
+      runName,
+      metadata
+    );
     let nodeInput: unknown = {};
 
     // Case-insensitive detection of LangGraph / agent nodes
@@ -599,14 +605,15 @@ export class GalileoCallback
     parentRunId?: string,
     extraParams?: Record<string, unknown>,
     tags?: string[],
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    runName?: string
   ): Promise<void> {
     const invocationParams = extraParams?.invocation_params as
       | Record<string, unknown>
       | undefined;
     const model = invocationParams?.model_name as string | undefined;
     const temperature = invocationParams?.temperature as number | undefined;
-    const name = GalileoCallback._getNodeName('llm', llm, extraParams);
+    const name = GalileoCallback._getNodeName('llm', llm, runName, metadata);
 
     this._startNode('llm', parentRunId, runId, {
       name,
@@ -653,7 +660,8 @@ export class GalileoCallback
     parentRunId?: string,
     extraParams?: Record<string, unknown>,
     tags?: string[],
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    runName?: string
   ): Promise<void> {
     const invocationParams = extraParams?.invocation_params as
       | Record<string, unknown>
@@ -664,7 +672,7 @@ export class GalileoCallback
     const tools = invocationParams?.tools as
       | Record<string, unknown>[]
       | undefined;
-    const name = GalileoCallback._getNodeName('chat', llm, extraParams);
+    const name = GalileoCallback._getNodeName('chat', llm, runName, metadata);
 
     // Serialize messages safely, preserving tool_calls when present
     let serializedMessages;
@@ -784,14 +792,15 @@ export class GalileoCallback
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    runName?: string
   ): Promise<void> {
     // Note: Python's on_tool_start checks for a structured inputs dict via **kwargs
     // and uses it over the flat input_str. The JS @langchain/core callback interface
     // does not expose an equivalent parameter, so we always use the flat `input`
     // string here. This is a known JS/Python divergence; revisit if a future
     // @langchain/core version adds an `inputs` parameter.
-    const name = GalileoCallback._getNodeName('tool', tool, metadata);
+    const name = GalileoCallback._getNodeName('tool', tool, runName, metadata);
     this._startNode('tool', parentRunId, runId, {
       name,
       input,
@@ -856,9 +865,15 @@ export class GalileoCallback
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, any>
+    metadata?: Record<string, any>,
+    runName?: string
   ): Promise<void> {
-    const name = GalileoCallback._getNodeName('retriever', retriever, metadata);
+    const name = GalileoCallback._getNodeName(
+      'retriever',
+      retriever,
+      runName,
+      metadata
+    );
     this._startNode('retriever', parentRunId, runId, {
       name,
       input: query,

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -8,7 +8,7 @@ import { LLMResult } from '@langchain/core/outputs';
 import { BaseMessage, ToolMessage } from '@langchain/core/messages';
 import { ChainValues } from '@langchain/core/utils/types';
 import { AgentFinish } from '@langchain/core/agents';
-import { Document, DocumentInterface } from '@langchain/core/documents';
+import { DocumentInterface } from '@langchain/core/documents';
 import { GalileoSingleton } from '../singleton';
 import { GalileoLogger } from '../utils/galileo-logger';
 import { toStringValue, toStringRecord } from '../utils/serialization';
@@ -61,7 +61,7 @@ export const rootNodeContext = {
 
 /**
  * Retroactively upgrade a root-level chain node to agent type when any of its
- * children carry langgraph_* metadata keys (Python: update_root_to_agent).
+ * children carry langgraph_* metadata keys.
  */
 function updateRootToAgent(
   parentRunId: string | undefined,
@@ -538,22 +538,8 @@ export class GalileoCallback
       nodeInput = { input: inputs };
     } else if (inputs instanceof BaseMessage) {
       nodeInput = inputs;
-    } else if (typeof inputs === 'object') {
-      nodeInput = Object.fromEntries(
-        Object.entries(inputs).filter(
-          ([key, value]: [string, unknown]) => key && typeof value === 'string'
-        )
-      );
-    } else if (
-      (Array.isArray(inputs) as boolean) &&
-      (inputs as Document[]).every((v: unknown) => v instanceof Document)
-    ) {
-      nodeInput = Object.fromEntries(
-        (inputs as Document[]).map((value: Document, index: number) => [
-          String(index),
-          value.pageContent
-        ])
-      );
+    } else {
+      nodeInput = toStringValue(inputs);
     }
 
     this._startNode(nodeType, parentRunId, runId, {
@@ -621,11 +607,7 @@ export class GalileoCallback
       tags,
       model,
       temperature,
-      metadata: metadata
-        ? Object.fromEntries(
-            Object.entries(metadata).map(([k, v]) => [k, String(v)])
-          )
-        : undefined,
+      metadata: metadata ? toStringRecord(metadata) : undefined,
       timeToFirstTokenNs: null
     });
   }
@@ -708,11 +690,7 @@ export class GalileoCallback
       tools,
       model,
       temperature,
-      metadata: metadata
-        ? Object.fromEntries(
-            Object.entries(metadata).map(([k, v]) => [k, String(v)])
-          )
-        : undefined,
+      metadata: metadata ? toStringRecord(metadata) : undefined,
       timeToFirstTokenNs: null
     });
   }
@@ -805,11 +783,7 @@ export class GalileoCallback
       name,
       input,
       tags,
-      metadata: metadata
-        ? Object.fromEntries(
-            Object.entries(metadata).map(([k, v]) => [k, String(v)])
-          )
-        : undefined
+      metadata: metadata ? toStringRecord(metadata) : undefined
     });
   }
 

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -115,13 +115,13 @@ export class GalileoCallback
 
   /**
    * Shared name resolution helper (Python: _get_node_name).
-   * Resolution order: serialized.name → serialized.id[-1] → kwargs.name →
-   * kwargs.metadata.name → nodeType capitalised.
+   * Resolution order: serialized.name → serialized.id[-1] → params.name →
+   * params.metadata.name → nodeType capitalised.
    */
   private static _getNodeName(
     nodeType: string,
     serialized?: Serialized | null,
-    kwargs?: Record<string, unknown>
+    params?: Record<string, unknown>
   ): string {
     try {
       if (serialized?.name && serialized.name.length > 0) {
@@ -131,11 +131,11 @@ export class GalileoCallback
       if (Array.isArray(idArr) && idArr.length > 0) {
         return String(idArr[idArr.length - 1]);
       }
-      const kwargsName = kwargs?.name;
-      if (typeof kwargsName === 'string' && kwargsName.length > 0) {
-        return kwargsName;
+      const paramsName = params?.name;
+      if (typeof paramsName === 'string' && paramsName.length > 0) {
+        return paramsName;
       }
-      const metaName = (kwargs?.metadata as Record<string, unknown>)?.name;
+      const metaName = (params?.metadata as Record<string, unknown>)?.name;
       if (typeof metaName === 'string' && metaName.length > 0) {
         return metaName;
       }
@@ -202,12 +202,24 @@ export class GalileoCallback
 
     try {
       if (this._startNewTrace) {
+        let traceMetadata: Record<string, string> | undefined;
+        if (rootNode.spanParams.metadata) {
+          try {
+            traceMetadata = toStringRecord(
+              rootNode.spanParams.metadata as Record<string, unknown>
+            );
+          } catch (e) {
+            sdkLogger.warn(
+              'Unable to convert trace metadata to string dictionary',
+              e
+            );
+          }
+        }
+
         this._galileoLogger.startTrace({
           input: toStringValue(rootNode.spanParams.input || ''),
           name: rootNode.spanParams.name as string | undefined,
-          metadata: rootNode.spanParams.metadata as
-            | Record<string, string>
-            | undefined
+          metadata: traceMetadata
         });
       }
 
@@ -467,6 +479,26 @@ export class GalileoCallback
     }
   }
 
+  /**
+   * Shared error handler for all callback error methods.
+   * Extracts HTTP status from the error's response if available, falls back to 400.
+   */
+  private async _handleError(err: Error, runId: string): Promise<void> {
+    const errRecord = err as unknown as Record<string, unknown>;
+    const response = errRecord.response;
+    const status =
+      typeof response === 'object' &&
+      response !== null &&
+      typeof (response as Record<string, unknown>).status === 'number'
+        ? ((response as Record<string, unknown>).status as number)
+        : 400;
+
+    await this._endNode(runId, {
+      output: `Error: ${err.name}: ${err.message}`,
+      statusCode: status
+    });
+  }
+
   // LangChain callback methods
 
   public async handleChainStart(
@@ -527,10 +559,7 @@ export class GalileoCallback
   }
 
   public async handleChainError(err: Error, runId: string): Promise<void> {
-    await this._endNode(runId, {
-      output: `Error: ${err.name}: ${err.message}`,
-      statusCode: (err as any).response?.status ?? 400
-    });
+    await this._handleError(err, runId);
   }
 
   public async handleChainEnd(
@@ -595,10 +624,7 @@ export class GalileoCallback
   }
 
   public async handleLLMError(err: Error, runId: string): Promise<void> {
-    await this._endNode(runId, {
-      output: `Error: ${err.name}: ${err.message}`,
-      statusCode: (err as any).response?.status ?? 400
-    });
+    await this._handleError(err, runId);
   }
 
   public async handleLLMNewToken(
@@ -645,7 +671,11 @@ export class GalileoCallback
     let serializedMessages;
     try {
       const flattenedMessages = messages.flat().map((msg) => {
-        const serialized: Record<string, any> = {
+        const serialized: {
+          content: unknown;
+          role: string;
+          tool_calls?: unknown[];
+        } = {
           content: msg.content,
           role: msg.getType()
         };
@@ -705,8 +735,17 @@ export class GalileoCallback
     ) {
       const firstGen = output.generations?.flat()?.[0];
       // ChatGeneration has a .message property with usage_metadata; plain Generation does not.
-      // Access via optional chaining on 'any' since the Generation type doesn't declare .message.
-      const usageMeta = (firstGen as any)?.message?.usage_metadata as
+      // Use property narrowing since the Generation type doesn't declare .message.
+      const genRecord = firstGen as unknown as
+        | Record<string, unknown>
+        | undefined;
+      const message =
+        genRecord &&
+        typeof genRecord.message === 'object' &&
+        genRecord.message !== null
+          ? (genRecord.message as Record<string, unknown>)
+          : undefined;
+      const usageMeta = message?.usage_metadata as
         | Record<string, unknown>
         | undefined;
       if (usageMeta) {
@@ -748,9 +787,9 @@ export class GalileoCallback
     tags?: string[],
     metadata?: Record<string, any>
   ): Promise<void> {
-    // Note: Python's on_tool_start checks kwargs["inputs"] for a structured dict
+    // Note: Python's on_tool_start checks for a structured inputs dict via **kwargs
     // and uses it over the flat input_str. The JS @langchain/core callback interface
-    // does not expose a kwargs/inputs parameter, so we always use the flat `input`
+    // does not expose an equivalent parameter, so we always use the flat `input`
     // string here. This is a known JS/Python divergence; revisit if a future
     // @langchain/core version adds an `inputs` parameter.
     const name = GalileoCallback._getNodeName('tool', tool, metadata);
@@ -767,10 +806,7 @@ export class GalileoCallback
   }
 
   public async handleToolError(err: Error, runId: string): Promise<void> {
-    await this._endNode(runId, {
-      output: `Error: ${err.name}: ${err.message}`,
-      statusCode: (err as any).response?.status ?? 400
-    });
+    await this._handleError(err, runId);
   }
 
   public async handleToolEnd(output: unknown, runId: string): Promise<void> {
@@ -833,10 +869,7 @@ export class GalileoCallback
   }
 
   public async handleRetrieverError(err: Error, runId: string): Promise<void> {
-    await this._endNode(runId, {
-      output: `Error: ${err.name}: ${err.message}`,
-      statusCode: (err as any).response?.status ?? 400
-    });
+    await this._handleError(err, runId);
   }
 
   public async handleRetrieverEnd(

--- a/src/handlers/langchain.ts
+++ b/src/handlers/langchain.ts
@@ -655,10 +655,9 @@ export class GalileoCallback
     tags?: string[],
     metadata?: Record<string, any>
   ): Promise<void> {
-    const invocationParams = extraParams?.invocation_params as Record<
-      string,
-      unknown
-    >;
+    const invocationParams = extraParams?.invocation_params as
+      | Record<string, unknown>
+      | undefined;
     const model =
       invocationParams?.model || invocationParams?._type || 'undefined-type';
     const temperature = invocationParams?.temperature || 0.0;

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -1,19 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import {
-  BaseCallbackHandler,
+
+// Type-only imports — erased at runtime, safe when @langchain/core is not installed
+import type {
   CallbackHandlerMethods,
   NewTokenIndices
 } from '@langchain/core/callbacks/base';
-import { LLMResult } from '@langchain/core/outputs';
-import { BaseMessage, ToolMessage } from '@langchain/core/messages';
-import { ChainValues } from '@langchain/core/utils/types';
-import { AgentFinish } from '@langchain/core/agents';
-import { DocumentInterface } from '@langchain/core/documents';
+import type { LLMResult } from '@langchain/core/outputs';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { ChainValues } from '@langchain/core/utils/types';
+import type { AgentFinish } from '@langchain/core/agents';
+import type { DocumentInterface } from '@langchain/core/documents';
+import type { Serialized } from '@langchain/core/load/serializable.js';
+
+// Internal imports
 import { GalileoSingleton } from '../../singleton';
 import { GalileoLogger } from '../../utils/galileo-logger';
 import { toStringValue, toStringRecord } from '../../utils/serialization';
 import { getSdkLogger } from 'galileo-generated';
-import { Serialized } from '@langchain/core/load/serializable.js';
 import type { LogTracesIngestRequest } from '../../types/logging/trace.types';
 import { Node, LANGCHAIN_NODE_TYPE, rootNodeContext } from './node';
 import {
@@ -28,11 +31,36 @@ export { rootNodeContext } from './node';
 
 const sdkLogger = getSdkLogger();
 
+// Runtime imports — guarded for optional @langchain/core peer dependency.
+// Values used at runtime (extends, instanceof) must be loaded via require().
+/* eslint-disable @typescript-eslint/no-var-requires */
+let _BaseCallbackHandler: unknown;
+let _BaseMessage: any;
+let _ToolMessage: any;
+let _langchainAvailable = false;
+
+try {
+  _BaseCallbackHandler =
+    require('@langchain/core/callbacks/base').BaseCallbackHandler;
+  const messages = require('@langchain/core/messages');
+  _BaseMessage = messages.BaseMessage;
+  _ToolMessage = messages.ToolMessage;
+  _langchainAvailable = true;
+} catch {
+  // @langchain/core is not installed — provide a stub base class.
+  // GalileoCallback will throw a clear error at construction time.
+  _BaseCallbackHandler = class LangChainNotAvailable {};
+}
+/* eslint-enable @typescript-eslint/no-var-requires */
+
 /**
  * Langchain callback handler for logging traces to the Galileo platform.
+ *
+ * Requires `@langchain/core` to be installed as a peer dependency.
+ * Install it with: `npm install @langchain/core`
  */
 export class GalileoCallback
-  extends BaseCallbackHandler
+  extends (_BaseCallbackHandler as typeof import('@langchain/core/callbacks/base').BaseCallbackHandler)
   implements CallbackHandlerMethods
 {
   _galileoLogger: GalileoLogger;
@@ -48,6 +76,12 @@ export class GalileoCallback
     flushOnChainEnd: boolean = true,
     ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void
   ) {
+    if (!_langchainAvailable) {
+      throw new Error(
+        'GalileoCallback requires @langchain/core to be installed.\n' +
+          'Install it with: npm install @langchain/core'
+      );
+    }
     super();
     if (galileoLogger) {
       this._galileoLogger = galileoLogger;
@@ -135,7 +169,7 @@ export class GalileoCallback
     nodeType: LANGCHAIN_NODE_TYPE,
     parentRunId: string | undefined,
     runId: string,
-    params: Record<string, any>
+    params: Record<string, unknown>
   ): Node {
     const nodeId = runId;
     const parentNodeId = parentRunId;
@@ -147,7 +181,7 @@ export class GalileoCallback
     }
 
     // Set startTime and createdAt as defaults; callers may override.
-    const nodeParams: Record<string, any> = {
+    const nodeParams: Record<string, unknown> = {
       startTime: performance.now(),
       createdAt: new Date(),
       ...params
@@ -182,7 +216,7 @@ export class GalileoCallback
    */
   private async _endNode(
     runId: string,
-    params: Record<string, any>
+    params: Record<string, unknown>
   ): Promise<void> {
     const nodeId = runId;
     const node = this._nodes[nodeId];
@@ -194,8 +228,10 @@ export class GalileoCallback
 
     // Compute durationNs before merging params
     if (node.spanParams.startTime !== undefined) {
-      node.spanParams.durationNs =
+      const durationNs =
         (performance.now() - (node.spanParams.startTime as number)) * 1e6;
+      // OpenAPI schema expects safe integers for nanosecond fields.
+      node.spanParams.durationNs = Math.max(0, Math.round(durationNs));
     }
 
     // Update node parameters
@@ -261,7 +297,7 @@ export class GalileoCallback
 
     if (typeof inputs === 'string') {
       nodeInput = { input: inputs };
-    } else if (inputs instanceof BaseMessage) {
+    } else if (_BaseMessage && inputs instanceof _BaseMessage) {
       nodeInput = inputs;
     } else {
       nodeInput = toStringValue(inputs);
@@ -354,8 +390,12 @@ export class GalileoCallback
     if (node.spanParams.timeToFirstTokenNs === null) {
       const startTime = node.spanParams.startTime;
       if (startTime !== undefined) {
-        node.spanParams.timeToFirstTokenNs =
-          (performance.now() - startTime) * 1e6; // Convert ms to ns
+        const timeToFirstTokenNs = (performance.now() - startTime) * 1e6;
+        // OpenAPI schema expects safe integers for nanosecond fields.
+        node.spanParams.timeToFirstTokenNs = Math.max(
+          0,
+          Math.round(timeToFirstTokenNs)
+        );
       }
     }
   }
@@ -535,7 +575,7 @@ export class GalileoCallback
     // Handle [content, artifact] tuple outputs (response_format="content_and_artifact")
     if (Array.isArray(output) && output.length >= 1) {
       // Check if the first element is itself a ToolMessage
-      if (output[0] instanceof ToolMessage) {
+      if (_ToolMessage && output[0] instanceof _ToolMessage) {
         serializedOutput = toStringValue(output[0].content);
         await this._endNode(runId, {
           output: serializedOutput,

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -99,24 +99,26 @@ export class GalileoCallback
    * Uses try/finally to guarantee node state is always cleared even on error.
    */
   private async _commit(): Promise<void> {
-    if (Object.keys(this._nodes).length === 0) {
-      sdkLogger.warn('No nodes to commit');
-      return;
-    }
-
-    const root = rootNodeContext.get();
-    if (root === null) {
-      sdkLogger.warn('Unable to add nodes to trace: Root node not set');
-      return;
-    }
-
-    const rootNode = this._nodes[root.runId];
-    if (rootNode === undefined) {
-      sdkLogger.warn('Unable to add nodes to trace: Root node does not exist');
-      return;
-    }
-
     try {
+      if (Object.keys(this._nodes).length === 0) {
+        sdkLogger.warn('No nodes to commit');
+        return;
+      }
+
+      const root = rootNodeContext.get();
+      if (root === null) {
+        sdkLogger.warn('Unable to add nodes to trace: Root node not set');
+        return;
+      }
+
+      const rootNode = this._nodes[root.runId];
+      if (rootNode === undefined) {
+        sdkLogger.warn(
+          'Unable to add nodes to trace: Root node does not exist'
+        );
+        return;
+      }
+
       if (this._startNewTrace) {
         let traceMetadata: Record<string, string> | undefined;
         if (rootNode.spanParams.metadata) {
@@ -246,7 +248,8 @@ export class GalileoCallback
 
   /**
    * Shared error handler for all callback error methods.
-   * Extracts HTTP status from the error's response if available, falls back to 400.
+   * Extracts HTTP status from the error's response if available, falls back to 500
+   * (unknown/internal error) when no HTTP status is present.
    */
   private async _handleError(err: Error, runId: string): Promise<void> {
     const errRecord = err as unknown as Record<string, unknown>;
@@ -256,7 +259,7 @@ export class GalileoCallback
       response !== null &&
       typeof (response as Record<string, unknown>).status === 'number'
         ? ((response as Record<string, unknown>).status as number)
-        : 400;
+        : 500;
 
     await this._endNode(runId, {
       output: `Error: ${err.name}: ${err.message}`,

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -99,7 +99,7 @@ export class GalileoCallback
         }
 
         this._galileoLogger.startTrace({
-          input: toStringValue(rootNode.spanParams.input || ''),
+          input: toStringValue(rootNode.spanParams.input ?? ''),
           name: rootNode.spanParams.name as string | undefined,
           metadata: traceMetadata
         });
@@ -108,7 +108,7 @@ export class GalileoCallback
       logNodeTree(rootNode, this._nodes, this._galileoLogger);
 
       // Conclude the trace with the root node's output
-      const rootOutput = rootNode.spanParams.output || '';
+      const rootOutput = rootNode.spanParams.output ?? '';
 
       if (this._startNewTrace) {
         this._galileoLogger.conclude({

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -9,77 +9,24 @@ import { BaseMessage, ToolMessage } from '@langchain/core/messages';
 import { ChainValues } from '@langchain/core/utils/types';
 import { AgentFinish } from '@langchain/core/agents';
 import { DocumentInterface } from '@langchain/core/documents';
-import { GalileoSingleton } from '../singleton';
-import { GalileoLogger } from '../utils/galileo-logger';
-import { toStringValue, toStringRecord } from '../utils/serialization';
+import { GalileoSingleton } from '../../singleton';
+import { GalileoLogger } from '../../utils/galileo-logger';
+import { toStringValue, toStringRecord } from '../../utils/serialization';
 import { getSdkLogger } from 'galileo-generated';
 import { Serialized } from '@langchain/core/load/serializable.js';
-import type { LogTracesIngestRequest } from '../types/logging/trace.types';
+import type { LogTracesIngestRequest } from '../../types/logging/trace.types';
+import { Node, LANGCHAIN_NODE_TYPE, rootNodeContext } from './node';
+import {
+  getNodeName,
+  getAgentName,
+  findToolMessage,
+  updateRootToAgent
+} from './utils';
+import { logNodeTree } from './tree-logger';
+
+export { rootNodeContext } from './node';
 
 const sdkLogger = getSdkLogger();
-
-type LANGCHAIN_NODE_TYPE =
-  | 'agent'
-  | 'chain'
-  | 'chat'
-  | 'llm'
-  | 'retriever'
-  | 'tool';
-
-/**
- * A node in the LangChain trace.
- */
-class Node {
-  nodeType: LANGCHAIN_NODE_TYPE;
-  spanParams: Record<string, any>;
-  runId: string;
-  parentRunId?: string;
-  children: string[] = [];
-
-  constructor(
-    nodeType: LANGCHAIN_NODE_TYPE,
-    spanParams: Record<string, any>,
-    runId: string,
-    parentRunId?: string
-  ) {
-    this.nodeType = nodeType;
-    this.spanParams = spanParams;
-    this.runId = runId;
-    this.parentRunId = parentRunId;
-  }
-}
-
-// Root node tracking
-let _rootNode: Node | null = null;
-
-export const rootNodeContext = {
-  get: (): Node | null => _rootNode,
-  set: (value: Node | null): void => {
-    _rootNode = value;
-  }
-};
-
-/**
- * Retroactively upgrade a root-level chain node to agent type when any of its
- * children carry langgraph_* metadata keys.
- */
-function updateRootToAgent(
-  parentRunId: string | undefined,
-  metadata: Record<string, unknown> | undefined,
-  nodes: Record<string, Node>
-): void {
-  if (!parentRunId) return;
-  if (!metadata) return;
-  const hasLangGraphKey = Object.keys(metadata).some((k) =>
-    k.startsWith('langgraph_')
-  );
-  if (!hasLangGraphKey) return;
-  const parentNode = nodes[parentRunId];
-  if (!parentNode) return;
-  if (parentNode.nodeType === 'chain' && parentNode.parentRunId === undefined) {
-    parentNode.nodeType = 'agent';
-  }
-}
 
 /**
  * Langchain callback handler for logging traces to the Galileo platform.
@@ -111,70 +58,6 @@ export class GalileoCallback
     }
     this._startNewTrace = startNewTrace;
     this._flushOnChainEnd = flushOnChainEnd;
-  }
-
-  /**
-   * Resolve a node name from serialized data, runName, or metadata.
-   * Falls back to capitalised nodeType.
-   */
-  private static _getNodeName(
-    nodeType: string,
-    serialized?: Serialized | null,
-    runName?: string,
-    metadata?: Record<string, unknown>
-  ): string {
-    try {
-      if (serialized?.name && serialized.name.length > 0) {
-        return serialized.name;
-      }
-      const idArr = serialized?.id;
-      if (Array.isArray(idArr) && idArr.length > 0) {
-        return String(idArr[idArr.length - 1]);
-      }
-      if (typeof runName === 'string' && runName.length > 0) {
-        return runName;
-      }
-      const metaName = metadata?.name;
-      if (typeof metaName === 'string' && metaName.length > 0) {
-        return metaName;
-      }
-      return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
-    } catch {
-      return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
-    }
-  }
-
-  /**
-   * Build a hierarchical agent name from the parent node (Python: get_agent_name).
-   */
-  private _getAgentName(
-    parentRunId: string | undefined,
-    defaultName: string
-  ): string {
-    if (parentRunId !== undefined && this._nodes[parentRunId]) {
-      return `${this._nodes[parentRunId].spanParams.name}:${defaultName}`;
-    }
-    return defaultName;
-  }
-
-  /**
-   * Detect a ToolMessage inside a tool output, including LangGraph Command objects
-   * that carry a messages array (Python: _find_tool_message).
-   */
-  private static _findToolMessage(output: unknown): ToolMessage | null {
-    if (output instanceof ToolMessage) return output;
-    const update = (output as Record<string, unknown>)?.update;
-    if (
-      typeof update === 'object' &&
-      update !== null &&
-      Array.isArray((update as Record<string, unknown>).messages)
-    ) {
-      const messages = (update as Record<string, unknown>)
-        .messages as unknown[];
-      const last = messages.length === 0 ? null : messages[messages.length - 1];
-      if (last instanceof ToolMessage) return last;
-    }
-    return null;
   }
 
   /**
@@ -222,7 +105,7 @@ export class GalileoCallback
         });
       }
 
-      this._logNodeTree(rootNode);
+      logNodeTree(rootNode, this._nodes, this._galileoLogger);
 
       // Conclude the trace with the root node's output
       const rootOutput = rootNode.spanParams.output || '';
@@ -245,159 +128,6 @@ export class GalileoCallback
   }
 
   /**
-   * Log a node and its children recursively.
-   */
-  private _logNodeTree(node: Node): void {
-    let isWorkflowSpan = false;
-    const input = node.spanParams.input || '';
-    const inputAsString =
-      typeof input === 'string' ? input : toStringValue(input);
-    const output = node.spanParams.output || '';
-    const outputAsString =
-      typeof output === 'string' ? output : toStringValue(output);
-    const name = node.spanParams.name;
-    const tags = node.spanParams.tags;
-    const durationNs = node.spanParams.durationNs as number | undefined;
-    const createdAt = node.spanParams.createdAt as Date | undefined;
-    const statusCode = node.spanParams.statusCode as number | undefined;
-
-    let metadata: Record<string, string> | undefined = undefined;
-    if (node.spanParams.metadata) {
-      try {
-        metadata = toStringRecord(
-          node.spanParams.metadata as Record<string, unknown>
-        );
-      } catch (e) {
-        sdkLogger.warn('Unable to convert metadata to a string dictionary', e);
-      }
-    }
-
-    // Extract step number from metadata
-    let stepNumber: number | undefined = undefined;
-    if (metadata) {
-      const langgraphStep = metadata['langgraph_step'];
-      if (langgraphStep !== undefined) {
-        try {
-          stepNumber = parseInt(langgraphStep, 10);
-          if (isNaN(stepNumber)) {
-            sdkLogger.warn(
-              `Invalid step number: ${langgraphStep}, not a valid integer`
-            );
-            stepNumber = undefined;
-          }
-        } catch (e) {
-          sdkLogger.warn(
-            `Invalid step number: ${langgraphStep}, exception raised ${e}`
-          );
-          stepNumber = undefined;
-        }
-      }
-    }
-
-    // Log the current node based on its type
-    if (node.nodeType === 'agent') {
-      this._galileoLogger.addAgentSpan({
-        input: inputAsString,
-        output: outputAsString,
-        name,
-        metadata,
-        tags,
-        durationNs,
-        createdAt,
-        statusCode,
-        stepNumber
-      });
-      isWorkflowSpan = true;
-    } else if (node.nodeType === 'chain') {
-      this._galileoLogger.addWorkflowSpan({
-        input: inputAsString,
-        output: outputAsString,
-        name,
-        metadata,
-        tags,
-        durationNs,
-        createdAt,
-        statusCode,
-        stepNumber
-      });
-      isWorkflowSpan = true;
-    } else if (node.nodeType === 'llm' || node.nodeType === 'chat') {
-      this._galileoLogger.addLlmSpan({
-        input,
-        output,
-        model: node.spanParams.model,
-        temperature: node.spanParams.temperature,
-        tools: 'tools' in node.spanParams ? node.spanParams.tools : undefined,
-        name,
-        metadata,
-        tags,
-        numInputTokens: node.spanParams.numInputTokens,
-        numOutputTokens: node.spanParams.numOutputTokens,
-        totalTokens: node.spanParams.totalTokens,
-        timeToFirstTokenNs: node.spanParams.timeToFirstTokenNs,
-        durationNs,
-        createdAt,
-        statusCode,
-        stepNumber
-      });
-    } else if (node.nodeType === 'retriever') {
-      this._galileoLogger.addRetrieverSpan({
-        input: inputAsString,
-        output,
-        name,
-        metadata,
-        tags,
-        durationNs,
-        createdAt,
-        statusCode,
-        stepNumber
-      });
-    } else if (node.nodeType === 'tool') {
-      const toolSpan = this._galileoLogger.addToolSpan({
-        input: inputAsString,
-        output: outputAsString,
-        name,
-        metadata,
-        tags,
-        toolCallId: node.spanParams.toolCallId as string | undefined,
-        durationNs,
-        createdAt,
-        statusCode,
-        stepNumber
-      });
-      if (node.children.length > 0) {
-        // Push tool span as parent so agent-as-tool child spans nest correctly
-        this._galileoLogger.pushParent(toolSpan);
-        isWorkflowSpan = true;
-      }
-    } else {
-      sdkLogger.warn(`Unknown node type: ${node.nodeType}`);
-    }
-
-    // Process all child nodes
-    let lastChild: Node | null = null;
-    for (const childId of node.children) {
-      const childNode = this._nodes[childId];
-      if (childNode) {
-        this._logNodeTree(childNode);
-        lastChild = childNode;
-      } else {
-        sdkLogger.debug(`Child node ${childId} not found`);
-      }
-    }
-
-    // Conclude workflow/agent span. Use the last child's output if necessary
-    if (isWorkflowSpan) {
-      const finalOutput =
-        output || (lastChild ? lastChild.spanParams.output || '' : '');
-      this._galileoLogger.conclude({
-        output: toStringValue(finalOutput),
-        statusCode
-      });
-    }
-  }
-
-  /**
    * Start a new node in the chain.
    * Records startTime and createdAt for all nodes automatically.
    */
@@ -416,11 +146,11 @@ export class GalileoCallback
       );
     }
 
-    // Always record startTime and createdAt for duration tracking.
+    // Set startTime and createdAt as defaults; callers may override.
     const nodeParams: Record<string, any> = {
-      ...params,
       startTime: performance.now(),
-      createdAt: new Date()
+      createdAt: new Date(),
+      ...params
     };
 
     // Create new node
@@ -519,19 +249,14 @@ export class GalileoCallback
     updateRootToAgent(parentRunId, metadata, this._nodes);
 
     let nodeType: LANGCHAIN_NODE_TYPE = 'chain';
-    let nodeName = GalileoCallback._getNodeName(
-      'chain',
-      chain,
-      runName,
-      metadata
-    );
+    let nodeName = getNodeName('chain', chain, runName, metadata);
     let nodeInput: unknown = {};
 
     // Case-insensitive detection of LangGraph / agent nodes
     const lowerName = nodeName.toLowerCase();
     if (lowerName === 'langgraph' || lowerName === 'agent') {
       nodeType = 'agent';
-      nodeName = this._getAgentName(parentRunId, 'Agent');
+      nodeName = getAgentName(this._nodes, parentRunId, 'Agent');
     }
 
     if (typeof inputs === 'string') {
@@ -599,7 +324,7 @@ export class GalileoCallback
       | undefined;
     const model = invocationParams?.model_name as string | undefined;
     const temperature = invocationParams?.temperature as number | undefined;
-    const name = GalileoCallback._getNodeName('llm', llm, runName, metadata);
+    const name = getNodeName('llm', llm, runName, metadata);
 
     this._startNode('llm', parentRunId, runId, {
       name,
@@ -654,7 +379,7 @@ export class GalileoCallback
     const tools = invocationParams?.tools as
       | Record<string, unknown>[]
       | undefined;
-    const name = GalileoCallback._getNodeName('chat', llm, runName, metadata);
+    const name = getNodeName('chat', llm, runName, metadata);
 
     // Serialize messages safely, preserving tool_calls when present
     let serializedMessages;
@@ -778,7 +503,7 @@ export class GalileoCallback
     // does not expose an equivalent parameter, so we always use the flat `input`
     // string here. This is a known JS/Python divergence; revisit if a future
     // @langchain/core version adds an `inputs` parameter.
-    const name = GalileoCallback._getNodeName('tool', tool, runName, metadata);
+    const name = getNodeName('tool', tool, runName, metadata);
     this._startNode('tool', parentRunId, runId, {
       name,
       input,
@@ -796,7 +521,7 @@ export class GalileoCallback
 
     // Check for ToolMessage (covers response_format="content_and_artifact" indirectly
     // and LangGraph Command objects carrying a ToolMessage)
-    const toolMessage = GalileoCallback._findToolMessage(output);
+    const toolMessage = findToolMessage(output);
     if (toolMessage !== null) {
       serializedOutput = toStringValue(toolMessage.content);
       await this._endNode(runId, {
@@ -842,12 +567,7 @@ export class GalileoCallback
     metadata?: Record<string, any>,
     runName?: string
   ): Promise<void> {
-    const name = GalileoCallback._getNodeName(
-      'retriever',
-      retriever,
-      runName,
-      metadata
-    );
+    const name = getNodeName('retriever', retriever, runName, metadata);
     this._startNode('retriever', parentRunId, runId, {
       name,
       input: query,

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -374,8 +374,8 @@ export class GalileoCallback
       | Record<string, unknown>
       | undefined;
     const model =
-      invocationParams?.model || invocationParams?._type || 'undefined-type';
-    const temperature = invocationParams?.temperature || 0.0;
+      invocationParams?.model ?? invocationParams?._type ?? 'undefined-type';
+    const temperature = invocationParams?.temperature ?? 0.0;
     const tools = invocationParams?.tools as
       | Record<string, unknown>[]
       | undefined;

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -236,7 +236,7 @@ export class GalileoCallback
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, any>,
+    metadata?: Record<string, unknown>,
     runType?: string,
     runName?: string
   ): Promise<void> {
@@ -316,7 +316,7 @@ export class GalileoCallback
     parentRunId?: string,
     extraParams?: Record<string, unknown>,
     tags?: string[],
-    metadata?: Record<string, any>,
+    metadata?: Record<string, unknown>,
     runName?: string
   ): Promise<void> {
     const invocationParams = extraParams?.invocation_params as
@@ -367,7 +367,7 @@ export class GalileoCallback
     parentRunId?: string,
     extraParams?: Record<string, unknown>,
     tags?: string[],
-    metadata?: Record<string, any>,
+    metadata?: Record<string, unknown>,
     runName?: string
   ): Promise<void> {
     const invocationParams = extraParams?.invocation_params as
@@ -495,7 +495,7 @@ export class GalileoCallback
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, any>,
+    metadata?: Record<string, unknown>,
     runName?: string
   ): Promise<void> {
     // Note: Python's on_tool_start checks for a structured inputs dict via **kwargs
@@ -564,7 +564,7 @@ export class GalileoCallback
     runId: string,
     parentRunId?: string,
     tags?: string[],
-    metadata?: Record<string, any>,
+    metadata?: Record<string, unknown>,
     runName?: string
   ): Promise<void> {
     const name = getNodeName('retriever', retriever, runName, metadata);

--- a/src/handlers/langchain/node.ts
+++ b/src/handlers/langchain/node.ts
@@ -1,0 +1,42 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+export type LANGCHAIN_NODE_TYPE =
+  | 'agent'
+  | 'chain'
+  | 'chat'
+  | 'llm'
+  | 'retriever'
+  | 'tool';
+
+/**
+ * A node in the LangChain trace.
+ */
+export class Node {
+  nodeType: LANGCHAIN_NODE_TYPE;
+  spanParams: Record<string, any>;
+  runId: string;
+  parentRunId?: string;
+  children: string[] = [];
+
+  constructor(
+    nodeType: LANGCHAIN_NODE_TYPE,
+    spanParams: Record<string, any>,
+    runId: string,
+    parentRunId?: string
+  ) {
+    this.nodeType = nodeType;
+    this.spanParams = spanParams;
+    this.runId = runId;
+    this.parentRunId = parentRunId;
+  }
+}
+
+// Root node tracking
+let _rootNode: Node | null = null;
+
+export const rootNodeContext = {
+  get: (): Node | null => _rootNode,
+  set: (value: Node | null): void => {
+    _rootNode = value;
+  }
+};

--- a/src/handlers/langchain/tree-logger.ts
+++ b/src/handlers/langchain/tree-logger.ts
@@ -14,10 +14,10 @@ export function logNodeTree(
   logger: GalileoLogger
 ): void {
   let isWorkflowSpan = false;
-  const input = node.spanParams.input || '';
+  const input = node.spanParams.input ?? '';
   const inputAsString =
     typeof input === 'string' ? input : toStringValue(input);
-  const output = node.spanParams.output || '';
+  const output = node.spanParams.output ?? '';
   const outputAsString =
     typeof output === 'string' ? output : toStringValue(output);
   const name = node.spanParams.name;
@@ -154,7 +154,7 @@ export function logNodeTree(
   // Conclude workflow/agent span. Use the last child's output if necessary
   if (isWorkflowSpan) {
     const finalOutput =
-      output || (lastChild ? lastChild.spanParams.output || '' : '');
+      output ?? (lastChild ? (lastChild.spanParams.output ?? '') : '');
     logger.conclude({
       output: toStringValue(finalOutput),
       statusCode

--- a/src/handlers/langchain/tree-logger.ts
+++ b/src/handlers/langchain/tree-logger.ts
@@ -1,0 +1,163 @@
+import { GalileoLogger } from '../../utils/galileo-logger';
+import { toStringValue, toStringRecord } from '../../utils/serialization';
+import { getSdkLogger } from 'galileo-generated';
+import { Node } from './node';
+
+const sdkLogger = getSdkLogger();
+
+/**
+ * Log a node and its children recursively as Galileo spans.
+ */
+export function logNodeTree(
+  node: Node,
+  nodes: Record<string, Node>,
+  logger: GalileoLogger
+): void {
+  let isWorkflowSpan = false;
+  const input = node.spanParams.input || '';
+  const inputAsString =
+    typeof input === 'string' ? input : toStringValue(input);
+  const output = node.spanParams.output || '';
+  const outputAsString =
+    typeof output === 'string' ? output : toStringValue(output);
+  const name = node.spanParams.name;
+  const tags = node.spanParams.tags;
+  const durationNs = node.spanParams.durationNs as number | undefined;
+  const createdAt = node.spanParams.createdAt as Date | undefined;
+  const statusCode = node.spanParams.statusCode as number | undefined;
+
+  let metadata: Record<string, string> | undefined = undefined;
+  if (node.spanParams.metadata) {
+    try {
+      metadata = toStringRecord(
+        node.spanParams.metadata as Record<string, unknown>
+      );
+    } catch (e) {
+      sdkLogger.warn('Unable to convert metadata to a string dictionary', e);
+    }
+  }
+
+  // Extract step number from metadata
+  let stepNumber: number | undefined = undefined;
+  if (metadata) {
+    const langgraphStep = metadata['langgraph_step'];
+    if (langgraphStep !== undefined) {
+      try {
+        stepNumber = parseInt(langgraphStep, 10);
+        if (isNaN(stepNumber)) {
+          sdkLogger.warn(
+            `Invalid step number: ${langgraphStep}, not a valid integer`
+          );
+          stepNumber = undefined;
+        }
+      } catch (e) {
+        sdkLogger.warn(
+          `Invalid step number: ${langgraphStep}, exception raised ${e}`
+        );
+        stepNumber = undefined;
+      }
+    }
+  }
+
+  // Log the current node based on its type
+  if (node.nodeType === 'agent') {
+    logger.addAgentSpan({
+      input: inputAsString,
+      output: outputAsString,
+      name,
+      metadata,
+      tags,
+      durationNs,
+      createdAt,
+      statusCode,
+      stepNumber
+    });
+    isWorkflowSpan = true;
+  } else if (node.nodeType === 'chain') {
+    logger.addWorkflowSpan({
+      input: inputAsString,
+      output: outputAsString,
+      name,
+      metadata,
+      tags,
+      durationNs,
+      createdAt,
+      statusCode,
+      stepNumber
+    });
+    isWorkflowSpan = true;
+  } else if (node.nodeType === 'llm' || node.nodeType === 'chat') {
+    logger.addLlmSpan({
+      input,
+      output,
+      model: node.spanParams.model,
+      temperature: node.spanParams.temperature,
+      tools: 'tools' in node.spanParams ? node.spanParams.tools : undefined,
+      name,
+      metadata,
+      tags,
+      numInputTokens: node.spanParams.numInputTokens,
+      numOutputTokens: node.spanParams.numOutputTokens,
+      totalTokens: node.spanParams.totalTokens,
+      timeToFirstTokenNs: node.spanParams.timeToFirstTokenNs,
+      durationNs,
+      createdAt,
+      statusCode,
+      stepNumber
+    });
+  } else if (node.nodeType === 'retriever') {
+    logger.addRetrieverSpan({
+      input: inputAsString,
+      output,
+      name,
+      metadata,
+      tags,
+      durationNs,
+      createdAt,
+      statusCode,
+      stepNumber
+    });
+  } else if (node.nodeType === 'tool') {
+    const toolSpan = logger.addToolSpan({
+      input: inputAsString,
+      output: outputAsString,
+      name,
+      metadata,
+      tags,
+      toolCallId: node.spanParams.toolCallId as string | undefined,
+      durationNs,
+      createdAt,
+      statusCode,
+      stepNumber
+    });
+    if (node.children.length > 0) {
+      // Push tool span as parent so agent-as-tool child spans nest correctly
+      logger.pushParent(toolSpan);
+      isWorkflowSpan = true;
+    }
+  } else {
+    sdkLogger.warn(`Unknown node type: ${node.nodeType}`);
+  }
+
+  // Process all child nodes
+  let lastChild: Node | null = null;
+  for (const childId of node.children) {
+    const childNode = nodes[childId];
+    if (childNode) {
+      logNodeTree(childNode, nodes, logger);
+      lastChild = childNode;
+    } else {
+      sdkLogger.debug(`Child node ${childId} not found`);
+    }
+  }
+
+  // Conclude workflow/agent span. Use the last child's output if necessary
+  if (isWorkflowSpan) {
+    const finalOutput =
+      output || (lastChild ? lastChild.spanParams.output || '' : '');
+    logger.conclude({
+      output: toStringValue(finalOutput),
+      statusCode
+    });
+  }
+}

--- a/src/handlers/langchain/utils.ts
+++ b/src/handlers/langchain/utils.ts
@@ -1,6 +1,17 @@
-import { ToolMessage } from '@langchain/core/messages';
-import { Serialized } from '@langchain/core/load/serializable.js';
+import type { ToolMessage } from '@langchain/core/messages';
+import type { Serialized } from '@langchain/core/load/serializable.js';
 import { Node } from './node';
+
+// Runtime import — ToolMessage is used for instanceof checks.
+// Guarded so the module loads safely when @langchain/core is not installed.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let _ToolMessage: any;
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  _ToolMessage = require('@langchain/core/messages').ToolMessage;
+} catch {
+  // @langchain/core not installed — instanceof checks will safely return false
+}
 
 /**
  * Resolve a node name from serialized data, runName, or metadata.
@@ -52,7 +63,8 @@ export function getAgentName(
  * that carry a messages array.
  */
 export function findToolMessage(output: unknown): ToolMessage | null {
-  if (output instanceof ToolMessage) return output;
+  if (_ToolMessage && output instanceof _ToolMessage)
+    return output as ToolMessage;
   const update = (output as Record<string, unknown>)?.update;
   if (
     typeof update === 'object' &&
@@ -61,7 +73,8 @@ export function findToolMessage(output: unknown): ToolMessage | null {
   ) {
     const messages = (update as Record<string, unknown>).messages as unknown[];
     const last = messages.length === 0 ? null : messages[messages.length - 1];
-    if (last instanceof ToolMessage) return last;
+    if (_ToolMessage && last instanceof _ToolMessage)
+      return last as ToolMessage;
   }
   return null;
 }

--- a/src/handlers/langchain/utils.ts
+++ b/src/handlers/langchain/utils.ts
@@ -1,0 +1,89 @@
+import { ToolMessage } from '@langchain/core/messages';
+import { Serialized } from '@langchain/core/load/serializable.js';
+import { Node } from './node';
+
+/**
+ * Resolve a node name from serialized data, runName, or metadata.
+ * Falls back to capitalised nodeType.
+ */
+export function getNodeName(
+  nodeType: string,
+  serialized?: Serialized | null,
+  runName?: string,
+  metadata?: Record<string, unknown>
+): string {
+  try {
+    if (serialized?.name && serialized.name.length > 0) {
+      return serialized.name;
+    }
+    const idArr = serialized?.id;
+    if (Array.isArray(idArr) && idArr.length > 0) {
+      return String(idArr[idArr.length - 1]);
+    }
+    if (typeof runName === 'string' && runName.length > 0) {
+      return runName;
+    }
+    const metaName = metadata?.name;
+    if (typeof metaName === 'string' && metaName.length > 0) {
+      return metaName;
+    }
+    return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
+  } catch {
+    return nodeType.charAt(0).toUpperCase() + nodeType.slice(1);
+  }
+}
+
+/**
+ * Build a hierarchical agent name from the parent node.
+ */
+export function getAgentName(
+  nodes: Record<string, Node>,
+  parentRunId: string | undefined,
+  defaultName: string
+): string {
+  if (parentRunId !== undefined && nodes[parentRunId]) {
+    return `${nodes[parentRunId].spanParams.name}:${defaultName}`;
+  }
+  return defaultName;
+}
+
+/**
+ * Detect a ToolMessage inside a tool output, including LangGraph Command objects
+ * that carry a messages array.
+ */
+export function findToolMessage(output: unknown): ToolMessage | null {
+  if (output instanceof ToolMessage) return output;
+  const update = (output as Record<string, unknown>)?.update;
+  if (
+    typeof update === 'object' &&
+    update !== null &&
+    Array.isArray((update as Record<string, unknown>).messages)
+  ) {
+    const messages = (update as Record<string, unknown>).messages as unknown[];
+    const last = messages.length === 0 ? null : messages[messages.length - 1];
+    if (last instanceof ToolMessage) return last;
+  }
+  return null;
+}
+
+/**
+ * Retroactively upgrade a root-level chain node to agent type when any of its
+ * children carry langgraph_* metadata keys.
+ */
+export function updateRootToAgent(
+  parentRunId: string | undefined,
+  metadata: Record<string, unknown> | undefined,
+  nodes: Record<string, Node>
+): void {
+  if (!parentRunId) return;
+  if (!metadata) return;
+  const hasLangGraphKey = Object.keys(metadata).some((k) =>
+    k.startsWith('langgraph_')
+  );
+  if (!hasLangGraphKey) return;
+  const parentNode = nodes[parentRunId];
+  if (!parentNode) return;
+  if (parentNode.nodeType === 'chain' && parentNode.parentRunId === undefined) {
+    parentNode.nodeType = 'agent';
+  }
+}

--- a/src/observe/callback.ts
+++ b/src/observe/callback.ts
@@ -1,30 +1,55 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { AxiosError } from 'axios';
-import { ChainValues } from '@langchain/core/utils/types';
-import { LLMResult } from '@langchain/core/outputs';
 
-import {
-  BaseCallbackHandler,
-  NewTokenIndices
-} from '@langchain/core/callbacks/base';
-import { BaseMessage } from '@langchain/core/messages';
-import { ChatPromptValue } from '@langchain/core/prompt_values';
-import { Document, DocumentInterface } from '@langchain/core/documents';
-import { encoding_for_model, TiktokenModel } from 'tiktoken/init';
-import { Serialized } from '@langchain/core/dist/load/serializable.js';
+// Type-only imports — erased at runtime, safe when @langchain/core is not installed
+import type { ChainValues } from '@langchain/core/utils/types';
+import type { LLMResult } from '@langchain/core/outputs';
+import type { NewTokenIndices } from '@langchain/core/callbacks/base';
+import type { BaseMessage } from '@langchain/core/messages';
+import type { DocumentInterface } from '@langchain/core/documents';
+import type { Serialized } from '@langchain/core/dist/load/serializable.js';
+import type { AgentFinish } from '@langchain/core/dist/agents.js';
+
 import {
   TransactionLoggingMethod,
   TransactionRecord,
   TransactionRecordBatch
 } from '../types/transaction.types';
 import { version } from '../../package.json';
-import { AgentFinish } from '@langchain/core/dist/agents.js';
 import GalileoObserveApiClient from './api-client';
 import { NodeType } from '../types/legacy-step.types';
+
+// Runtime imports — guarded for optional @langchain/core and tiktoken peer dependencies.
+/* eslint-disable @typescript-eslint/no-var-requires */
+let _BaseCallbackHandler: any;
+let _BaseMessage: any;
+let _ChatPromptValue: any;
+let _Document: any;
+let _encoding_for_model: any;
+let _langchainAvailable = false;
+
+try {
+  _BaseCallbackHandler =
+    require('@langchain/core/callbacks/base').BaseCallbackHandler;
+  _BaseMessage = require('@langchain/core/messages').BaseMessage;
+  _ChatPromptValue = require('@langchain/core/prompt_values').ChatPromptValue;
+  _Document = require('@langchain/core/documents').Document;
+  _langchainAvailable = true;
+} catch {
+  _BaseCallbackHandler = class LangChainNotAvailable {};
+}
+
+try {
+  _encoding_for_model = require('tiktoken/init').encoding_for_model;
+} catch {
+  // tiktoken not installed — token counting will fall back to zeros
+}
+/* eslint-enable @typescript-eslint/no-var-requires */
 
 /**
  * @deprecated This class is no longer actively maintained. Please use `GalileoCallback` instead.
  */
-export default class GalileoObserveCallback extends BaseCallbackHandler {
+export default class GalileoObserveCallback extends (_BaseCallbackHandler as typeof import('@langchain/core/callbacks/base').BaseCallbackHandler) {
   public name = 'GalileoObserveCallback';
   private api_client: GalileoObserveApiClient;
 
@@ -34,6 +59,12 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
   public project_name: string;
 
   constructor(project_name: string, version?: string) {
+    if (!_langchainAvailable) {
+      throw new Error(
+        'GalileoObserveCallback requires @langchain/core to be installed.\n' +
+          'Install it with: npm install @langchain/core'
+      );
+    }
     super();
     this.version = version;
     this.project_name = project_name;
@@ -202,14 +233,14 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
       num_total_tokens = usage.totalTokens as number | undefined;
     } else {
       try {
-        const encoding = encoding_for_model(
-          this.records[node_id].model as TiktokenModel
+        const encoding = _encoding_for_model(
+          this.records[node_id].model as string
         );
         num_input_tokens = encoding.encode(
           this.records[node_id].input_text
         ).length;
         num_output_tokens = encoding.encode(output_text).length;
-        num_total_tokens = num_input_tokens + num_output_tokens;
+        num_total_tokens = (num_input_tokens ?? 0) + (num_output_tokens ?? 0);
       } catch (error) {
         num_input_tokens = 0;
         num_output_tokens = 0;
@@ -256,7 +287,7 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
       parentRunId
     );
 
-    const chat_messages = new ChatPromptValue(messages[0]);
+    const chat_messages = new _ChatPromptValue(messages[0]);
     const invocation_params = extraParams?.invocation_params as Record<
       string,
       unknown
@@ -327,7 +358,7 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
 
     if (typeof inputs === 'string') {
       node_input = { input: inputs };
-    } else if (inputs instanceof BaseMessage) {
+    } else if (_BaseMessage && inputs instanceof _BaseMessage) {
       node_input = inputs;
     } else if (typeof inputs === 'object') {
       node_input = Object.fromEntries(
@@ -338,13 +369,17 @@ export default class GalileoObserveCallback extends BaseCallbackHandler {
       );
     } else if (
       (Array.isArray(inputs) as boolean) &&
-      (inputs as Document[]).every((v: unknown) => v instanceof Document)
+      (inputs as DocumentInterface[]).every(
+        (v: unknown) => _Document && v instanceof _Document
+      )
     ) {
       node_input = Object.fromEntries(
-        (inputs as Document[]).map((value: Document, index: number) => [
-          String(index),
-          value.pageContent
-        ])
+        (inputs as DocumentInterface[]).map(
+          (value: DocumentInterface, index: number) => [
+            String(index),
+            value.pageContent
+          ]
+        )
       );
     }
 

--- a/src/types/logging/logger.types.ts
+++ b/src/types/logging/logger.types.ts
@@ -424,7 +424,6 @@ export interface IGalileoLoggerSpan {
     agentType?: AgentType;
     statusCode?: number;
     stepNumber?: number;
-    statusCode?: number;
   }): AgentSpan;
 }
 

--- a/src/types/logging/logger.types.ts
+++ b/src/types/logging/logger.types.ts
@@ -60,6 +60,12 @@ export interface IGalileoLoggerCore {
   previousParent(): StepWithChildSpans | undefined;
 
   /**
+   * Push a span onto the parent stack so subsequent child spans nest under it.
+   * Used by handlers that need to make leaf spans (like tool) act as parents.
+   */
+  pushParent(span: StepWithChildSpans): void;
+
+  /**
    * Check if there is an active trace.
    * @returns True if there is a current parent (trace or span), false otherwise.
    */
@@ -396,6 +402,7 @@ export interface IGalileoLoggerSpan {
     createdAt?: Date;
     metadata?: Record<string, string>;
     tags?: string[];
+    statusCode?: number;
     stepNumber?: number;
   }): WorkflowSpan;
 
@@ -415,6 +422,7 @@ export interface IGalileoLoggerSpan {
     metadata?: Record<string, string>;
     tags?: string[];
     agentType?: AgentType;
+    statusCode?: number;
     stepNumber?: number;
     statusCode?: number;
   }): AgentSpan;

--- a/src/types/logging/span.types.ts
+++ b/src/types/logging/span.types.ts
@@ -405,7 +405,11 @@ export interface ToolSpanOptions extends Omit<
   toolCallId?: string;
 }
 
-export class ToolSpan extends BaseStep {
+export interface SerializedToolSpan extends SerializedStepWithChildSpans {
+  toolCallId?: string;
+}
+
+export class ToolSpan extends StepWithChildSpans {
   type: StepType = StepType.tool;
   input: string;
   redactedInput?: string;
@@ -414,56 +418,44 @@ export class ToolSpan extends BaseStep {
   toolCallId?: string;
 
   constructor(data: ToolSpanOptions) {
-    // Convert JsonValue input to string for BaseStepOptions compatibility
-    super(StepType.tool, {
-      ...data,
-      input:
-        typeof data.input === 'string'
-          ? data.input
-          : JSON.stringify(data.input),
-      redactedInput: data.redactedInput
-        ? typeof data.redactedInput === 'string'
-          ? data.redactedInput
-          : JSON.stringify(data.redactedInput)
-        : undefined,
-      output:
-        typeof data.output === 'string'
-          ? data.output
-          : JSON.stringify(data.output),
-      redactedOutput: data.redactedOutput
-        ? typeof data.redactedOutput === 'string'
-          ? data.redactedOutput
-          : JSON.stringify(data.redactedOutput)
-        : undefined
-    });
-
-    // Convert JsonValue to string for storage
-    this.input =
+    // Convert JsonValue input/output to string for StepWithChildSpansOptions compatibility
+    const stringInput =
       typeof data.input === 'string' ? data.input : JSON.stringify(data.input);
-    this.redactedInput =
-      typeof data.redactedInput === 'string'
+    const stringRedactedInput = data.redactedInput
+      ? typeof data.redactedInput === 'string'
         ? data.redactedInput
-        : data.redactedInput !== undefined
-          ? JSON.stringify(data.redactedInput)
-          : undefined;
-    this.output =
+        : JSON.stringify(data.redactedInput)
+      : undefined;
+    const stringOutput =
       typeof data.output === 'string'
         ? data.output
         : JSON.stringify(data.output);
-    this.redactedOutput =
-      typeof data.redactedOutput === 'string'
-        ? (data.redactedOutput ?? '')
-        : data.redactedOutput !== undefined
-          ? JSON.stringify(data.redactedOutput)
-          : undefined;
+    const stringRedactedOutput = data.redactedOutput
+      ? typeof data.redactedOutput === 'string'
+        ? data.redactedOutput
+        : JSON.stringify(data.redactedOutput)
+      : undefined;
+
+    super(StepType.tool, {
+      ...data,
+      input: stringInput,
+      redactedInput: stringRedactedInput,
+      output: stringOutput,
+      redactedOutput: stringRedactedOutput
+    });
+
+    this.input = stringInput;
+    this.redactedInput = stringRedactedInput;
+    this.output = stringOutput;
+    this.redactedOutput = stringRedactedOutput;
     this.toolCallId = data.toolCallId;
   }
 
-  toJSON(): SerializedStep {
+  toJSON(): SerializedToolSpan {
     return {
       ...super.toJSON(),
       toolCallId: this.toolCallId
-    } as SerializedStep;
+    };
   }
 }
 

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -210,6 +210,16 @@ class GalileoLogger implements IGalileoLogger {
   }
 
   /**
+   * Push a span onto the parent stack so subsequent child spans nest under it.
+   * Used by handlers that need to make leaf spans (like tool) act as parents.
+   */
+  pushParent(span: StepWithChildSpans): void {
+    const stack = this.getParentStack();
+    stack.push(span);
+    this.setParentStack(stack);
+  }
+
+  /**
    * Check if there is an active trace.
    * @returns True if there is a current parent (trace or span), false otherwise.
    */
@@ -1143,6 +1153,7 @@ class GalileoLogger implements IGalileoLogger {
       tags: options.tags,
       statusCode: options.statusCode,
       metrics: new Metrics({ durationNs: options.durationNs }),
+      statusCode: options.statusCode,
       stepNumber: options.stepNumber
     });
 
@@ -1186,6 +1197,7 @@ class GalileoLogger implements IGalileoLogger {
     metadata?: Record<string, string>;
     tags?: string[];
     agentType?: AgentType;
+    statusCode?: number;
     stepNumber?: number;
     statusCode?: number;
   }): AgentSpan {

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -1153,7 +1153,6 @@ class GalileoLogger implements IGalileoLogger {
       tags: options.tags,
       statusCode: options.statusCode,
       metrics: new Metrics({ durationNs: options.durationNs }),
-      statusCode: options.statusCode,
       stepNumber: options.stepNumber
     });
 
@@ -1199,7 +1198,6 @@ class GalileoLogger implements IGalileoLogger {
     agentType?: AgentType;
     statusCode?: number;
     stepNumber?: number;
-    statusCode?: number;
   }): AgentSpan {
     const span = new AgentSpan({
       input: options.input,

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -1,5 +1,8 @@
-import { GalileoCallback, rootNodeContext } from '../../src/handlers/langchain';
-import { GalileoLogger } from '../../src/utils/galileo-logger';
+import {
+  GalileoCallback,
+  rootNodeContext
+} from '../../../src/handlers/langchain';
+import { GalileoLogger } from '../../../src/utils/galileo-logger';
 import { AgentFinish } from '@langchain/core/agents';
 import {
   BaseMessage,
@@ -11,13 +14,13 @@ import { LLMResult } from '@langchain/core/outputs';
 import { Serialized } from '@langchain/core/load/serializable';
 import { ChainValues } from '@langchain/core/utils/types';
 import { DocumentInterface, Document } from '@langchain/core/documents';
-import { StepType } from '../../src/types/logging/step.types';
+import { StepType } from '../../../src/types/logging/step.types';
 import {
   AgentSpan,
   LlmSpan,
   ToolSpan,
   WorkflowSpan
-} from '../../src/types/logging/span.types';
+} from '../../../src/types/logging/span.types';
 
 // Mock implementation functions
 const mockInit = jest.fn().mockResolvedValue(undefined);
@@ -28,7 +31,7 @@ const mockGetLogStreams = jest.fn();
 const mockGetLogStreamByName = jest.fn();
 const mockIngestTraces = jest.fn();
 
-jest.mock('../../src/api-client', () => {
+jest.mock('../../../src/api-client', () => {
   return {
     GalileoApiClient: Object.assign(
       jest.fn().mockImplementation(() => {

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -1884,7 +1884,7 @@ describe('GalileoCallback', () => {
         const traces = callback._galileoLogger.traces;
         expect(traces).toHaveLength(1);
         const span = traces[0].spans[0] as WorkflowSpan;
-        expect(span.statusCode).toBe(400);
+        expect(span.statusCode).toBe(500);
       });
     });
 

--- a/tests/handlers/langchain/node.test.ts
+++ b/tests/handlers/langchain/node.test.ts
@@ -1,0 +1,77 @@
+import {
+  Node,
+  rootNodeContext,
+  LANGCHAIN_NODE_TYPE
+} from '../../../src/handlers/langchain/node';
+
+describe('Node', () => {
+  it('test construct node with all properties', () => {
+    const node = new Node(
+      'llm',
+      { name: 'test', input: 'hello' },
+      'run-1',
+      'parent-1'
+    );
+
+    expect(node.nodeType).toBe('llm');
+    expect(node.spanParams).toEqual({ name: 'test', input: 'hello' });
+    expect(node.runId).toBe('run-1');
+    expect(node.parentRunId).toBe('parent-1');
+    expect(node.children).toEqual([]);
+  });
+
+  it('test construct node without parentRunId', () => {
+    const node = new Node('chain', { name: 'chain' }, 'run-2');
+
+    expect(node.parentRunId).toBeUndefined();
+  });
+
+  it('test children array is mutable', () => {
+    const node = new Node('agent', {}, 'run-3');
+
+    node.children.push('child-1', 'child-2');
+
+    expect(node.children).toEqual(['child-1', 'child-2']);
+  });
+
+  it('test all node types are valid', () => {
+    const types: LANGCHAIN_NODE_TYPE[] = [
+      'agent',
+      'chain',
+      'chat',
+      'llm',
+      'retriever',
+      'tool'
+    ];
+
+    for (const type of types) {
+      const node = new Node(type, {}, `run-${type}`);
+      expect(node.nodeType).toBe(type);
+    }
+  });
+});
+
+describe('rootNodeContext', () => {
+  beforeEach(() => {
+    rootNodeContext.set(null);
+  });
+
+  it('test get returns null by default', () => {
+    expect(rootNodeContext.get()).toBeNull();
+  });
+
+  it('test set and get a node', () => {
+    const node = new Node('chain', {}, 'root-1');
+    rootNodeContext.set(node);
+
+    expect(rootNodeContext.get()).toBe(node);
+  });
+
+  it('test reset to null', () => {
+    const node = new Node('chain', {}, 'root-1');
+    rootNodeContext.set(node);
+    rootNodeContext.set(null);
+
+    expect(rootNodeContext.get()).toBeNull();
+  });
+});

--- a/tests/handlers/langchain/tree-logger.test.ts
+++ b/tests/handlers/langchain/tree-logger.test.ts
@@ -1,0 +1,314 @@
+import { GalileoLogger } from '../../../src/utils/galileo-logger';
+import { Node } from '../../../src/handlers/langchain/node';
+import { logNodeTree } from '../../../src/handlers/langchain/tree-logger';
+import { StepType } from '../../../src/types/logging/step.types';
+import {
+  LlmSpan,
+  ToolSpan,
+  WorkflowSpan
+} from '../../../src/types/logging/span.types';
+
+// Mock implementation functions
+const mockInit = jest.fn().mockResolvedValue(undefined);
+const mockGetProject = jest.fn();
+const mockGetProjects = jest.fn();
+const mockGetProjectByName = jest.fn();
+const mockGetLogStreams = jest.fn();
+const mockGetLogStreamByName = jest.fn();
+const mockIngestTraces = jest.fn();
+
+jest.mock('../../../src/api-client', () => {
+  return {
+    GalileoApiClient: Object.assign(
+      jest.fn().mockImplementation(() => {
+        return {
+          init: mockInit,
+          getProject: mockGetProject,
+          getProjects: mockGetProjects,
+          getProjectByName: mockGetProjectByName,
+          getLogStreams: mockGetLogStreams,
+          getLogStreamByName: mockGetLogStreamByName,
+          ingestTraces: mockIngestTraces
+        };
+      }),
+      {
+        getTimestampRecord: jest.fn().mockReturnValue(new Date())
+      }
+    )
+  };
+});
+
+describe('logNodeTree', () => {
+  let logger: GalileoLogger;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GALILEO_PROJECT = 'test-project';
+    process.env.GALILEO_LOG_STREAM = 'test-log-stream';
+    logger = new GalileoLogger();
+    logger.startTrace({ input: 'test' });
+  });
+
+  it('test log agent node as agent span', () => {
+    const node = new Node(
+      'agent',
+      {
+        input: 'hello',
+        output: 'world',
+        name: 'TestAgent',
+        tags: ['tag1']
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    expect(trace.spans.length).toBe(1);
+    expect(trace.spans[0].type).toBe(StepType.agent);
+  });
+
+  it('test log chain node as workflow span', () => {
+    const node = new Node(
+      'chain',
+      {
+        input: 'hello',
+        output: 'world',
+        name: 'TestChain'
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    expect(trace.spans.length).toBe(1);
+    expect(trace.spans[0].type).toBe(StepType.workflow);
+  });
+
+  it('test log llm node as llm span with tokens', () => {
+    const node = new Node(
+      'llm',
+      {
+        input: [{ content: 'prompt', role: 'user' }],
+        output: { text: 'response' },
+        name: 'GPT',
+        model: 'gpt-4',
+        temperature: 0.7,
+        numInputTokens: 10,
+        numOutputTokens: 20,
+        totalTokens: 30
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    expect(trace.spans.length).toBe(1);
+    const span = trace.spans[0] as LlmSpan;
+    expect(span.type).toBe(StepType.llm);
+    expect(span.metrics.numInputTokens).toBe(10);
+    expect(span.metrics.numOutputTokens).toBe(20);
+    expect(span.metrics.numTotalTokens).toBe(30);
+  });
+
+  it('test log tool node as tool span', () => {
+    const node = new Node(
+      'tool',
+      {
+        input: 'query',
+        output: 'result',
+        name: 'Search',
+        toolCallId: 'tc-1'
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    expect(trace.spans.length).toBe(1);
+    expect(trace.spans[0].type).toBe(StepType.tool);
+  });
+
+  it('test log retriever node as retriever span', () => {
+    const node = new Node(
+      'retriever',
+      {
+        input: 'search query',
+        output: [{ pageContent: 'doc' }],
+        name: 'VectorDB'
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    expect(trace.spans.length).toBe(1);
+    expect(trace.spans[0].type).toBe(StepType.retriever);
+  });
+
+  it('test recurse into child nodes', () => {
+    const parent = new Node(
+      'chain',
+      {
+        input: 'hello',
+        output: 'world',
+        name: 'Parent'
+      },
+      'parent-1'
+    );
+    parent.children = ['child-1', 'child-2'];
+
+    const child1 = new Node(
+      'llm',
+      {
+        input: 'prompt',
+        output: 'response',
+        name: 'LLM'
+      },
+      'child-1',
+      'parent-1'
+    );
+
+    const child2 = new Node(
+      'tool',
+      {
+        input: 'query',
+        output: 'result',
+        name: 'Tool'
+      },
+      'child-2',
+      'parent-1'
+    );
+
+    const nodes: Record<string, Node> = {
+      'parent-1': parent,
+      'child-1': child1,
+      'child-2': child2
+    };
+
+    logNodeTree(parent, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    expect(trace.spans.length).toBe(1);
+    const workflow = trace.spans[0] as WorkflowSpan;
+    expect(workflow.type).toBe(StepType.workflow);
+    expect(workflow.spans.length).toBe(2);
+    expect(workflow.spans[0].type).toBe(StepType.llm);
+    expect(workflow.spans[1].type).toBe(StepType.tool);
+  });
+
+  it('test extract step number from langgraph_step metadata', () => {
+    const node = new Node(
+      'chain',
+      {
+        input: 'hello',
+        output: 'world',
+        name: 'Step',
+        metadata: { langgraph_step: '3' }
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    const span = trace.spans[0] as WorkflowSpan;
+    expect(span.stepNumber).toBe(3);
+  });
+
+  it('test handle invalid step number gracefully', () => {
+    const node = new Node(
+      'chain',
+      {
+        input: 'hello',
+        output: 'world',
+        name: 'Step',
+        metadata: { langgraph_step: 'not-a-number' }
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    logNodeTree(node, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    const span = trace.spans[0] as WorkflowSpan;
+    expect(span.stepNumber).toBeUndefined();
+  });
+
+  it('test tool span with children pushes parent for nesting', () => {
+    const toolNode = new Node(
+      'tool',
+      {
+        input: 'query',
+        output: 'result',
+        name: 'AgentTool'
+      },
+      'tool-1'
+    );
+    toolNode.children = ['llm-1'];
+
+    const llmNode = new Node(
+      'llm',
+      {
+        input: 'prompt',
+        output: 'response',
+        name: 'NestedLLM'
+      },
+      'llm-1',
+      'tool-1'
+    );
+
+    const nodes: Record<string, Node> = {
+      'tool-1': toolNode,
+      'llm-1': llmNode
+    };
+
+    logNodeTree(toolNode, nodes, logger);
+
+    logger.conclude({ output: 'done' });
+    const trace = logger.traces[0];
+    const toolSpan = trace.spans[0] as ToolSpan;
+    expect(toolSpan.type).toBe(StepType.tool);
+    // The LLM span should be nested under the tool span
+    expect((toolSpan as unknown as WorkflowSpan).spans?.length).toBe(1);
+  });
+
+  it('test metadata conversion error is handled gracefully', () => {
+    const circularRef: Record<string, unknown> = {};
+    circularRef.self = circularRef;
+
+    const node = new Node(
+      'chain',
+      {
+        input: 'hello',
+        output: 'world',
+        name: 'Test',
+        metadata: circularRef
+      },
+      'run-1'
+    );
+    const nodes: Record<string, Node> = { 'run-1': node };
+
+    // Should not throw
+    expect(() => logNodeTree(node, nodes, logger)).not.toThrow();
+  });
+});

--- a/tests/handlers/langchain/utils.test.ts
+++ b/tests/handlers/langchain/utils.test.ts
@@ -1,0 +1,191 @@
+import { ToolMessage } from '@langchain/core/messages';
+import { Serialized } from '@langchain/core/load/serializable';
+import { Node } from '../../../src/handlers/langchain/node';
+import {
+  getNodeName,
+  getAgentName,
+  findToolMessage,
+  updateRootToAgent
+} from '../../../src/handlers/langchain/utils';
+
+describe('getNodeName', () => {
+  it('test return serialized.name when present', () => {
+    const serialized = {
+      name: 'MyChain',
+      lc: 1,
+      type: 'secret',
+      id: ['test']
+    } as Serialized;
+
+    expect(getNodeName('chain', serialized)).toBe('MyChain');
+  });
+
+  it('test return last element of serialized.id when name is absent', () => {
+    const serialized = {
+      lc: 1,
+      type: 'secret',
+      id: ['langchain', 'llms', 'ChatOpenAI']
+    } as Serialized;
+
+    expect(getNodeName('llm', serialized)).toBe('ChatOpenAI');
+  });
+
+  it('test return runName when serialized has no name or id', () => {
+    expect(getNodeName('llm', undefined, 'my-custom-run')).toBe(
+      'my-custom-run'
+    );
+  });
+
+  it('test return metadata.name when runName is absent', () => {
+    expect(
+      getNodeName('tool', undefined, undefined, { name: 'MetaTool' })
+    ).toBe('MetaTool');
+  });
+
+  it('test fallback to capitalised nodeType', () => {
+    expect(getNodeName('retriever')).toBe('Retriever');
+    expect(getNodeName('llm')).toBe('Llm');
+    expect(getNodeName('agent')).toBe('Agent');
+  });
+
+  it('test skip empty serialized.name', () => {
+    const serialized = {
+      name: '',
+      lc: 1,
+      type: 'secret',
+      id: ['Fallback']
+    } as Serialized;
+
+    expect(getNodeName('chain', serialized)).toBe('Fallback');
+  });
+
+  it('test skip empty runName', () => {
+    expect(getNodeName('tool', undefined, '', { name: 'FromMeta' })).toBe(
+      'FromMeta'
+    );
+  });
+
+  it('test priority order: serialized.name > id > runName > metadata', () => {
+    const serialized = {
+      name: 'Winner',
+      lc: 1,
+      type: 'secret',
+      id: ['Second']
+    } as Serialized;
+
+    expect(getNodeName('chain', serialized, 'Third', { name: 'Fourth' })).toBe(
+      'Winner'
+    );
+  });
+});
+
+describe('getAgentName', () => {
+  it('test build hierarchical name from parent', () => {
+    const nodes: Record<string, Node> = {
+      'parent-1': new Node('agent', { name: 'RootAgent' }, 'parent-1')
+    };
+
+    expect(getAgentName(nodes, 'parent-1', 'Agent')).toBe('RootAgent:Agent');
+  });
+
+  it('test return defaultName when parent not found', () => {
+    expect(getAgentName({}, 'missing', 'Agent')).toBe('Agent');
+  });
+
+  it('test return defaultName when parentRunId is undefined', () => {
+    expect(getAgentName({}, undefined, 'Agent')).toBe('Agent');
+  });
+});
+
+describe('findToolMessage', () => {
+  it('test detect direct ToolMessage', () => {
+    const msg = new ToolMessage({ content: 'result', tool_call_id: 'tc-1' });
+
+    expect(findToolMessage(msg)).toBe(msg);
+  });
+
+  it('test detect ToolMessage in LangGraph Command update.messages', () => {
+    const msg = new ToolMessage({ content: 'result', tool_call_id: 'tc-2' });
+    const output = { update: { messages: [msg] } };
+
+    expect(findToolMessage(output)).toBe(msg);
+  });
+
+  it('test return null for non-ToolMessage output', () => {
+    expect(findToolMessage('plain string')).toBeNull();
+    expect(findToolMessage({ content: 'not a ToolMessage' })).toBeNull();
+    expect(findToolMessage(null)).toBeNull();
+    expect(findToolMessage(undefined)).toBeNull();
+  });
+
+  it('test return null for empty messages array', () => {
+    const output = { update: { messages: [] } };
+
+    expect(findToolMessage(output)).toBeNull();
+  });
+
+  it('test return null when last message is not ToolMessage', () => {
+    const output = { update: { messages: ['not a ToolMessage'] } };
+
+    expect(findToolMessage(output)).toBeNull();
+  });
+});
+
+describe('updateRootToAgent', () => {
+  it('test upgrade root chain to agent on langgraph metadata', () => {
+    const root = new Node('chain', { name: 'Chain' }, 'root-1');
+    const nodes: Record<string, Node> = { 'root-1': root };
+
+    updateRootToAgent('root-1', { langgraph_step: '0' }, nodes);
+
+    expect(root.nodeType).toBe('agent');
+  });
+
+  it('test skip when no langgraph keys', () => {
+    const root = new Node('chain', { name: 'Chain' }, 'root-1');
+    const nodes: Record<string, Node> = { 'root-1': root };
+
+    updateRootToAgent('root-1', { some_key: 'value' }, nodes);
+
+    expect(root.nodeType).toBe('chain');
+  });
+
+  it('test skip when parent is not root (has parentRunId)', () => {
+    const parent = new Node(
+      'chain',
+      { name: 'Chain' },
+      'parent-1',
+      'grandparent'
+    );
+    const nodes: Record<string, Node> = { 'parent-1': parent };
+
+    updateRootToAgent('parent-1', { langgraph_step: '0' }, nodes);
+
+    expect(parent.nodeType).toBe('chain');
+  });
+
+  it('test skip when parent is already agent', () => {
+    const root = new Node('agent', { name: 'Agent' }, 'root-1');
+    const nodes: Record<string, Node> = { 'root-1': root };
+
+    updateRootToAgent('root-1', { langgraph_step: '0' }, nodes);
+
+    expect(root.nodeType).toBe('agent');
+  });
+
+  it('test skip when parentRunId is undefined', () => {
+    const nodes: Record<string, Node> = {};
+
+    updateRootToAgent(undefined, { langgraph_step: '0' }, nodes);
+    // No error thrown
+  });
+
+  it('test skip when metadata is undefined', () => {
+    const root = new Node('chain', {}, 'root-1');
+    const nodes: Record<string, Node> = { 'root-1': root };
+
+    updateRootToAgent('root-1', undefined, nodes);
+
+    expect(root.nodeType).toBe('chain');
+  });
+});

--- a/tests/utils/langchain.test.ts
+++ b/tests/utils/langchain.test.ts
@@ -1,13 +1,23 @@
 import { GalileoCallback, rootNodeContext } from '../../src/handlers/langchain';
 import { GalileoLogger } from '../../src/utils/galileo-logger';
 import { AgentFinish } from '@langchain/core/agents';
-import { BaseMessage, AIMessage, HumanMessage } from '@langchain/core/messages';
+import {
+  BaseMessage,
+  AIMessage,
+  HumanMessage,
+  ToolMessage
+} from '@langchain/core/messages';
 import { LLMResult } from '@langchain/core/outputs';
 import { Serialized } from '@langchain/core/load/serializable';
+import { ChainValues } from '@langchain/core/utils/types';
 import { DocumentInterface, Document } from '@langchain/core/documents';
-import { AxiosError } from 'axios';
 import { StepType } from '../../src/types/logging/step.types';
-import { LlmSpan, WorkflowSpan } from '../../src/types/logging/span.types';
+import {
+  AgentSpan,
+  LlmSpan,
+  ToolSpan,
+  WorkflowSpan
+} from '../../src/types/logging/span.types';
 
 // Mock implementation functions
 const mockInit = jest.fn().mockResolvedValue(undefined);
@@ -238,8 +248,8 @@ describe('GalileoCallback', () => {
         })
       );
       expect(trace.spans.length).toBe(1);
-      const span = trace.spans[0] as WorkflowSpan;
-      expect(span.type).toBe(StepType.workflow);
+      const span = trace.spans[0] as AgentSpan;
+      expect(span.type).toBe(StepType.agent);
       expect(span.input).toBe(JSON.stringify({ input: 'test input' }));
       expect(span.output).toBe(
         JSON.stringify({
@@ -871,7 +881,7 @@ describe('GalileoCallback', () => {
         outputArgs: {
           outputs: { result: 'answer' }
         },
-        expectedType: StepType.workflow
+        expectedType: StepType.agent
       }
     ];
 
@@ -1341,10 +1351,9 @@ describe('GalileoCallback', () => {
         );
 
         // End with error
-        const error = {
-          message: 'Chain execution failed',
+        const error = Object.assign(new Error('Chain execution failed'), {
           response: { status: 500 }
-        } as unknown as AxiosError;
+        });
 
         await callback.handleChainError(error, runId);
 
@@ -1364,10 +1373,9 @@ describe('GalileoCallback', () => {
         );
 
         // End with error
-        const error = {
-          message: 'LLM request failed',
+        const error = Object.assign(new Error('LLM request failed'), {
           response: { status: 503 }
-        } as unknown as AxiosError;
+        });
 
         await callback.handleLLMError(error, runId);
 
@@ -1386,10 +1394,9 @@ describe('GalileoCallback', () => {
         );
 
         // End with error
-        const error = {
-          message: 'Tool execution failed',
+        const error = Object.assign(new Error('Tool execution failed'), {
           response: { status: 400 }
-        } as unknown as AxiosError;
+        });
 
         await callback.handleToolError(error, runId);
 
@@ -1408,15 +1415,861 @@ describe('GalileoCallback', () => {
         );
 
         // End with error
-        const error = {
-          message: 'Retriever failed',
+        const error = Object.assign(new Error('Retriever failed'), {
           response: { status: 502 }
-        } as unknown as AxiosError;
+        });
 
         await callback.handleRetrieverError(error, runId);
 
         const traces = callback._galileoLogger.traces;
         expect(traces).toHaveLength(1);
+      });
+    });
+  });
+
+  describe('FIX-4 Coverage', () => {
+    describe('_getNodeName fallback resolution', () => {
+      it('test _getNodeName uses serialized.id array fallback when name absent', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            lc: 1,
+            type: 'secret',
+            id: ['path', 'to', 'ActualClassName']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        expect(callback['_nodes'][runId].spanParams.name).toBe(
+          'ActualClassName'
+        );
+      });
+
+      it('test _getNodeName uses capitalized nodeType catch-all when all sources absent', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          { lc: 1, type: 'secret', id: [] } as Serialized,
+          { query: 'test' },
+          runId,
+          undefined,
+          undefined,
+          {}
+        );
+
+        expect(callback['_nodes'][runId].spanParams.name).toBe('Chain');
+      });
+    });
+
+    describe('updateRootToAgent', () => {
+      it('test updateRootToAgent upgrades root chain to agent on langgraph_ metadata key', async () => {
+        const rootId = createId();
+        const childId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'MyChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          rootId
+        );
+
+        expect(callback['_nodes'][rootId].nodeType).toBe('chain');
+
+        await callback.handleChainStart(
+          {
+            name: 'ChildChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'child' },
+          childId,
+          rootId,
+          undefined,
+          { langgraph_step: '1' }
+        );
+
+        expect(callback['_nodes'][rootId].nodeType).toBe('agent');
+      });
+    });
+
+    describe('case-insensitive agent detection', () => {
+      it('test handleChainStart detects agent with lowercase langgraph name', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'langgraph',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        expect(callback['_nodes'][runId].nodeType).toBe('agent');
+      });
+    });
+
+    describe('_getAgentName hierarchical naming', () => {
+      it('test _getAgentName returns parent:child name format', async () => {
+        const parentId = createId();
+        const childId = createId();
+
+        // Create parent agent node directly
+        callback['_startNode']('agent', undefined, parentId, {
+          name: 'OuterAgent',
+          input: 'test'
+        });
+        rootNodeContext.set(callback['_nodes'][parentId]);
+
+        // Start child that triggers agent detection via name 'Agent'
+        await callback.handleChainStart(
+          { name: 'Agent', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          childId,
+          parentId
+        );
+
+        expect(callback['_nodes'][childId].spanParams.name).toBe(
+          'OuterAgent:Agent'
+        );
+      });
+    });
+
+    describe('_findToolMessage', () => {
+      it('test handleToolEnd captures content and toolCallId from direct ToolMessage', async () => {
+        const parentId = createId();
+        const toolId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleToolStart(
+          { name: 'myTool', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          'tool input',
+          toolId,
+          parentId
+        );
+
+        const toolMessage = new ToolMessage({
+          content: 'tool result',
+          tool_call_id: 'call_abc'
+        });
+        await callback.handleToolEnd(toolMessage, toolId);
+
+        expect(callback['_nodes'][toolId].spanParams.output).toBe(
+          'tool result'
+        );
+        expect(callback['_nodes'][toolId].spanParams.toolCallId).toBe(
+          'call_abc'
+        );
+      });
+
+      it('test handleToolEnd captures content and toolCallId from LangGraph Command', async () => {
+        const parentId = createId();
+        const toolId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleToolStart(
+          { name: 'myTool', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          'tool input',
+          toolId,
+          parentId
+        );
+
+        const toolMessage = new ToolMessage({
+          content: 'command result',
+          tool_call_id: 'call_xyz'
+        });
+        const commandOutput = { update: { messages: [toolMessage] } };
+        await callback.handleToolEnd(commandOutput, toolId);
+
+        expect(callback['_nodes'][toolId].spanParams.output).toBe(
+          'command result'
+        );
+        expect(callback['_nodes'][toolId].spanParams.toolCallId).toBe(
+          'call_xyz'
+        );
+      });
+
+      it('test handleToolEnd captures content and toolCallId from array-of-ToolMessage', async () => {
+        const parentId = createId();
+        const toolId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleToolStart(
+          { name: 'myTool', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          'tool input',
+          toolId,
+          parentId
+        );
+
+        const toolMessage = new ToolMessage({
+          content: 'array result',
+          tool_call_id: 'call_arr'
+        });
+        await callback.handleToolEnd([toolMessage], toolId);
+
+        expect(callback['_nodes'][toolId].spanParams.output).toBe(
+          'array result'
+        );
+        expect(callback['_nodes'][toolId].spanParams.toolCallId).toBe(
+          'call_arr'
+        );
+      });
+    });
+
+    describe('tool output handling', () => {
+      it('test tuple tool output serializes first element only', async () => {
+        const parentId = createId();
+        const toolId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleToolStart(
+          { name: 'myTool', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          'tool input',
+          toolId,
+          parentId
+        );
+
+        await callback.handleToolEnd(
+          ['content-value', { artifact: true }],
+          toolId
+        );
+
+        expect(callback['_nodes'][toolId].spanParams.output).toBe(
+          'content-value'
+        );
+      });
+    });
+
+    describe('duration and timestamp tracking', () => {
+      it('test durationNs is a positive number in the committed span', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        await callback.handleChainEnd({ result: 'answer' }, runId);
+
+        const traces = callback._galileoLogger.traces;
+        expect(traces).toHaveLength(1);
+        const span = traces[0].spans[0] as WorkflowSpan;
+        expect(typeof span.metrics.durationNs).toBe('number');
+        expect(span.metrics.durationNs).toBeGreaterThan(0);
+      });
+
+      it('test createdAt is a Date instance on freshly started node', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        expect(callback['_nodes'][runId].spanParams.createdAt).toBeInstanceOf(
+          Date
+        );
+      });
+    });
+
+    describe('multi-provider token extraction', () => {
+      it('test handleLLMEnd extracts OpenAI camelCase tokenUsage', async () => {
+        const parentId = createId();
+        const runId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleLLMStart(undefined, ['prompt'], runId, parentId, {
+          invocation_params: { model_name: 'gpt-4' }
+        });
+
+        const llmResult: LLMResult = {
+          generations: [[{ text: 'response', generationInfo: {} }]],
+          llmOutput: {
+            tokenUsage: {
+              promptTokens: 10,
+              completionTokens: 20,
+              totalTokens: 30
+            }
+          }
+        };
+        await callback.handleLLMEnd(llmResult, runId);
+
+        expect(callback['_nodes'][runId].spanParams.numInputTokens).toBe(10);
+        expect(callback['_nodes'][runId].spanParams.numOutputTokens).toBe(20);
+        expect(callback['_nodes'][runId].spanParams.totalTokens).toBe(30);
+      });
+
+      it('test handleLLMEnd extracts snake_case token_usage', async () => {
+        const parentId = createId();
+        const runId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleLLMStart(undefined, ['prompt'], runId, parentId, {
+          invocation_params: { model_name: 'vertex-ai' }
+        });
+
+        const llmResult = {
+          generations: [[{ text: 'response', generationInfo: {} }]],
+          llmOutput: {
+            token_usage: {
+              prompt_tokens: 5,
+              completion_tokens: 15,
+              total_tokens: 20
+            }
+          }
+        } as unknown as LLMResult;
+        await callback.handleLLMEnd(llmResult, runId);
+
+        expect(callback['_nodes'][runId].spanParams.numInputTokens).toBe(5);
+        expect(callback['_nodes'][runId].spanParams.numOutputTokens).toBe(15);
+        expect(callback['_nodes'][runId].spanParams.totalTokens).toBe(20);
+      });
+
+      it('test handleLLMEnd falls back to usage_metadata on generation message', async () => {
+        const parentId = createId();
+        const runId = createId();
+
+        await callback.handleChainStart(
+          { name: 'chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          parentId
+        );
+        await callback.handleLLMStart(undefined, ['prompt'], runId, parentId, {
+          invocation_params: { model_name: 'claude-3' }
+        });
+
+        const llmResult = {
+          generations: [
+            [
+              {
+                text: 'response',
+                generationInfo: {},
+                message: {
+                  usage_metadata: {
+                    input_tokens: 8,
+                    output_tokens: 12,
+                    total_tokens: 20
+                  }
+                }
+              }
+            ]
+          ],
+          llmOutput: {}
+        } as unknown as LLMResult;
+        await callback.handleLLMEnd(llmResult, runId);
+
+        expect(callback['_nodes'][runId].spanParams.numInputTokens).toBe(8);
+        expect(callback['_nodes'][runId].spanParams.numOutputTokens).toBe(12);
+        expect(callback['_nodes'][runId].spanParams.totalTokens).toBe(20);
+      });
+    });
+
+    describe('statusCode tracking', () => {
+      it('test statusCode is 200 on successful chain end', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        await callback.handleChainEnd({ result: 'answer' }, runId);
+
+        const traces = callback._galileoLogger.traces;
+        expect(traces).toHaveLength(1);
+        const span = traces[0].spans[0] as WorkflowSpan;
+        expect(span.statusCode).toBe(200);
+      });
+
+      it('test statusCode reflects error response status from handleChainError', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        const error = Object.assign(new Error('Bad request'), {
+          response: { status: 422 }
+        });
+        await callback.handleChainError(error, runId);
+
+        const traces = callback._galileoLogger.traces;
+        expect(traces).toHaveLength(1);
+        const span = traces[0].spans[0] as WorkflowSpan;
+        expect(span.statusCode).toBe(422);
+      });
+
+      it('test statusCode defaults to 400 when error has no response', async () => {
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        const error = new Error('Connection refused');
+        await callback.handleChainError(error, runId);
+
+        const traces = callback._galileoLogger.traces;
+        expect(traces).toHaveLength(1);
+        const span = traces[0].spans[0] as WorkflowSpan;
+        expect(span.statusCode).toBe(400);
+      });
+    });
+
+    describe('tool_calls extraction in chat messages', () => {
+      it('test handleChatModelStart preserves tool_calls from AIMessage', async () => {
+        const chainRunId = createId();
+        const chatRunId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          chainRunId
+        );
+
+        const aiMsg = new AIMessage({
+          content: 'I will search for that.',
+          tool_calls: [
+            { name: 'search', args: { q: 'LangChain' }, id: 'call_123' }
+          ]
+        });
+
+        await callback.handleChatModelStart(
+          { name: 'gpt-4', lc: 1, type: 'secret', id: ['gpt-4'] } as Serialized,
+          [[aiMsg]],
+          chatRunId,
+          chainRunId
+        );
+
+        const node = callback['_nodes'][chatRunId];
+        const input = node.spanParams.input;
+        expect(input).toHaveLength(1);
+        expect(input[0].content).toBe('I will search for that.');
+        expect(input[0].role).toBe('ai');
+        expect(input[0].tool_calls).toEqual([
+          expect.objectContaining({
+            name: 'search',
+            args: { q: 'LangChain' },
+            id: 'call_123'
+          })
+        ]);
+      });
+
+      it('test handleChatModelStart omits tool_calls when empty', async () => {
+        const chainRunId = createId();
+        const chatRunId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          chainRunId
+        );
+
+        const humanMsg = new HumanMessage('Hello');
+
+        await callback.handleChatModelStart(
+          { name: 'gpt-4', lc: 1, type: 'secret', id: ['gpt-4'] } as Serialized,
+          [[humanMsg]],
+          chatRunId,
+          chainRunId
+        );
+
+        const node = callback['_nodes'][chatRunId];
+        const input = node.spanParams.input;
+        expect(input).toHaveLength(1);
+        expect(input[0].content).toBe('Hello');
+        expect(input[0].role).toBe('human');
+        expect(input[0].tool_calls).toBeUndefined();
+      });
+    });
+
+    describe('ingestionHook constructor', () => {
+      it('test ingestionHook is called on flush with trace request', async () => {
+        const hook = jest.fn().mockResolvedValue(undefined);
+        const hookCallback = new GalileoCallback(undefined, true, true, hook);
+
+        const runId = createId();
+        await hookCallback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+        await hookCallback.handleChainEnd({ result: 'answer' }, runId);
+
+        expect(hook).toHaveBeenCalledTimes(1);
+        expect(hook).toHaveBeenCalledWith(
+          expect.objectContaining({ traces: expect.any(Array) })
+        );
+      });
+    });
+
+    describe('try/finally cleanup', () => {
+      it('test nodes and rootNodeContext are cleared even when flush throws', async () => {
+        jest
+          .spyOn(galileoLogger, 'flush')
+          .mockRejectedValueOnce(new Error('flush failed'));
+
+        const flushCallback = new GalileoCallback(galileoLogger, true, true);
+
+        const runId = createId();
+        await flushCallback.handleChainStart(
+          {
+            name: 'TestChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId
+        );
+        // _commit() re-throws after finally; catch it to inspect state
+        try {
+          await flushCallback.handleChainEnd({ result: 'answer' }, runId);
+        } catch {
+          // expected
+        }
+
+        expect(flushCallback['_nodes']).toEqual({});
+        expect(rootNodeContext.get()).toBeNull();
+      });
+    });
+
+    describe('startTrace receives name and metadata', () => {
+      it('test startTrace is called with root node name and metadata', async () => {
+        const spy = jest.spyOn(galileoLogger, 'startTrace');
+
+        const runId = createId();
+        await callback.handleChainStart(
+          {
+            name: 'MyChainName',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId,
+          undefined,
+          undefined,
+          { session_id: 'abc123' }
+        );
+        await callback.handleChainEnd({ result: 'answer' }, runId);
+
+        expect(spy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'MyChainName',
+            metadata: { session_id: 'abc123' }
+          })
+        );
+      });
+    });
+
+    describe('PARITY-2: tool span with children (agent-as-tool)', () => {
+      it('test LLM child span is nested under tool span when tool has children', async () => {
+        const chainRunId = createId();
+        const toolRunId = createId();
+        const llmRunId = createId();
+
+        // Start root chain
+        await callback.handleChainStart(
+          {
+            name: 'RootChain',
+            lc: 1,
+            type: 'secret',
+            id: ['RootChain']
+          } as Serialized,
+          { query: 'test' },
+          chainRunId
+        );
+
+        // Start tool as child of chain
+        await callback.handleToolStart(
+          {
+            name: 'SearchTool',
+            lc: 1,
+            type: 'secret',
+            id: ['SearchTool']
+          } as Serialized,
+          'search query',
+          toolRunId,
+          chainRunId
+        );
+
+        // Start LLM as child of tool (agent-as-tool pattern)
+        await callback.handleChatModelStart(
+          { name: 'gpt-4', lc: 1, type: 'secret', id: ['gpt-4'] } as Serialized,
+          [[new HumanMessage('hello')]],
+          llmRunId,
+          toolRunId
+        );
+        await callback.handleLLMEnd(
+          {
+            generations: [[{ text: 'llm-response', generationInfo: {} }]]
+          } as LLMResult,
+          llmRunId
+        );
+
+        // End tool
+        await callback.handleToolEnd('tool-output', toolRunId);
+
+        // End root chain
+        await callback.handleChainEnd({ result: 'done' }, chainRunId);
+
+        const traces = callback._galileoLogger.traces;
+        expect(traces).toHaveLength(1);
+        const rootSpan = traces[0].spans[0] as WorkflowSpan;
+        expect(rootSpan.type).toBe(StepType.workflow);
+
+        // Tool span is child of root chain
+        expect(rootSpan.spans).toHaveLength(1);
+        const toolSpan = rootSpan.spans[0] as ToolSpan;
+        expect(toolSpan.type).toBe(StepType.tool);
+
+        // LLM span is nested under tool span
+        expect(toolSpan.spans).toHaveLength(1);
+        const llmSpan = toolSpan.spans[0] as LlmSpan;
+        expect(llmSpan.type).toBe(StepType.llm);
+      });
+    });
+
+    describe('langsmith:hidden tag', () => {
+      it('test handleChainStart skips node creation for langsmith:hidden tag', async () => {
+        const runId = createId();
+        await callback.handleChainStart(
+          {
+            name: 'HiddenChain',
+            lc: 1,
+            type: 'secret',
+            id: ['test']
+          } as Serialized,
+          { query: 'test' },
+          runId,
+          undefined,
+          ['langsmith:hidden']
+        );
+
+        expect(callback['_nodes'][runId]).toBeUndefined();
+      });
+    });
+
+    describe('chain input type branches', () => {
+      it('test handleChainStart wraps string input as object', async () => {
+        const runId = createId();
+        await callback.handleChainStart(
+          { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          'plain string input' as unknown as ChainValues,
+          runId
+        );
+
+        expect(callback['_nodes'][runId].spanParams.input).toEqual({
+          input: 'plain string input'
+        });
+      });
+
+      it('test handleChainStart passes BaseMessage through directly', async () => {
+        const runId = createId();
+        const msg = new HumanMessage('Hello from user');
+        await callback.handleChainStart(
+          { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          msg as unknown as ChainValues,
+          runId
+        );
+
+        expect(callback['_nodes'][runId].spanParams.input).toBe(msg);
+      });
+
+      it('test handleChainStart filters non-string values from object input', async () => {
+        const runId = createId();
+        await callback.handleChainStart(
+          { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test', count: 42, valid: 'value' },
+          runId
+        );
+
+        const input = callback['_nodes'][runId].spanParams.input as Record<
+          string,
+          unknown
+        >;
+        expect(input.query).toBe('test');
+        expect(input.valid).toBe('value');
+        expect(input.count).toBeUndefined();
+      });
+    });
+
+    describe('handleLLMNewToken timing', () => {
+      it('test timeToFirstTokenNs is set only on first token', async () => {
+        const chainRunId = createId();
+        const llmRunId = createId();
+
+        await callback.handleChainStart(
+          { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          chainRunId
+        );
+        await callback.handleLLMStart(
+          { name: 'llm', lc: 1, type: 'secret', id: ['llm'] } as Serialized,
+          ['prompt'],
+          llmRunId,
+          chainRunId
+        );
+
+        // First token sets the time
+        await callback.handleLLMNewToken(
+          'first',
+          { prompt: 0, completion: 0 },
+          llmRunId
+        );
+        const firstTokenTime =
+          callback['_nodes'][llmRunId].spanParams.timeToFirstTokenNs;
+        expect(firstTokenTime).toBeGreaterThan(0);
+
+        // Second token should NOT overwrite
+        await callback.handleLLMNewToken(
+          'second',
+          { prompt: 0, completion: 1 },
+          llmRunId
+        );
+        const secondTokenTime =
+          callback['_nodes'][llmRunId].spanParams.timeToFirstTokenNs;
+        expect(secondTokenTime).toBe(firstTokenTime);
+      });
+
+      it('test handleLLMNewToken silently ignores missing node', async () => {
+        // Should not throw for nonexistent runId
+        await expect(
+          callback.handleLLMNewToken(
+            'token',
+            { prompt: 0, completion: 0 },
+            'nonexistent-id'
+          )
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe('handleLLMEnd edge cases', () => {
+      it('test handleLLMEnd handles empty generations array', async () => {
+        const chainRunId = createId();
+        const llmRunId = createId();
+
+        await callback.handleChainStart(
+          { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          chainRunId
+        );
+        await callback.handleLLMStart(
+          { name: 'llm', lc: 1, type: 'secret', id: ['llm'] } as Serialized,
+          ['prompt'],
+          llmRunId,
+          chainRunId
+        );
+
+        const llmResult = {
+          generations: [],
+          llmOutput: {}
+        } as unknown as LLMResult;
+
+        // Should not throw
+        await expect(
+          callback.handleLLMEnd(llmResult, llmRunId)
+        ).resolves.toBeUndefined();
+      });
+    });
+
+    describe('error handler output format', () => {
+      it('test error output includes error name and message', async () => {
+        const runId = createId();
+        await callback.handleChainStart(
+          { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
+          { query: 'test' },
+          runId
+        );
+
+        const error = new TypeError('invalid argument');
+        await callback.handleChainError(error, runId);
+
+        const traces = callback._galileoLogger.traces;
+        expect(traces).toHaveLength(1);
+        const span = traces[0].spans[0] as WorkflowSpan;
+        expect(span.output).toBe('Error: TypeError: invalid argument');
       });
     });
   });

--- a/tests/utils/langchain.test.ts
+++ b/tests/utils/langchain.test.ts
@@ -166,7 +166,9 @@ describe('GalileoCallback', () => {
 
       expect(callback['_nodes'][runId]).toBeDefined();
       expect(callback['_nodes'][runId].nodeType).toBe('chain');
-      expect(callback['_nodes'][runId].spanParams.input).toEqual(inputs);
+      expect(callback['_nodes'][runId].spanParams.input).toEqual(
+        JSON.stringify(inputs)
+      );
 
       const outputs = { result: 'test answer' };
       await callback.handleChainEnd(outputs, runId);
@@ -195,7 +197,9 @@ describe('GalileoCallback', () => {
 
       expect(callback['_nodes'][runId]).toBeDefined();
       expect(callback['_nodes'][runId].nodeType).toBe('chain');
-      expect(callback['_nodes'][runId].spanParams.input).toEqual(inputs);
+      expect(callback['_nodes'][runId].spanParams.input).toEqual(
+        JSON.stringify(inputs)
+      );
 
       // Update inputs
       inputs = { query: 'test question' };
@@ -2157,7 +2161,7 @@ describe('GalileoCallback', () => {
         expect(callback['_nodes'][runId].spanParams.input).toBe(msg);
       });
 
-      it('test handleChainStart filters non-string values from object input', async () => {
+      it('test handleChainStart serializes all object input values', async () => {
         const runId = createId();
         await callback.handleChainStart(
           { name: 'Chain', lc: 1, type: 'secret', id: ['test'] } as Serialized,
@@ -2165,13 +2169,11 @@ describe('GalileoCallback', () => {
           runId
         );
 
-        const input = callback['_nodes'][runId].spanParams.input as Record<
-          string,
-          unknown
-        >;
-        expect(input.query).toBe('test');
-        expect(input.valid).toBe('value');
-        expect(input.count).toBeUndefined();
+        const input = callback['_nodes'][runId].spanParams.input as string;
+        const parsed = JSON.parse(input);
+        expect(parsed.query).toBe('test');
+        expect(parsed.valid).toBe('value');
+        expect(parsed.count).toBe(42);
       });
     });
 


### PR DESCRIPTION
# User description
# (TS SDK Parity Effort) Refactor - Langchain -  [sc-44819](https://app.shortcut.com/galileo/story/44819/ts-sdk-parity-effort-refactor-langchain)

## Description
* Refactored available and new features into the Langchain handler
* Tests and documentation

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
GalileoCallback_commit_("GalileoCallback._commit"):::added
logNodeTree_("logNodeTree"):::added
rootNodeContext_("rootNodeContext"):::added
GalileoCallback_startNode_("GalileoCallback._startNode"):::added
Node_("Node"):::added
GalileoCallback_endNode_("GalileoCallback._endNode"):::added
GalileoLogger_addAgentSpan_("GalileoLogger.addAgentSpan"):::modified
GalileoLogger_pushParent_("GalileoLogger.pushParent"):::added
GalileoCallback_commit_ -- "Logs collected _nodes spans, then concludes and flushes trace." --> logNodeTree_
GalileoCallback_commit_ -- "Retrieves root node from context before starting/logging trace." --> rootNodeContext_
GalileoCallback_startNode_ -- "Creates Node with timing defaults and links into _nodes tree." --> Node_
GalileoCallback_endNode_ -- "Checks root context; commits only when ending root run." --> rootNodeContext_
GalileoCallback_endNode_ -- "Triggers commit after root duration calculation and node updates." --> GalileoCallback_commit_
logNodeTree_ -- "Emits agent spans including statusCode and optional stepNumber." --> GalileoLogger_addAgentSpan_
logNodeTree_ -- "Nests tool child spans under tool parent via pushParent." --> GalileoLogger_pushParent_
logNodeTree_ -- "Reads Node spanParams/children to recursively emit corresponding spans." --> Node_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Describe the new LangChain handler refactor that now loads LangChain at runtime, guards optional peer dependencies, and logs richer metadata, tokens, steps, and status codes through the <code>GalileoCallback</code> pipeline while keeping nodes and spans consistent. Highlight the expanded tests/docs/deps so integrators know how to stitch peer installations, observe callbacks, and dependency metadata together.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/544?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>src/handlers/langchain.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(agents): Support ...</td><td>March 20, 2026</td></tr>
<tr><td>pratyusha@galileo.ai</td><td>feat: langchain handle...</td><td>June 26, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/544?tool=ast&topic=LangChain+handler>LangChain handler</a>
        </td><td>Summarize the LangChain handler refactor (including <code>GalileoCallback</code>, node/tree logging utilities, <code>logNodeTree</code>, logger/span types, <code>GalileoLogger</code>, <code>GalileoObserveCallback</code>, and the handler utils) to guard optional <code>@langchain/core</code> installs, accurately serialize LangChain inputs/outputs, compute durations/tokens/statuses, enable last-child/agent-as-tool nesting, and clear state even when traces fail so traces remain reliable regardless of LangChain availability.<details><summary>Modified files (8)</summary><ul><li>src/handlers/langchain/index.ts</li>
<li>src/handlers/langchain/node.ts</li>
<li>src/handlers/langchain/tree-logger.ts</li>
<li>src/handlers/langchain/utils.ts</li>
<li>src/observe/callback.ts</li>
<li>src/types/logging/logger.types.ts</li>
<li>src/types/logging/span.types.ts</li>
<li>src/utils/galileo-logger.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/544?tool=ast&topic=Docs+%26+deps>Docs & deps</a>
        </td><td>Explain the docs/dependency updates (package metadata plus README) that explain which optional peer packages power each integration path and align <code>package.json</code>/<code>package-lock.json</code> peer/optional dependency tables so consumers know what to install for LangChain/OpenAI support.<details><summary>Modified files (3)</summary><ul><li>README.md</li>
<li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>fix(auth): Removed dep...</td><td>April 10, 2026</td></tr>
<tr><td>quinn-galileo</td><td>chore: release 2.0.0 (...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/544?tool=ast&topic=LangChain+tests>LangChain tests</a>
        </td><td>Detail the expanded LangChain unit suites covering <code>GalileoCallback</code> behavior, node/context helpers, tree logging, and handler utilities to assert serialization, error handling, metadata-driven agent upgrades, tool outputs, token/status tracking, and parent/child nesting semantics.<details><summary>Modified files (4)</summary><ul><li>tests/handlers/langchain/callback.test.ts</li>
<li>tests/handlers/langchain/node.test.ts</li>
<li>tests/handlers/langchain/tree-logger.test.ts</li>
<li>tests/handlers/langchain/utils.test.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/544?tool=ast>(Baz)</a>.