### PR TITLE
feat: add OpenTelemetry tracing support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,10 @@
       "devDependencies": {
         "@hey-api/openapi-ts": "^0.88.0",
         "@langchain/core": "^0.3.13",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
+        "@opentelemetry/resources": "^1.25.0",
+        "@opentelemetry/sdk-trace-base": "^1.25.0",
         "@types/jest": "^29.5.14",
         "@types/jsonwebtoken": "^9.0.6",
         "@types/lodash": "^4.17.17",
@@ -52,6 +56,10 @@
         "@langchain/core": ">=0.3.13",
         "@langchain/openai": ">=0.3.11",
         "@openai/agents": ">=0.4.0",
+        "@opentelemetry/api": ">=1.4.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+        "@opentelemetry/resources": ">=1.15.0",
+        "@opentelemetry/sdk-trace-base": ">=1.15.0",
         "openai": ">=4.0.0"
       },
       "peerDependenciesMeta": {
@@ -62,6 +70,18 @@
           "optional": true
         },
         "@openai/agents": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
           "optional": true
         },
         "openai": {
@@ -634,7 +654,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.0.3.tgz",
       "integrity": "sha512-ZykIcDTVv5UNmKWSTLAs3VukO6NDJkkSKxrgUTDPBkAlORVT3H9n5DbRjRl8xIotklscHdbLIa0b9+y3mQq73g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1455,7 +1475,7 @@
       "version": "0.3.78",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
       "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -1555,6 +1575,415 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+      "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/api-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.52.1.tgz",
+      "integrity": "sha512-qnSqB2DQ9TPP96dl8cDubDvrUyWc0/sK81xHTK8eSUspzDM3bsewX903qclQFvVhgStjRWdC5bLb3kQqMkfV5A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/core": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.25.1.tgz",
+      "integrity": "sha512-GeT/l6rBYWVQ4XArluLVB6WWQ8flHbdb6r2FCHC3smtdOAbrJBIv35tpV/yp9bmYUJf+xmZpu9DRTIeJVhFbEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/exporter-trace-otlp-http/-/exporter-trace-otlp-http-0.52.1.tgz",
+      "integrity": "sha512-05HcNizx0BxcFKKnS5rwOV+2GevLTVIRA0tRgWYyw4yCgR53Ic/xk83toYKts7kbzcI+dswInUg/4s8oyA+tqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-exporter-base": "0.52.1",
+        "@opentelemetry/otlp-transformer": "0.52.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/exporter-trace-otlp-http/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-exporter-base": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-exporter-base/-/otlp-exporter-base-0.52.1.tgz",
+      "integrity": "sha512-z175NXOtX5ihdlshtYBe5RpGeBoTXVCKPPLiQlD6FHvpM4Ch+p2B0yWKYSrBfLH24H9zjJiBdTrtD+hLlfnXEQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/otlp-transformer": "0.52.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/otlp-transformer/-/otlp-transformer-0.52.1.tgz",
+      "integrity": "sha512-I88uCZSZZtVa0XniRqQWKbjAUm73I8tpEy/uJYPPYw5d7BRdVk0RfTBQw8kSUl01oVWEuqxLDa802222MYyWHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/sdk-logs": "0.52.1",
+        "@opentelemetry/sdk-metrics": "1.25.1",
+        "@opentelemetry/sdk-trace-base": "1.25.1",
+        "protobufjs": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/otlp-transformer/node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.25.1.tgz",
+      "integrity": "sha512-C8k4hnEbc5FamuZQ92nTOp8X/diCY56XUTnMiv9UTuJitCzaNNHAVsdm5+HLCdI8SLQsLWIrG38tddMxLVoftw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.30.1.tgz",
+      "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/resources/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs": {
+      "version": "0.52.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-logs/-/sdk-logs-0.52.1.tgz",
+      "integrity": "sha512-MBYh+WcPPsN8YpRHRmK1Hsca9pVlyyKd4BxOC4SsgHACnl/bPp4Cri9hWhVm5+2tiQ9Zf4qSc1Jshw9tOLGWQA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/api-logs": "0.52.1",
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.4.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-logs/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-metrics/-/sdk-metrics-1.25.1.tgz",
+      "integrity": "sha512-9Mb7q5ioFL4E4dDrc4wC/A3NTHDat44v4I3p2pLPSxRvqUbDIQyMVr9uK+EU69+HWhlET1VaSrRzwdckWqY15Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/resources": "1.25.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-metrics/node_modules/@opentelemetry/resources": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-1.25.1.tgz",
+      "integrity": "sha512-pkZT+iFYIZsVn6+GzM0kSX+u3MSLCY9md+lIJOoKl/P+gJFfxJte/60Usdp8Ce4rOs8GduUpSPNe1ddGyDT1sQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.25.1",
+        "@opentelemetry/semantic-conventions": "1.25.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-1.30.1.tgz",
+      "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "1.30.1",
+        "@opentelemetry/resources": "1.30.1",
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/core": {
+      "version": "1.30.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-1.30.1.tgz",
+      "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/semantic-conventions": "1.28.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.0.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace-base/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.28.0.tgz",
+      "integrity": "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.25.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.25.1.tgz",
+      "integrity": "sha512-ZDjMJJQRlyk8A1KZFCc+bCbsyrn1wTwdNt56F7twdfUfnHUZUq77/WfONCj8p72NZOyP7pNTdUWSTYC3GTbuuQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@redocly/ajv": {
       "version": "8.11.2",
@@ -1866,7 +2295,7 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1927,7 +2356,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2156,7 +2585,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -2202,7 +2631,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -2287,7 +2716,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2644,7 +3073,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2895,7 +3324,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2929,7 +3358,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2946,7 +3375,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3080,7 +3509,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3093,7 +3522,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -3159,7 +3588,7 @@
       "version": "2.14.6",
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
       "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "simple-wcswidth": "^1.0.1"
@@ -3295,7 +3724,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4231,7 +4660,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4241,7 +4670,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -4551,14 +4980,14 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-domexception": "1.0.0",
@@ -4940,7 +5369,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5056,7 +5485,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -6435,7 +6864,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.15.tgz",
       "integrity": "sha512-65ruOWWXDEZHHbAo7EjOcNxOGasQKbL4Fq3jEr2xsCqSsoOo6VVSqzWQb6PRIqypFSDcma4jO90YP0w5X8qVXQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1"
@@ -6596,7 +7025,7 @@
       "version": "0.3.74",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.74.tgz",
       "integrity": "sha512-ZuW3Qawz8w88XcuCRH91yTp6lsdGuwzRqZ5J0Hf5q/AjMz7DwcSv0MkE6V5W+8hFMI850QZN2Wlxwm3R9lHlZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
@@ -6753,6 +7182,13 @@
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
       "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6994,7 +7430,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
@@ -7022,7 +7458,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7042,7 +7478,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -7271,7 +7707,7 @@
       "version": "4.104.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -7302,7 +7738,7 @@
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7312,7 +7748,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/openapi-fetch": {
@@ -7424,7 +7860,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7466,7 +7902,7 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.4",
@@ -7496,7 +7932,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-finally": "^1.0.0"
@@ -7889,6 +8325,31 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/proxy-from-env": {
@@ -8438,7 +8899,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sisteransi": {
@@ -8706,7 +9167,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8974,7 +9435,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -9369,7 +9830,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9408,7 +9869,7 @@
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -9418,7 +9879,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webworker-shim": {
@@ -9432,7 +9893,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -9781,7 +10242,7 @@
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
       "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@opentelemetry/api": ">=1.4.0",
     "@opentelemetry/sdk-trace-base": ">=1.15.0",
     "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+    "@opentelemetry/exporter-trace-otlp-proto": ">=0.41.0",
     "@opentelemetry/resources": ">=1.15.0",
     "openai": ">=4.0.0"
   },
@@ -74,6 +75,9 @@
       "optional": true
     },
     "@opentelemetry/exporter-trace-otlp-http": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-trace-otlp-proto": {
       "optional": true
     },
     "@opentelemetry/resources": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,10 @@
     "@langchain/core": ">=0.3.13",
     "@langchain/openai": ">=0.3.11",
     "@openai/agents": ">=0.4.0",
+    "@opentelemetry/api": ">=1.4.0",
+    "@opentelemetry/sdk-trace-base": ">=1.15.0",
+    "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+    "@opentelemetry/resources": ">=1.15.0",
     "openai": ">=4.0.0"
   },
   "peerDependenciesMeta": {
@@ -63,6 +67,18 @@
     "@openai/agents": {
       "optional": true
     },
+    "@opentelemetry/api": {
+      "optional": true
+    },
+    "@opentelemetry/sdk-trace-base": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-trace-otlp-http": {
+      "optional": true
+    },
+    "@opentelemetry/resources": {
+      "optional": true
+    },
     "openai": {
       "optional": true
     }
@@ -70,6 +86,10 @@
   "devDependencies": {
     "@hey-api/openapi-ts": "^0.88.0",
     "@langchain/core": "^0.3.13",
+    "@opentelemetry/api": "^1.9.0",
+    "@opentelemetry/sdk-trace-base": "^1.25.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
+    "@opentelemetry/resources": "^1.25.0",
     "@types/jest": "^29.5.14",
     "@types/jsonwebtoken": "^9.0.6",
     "@types/lodash": "^4.17.17",

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -31,8 +31,9 @@ const sdkLogger = getSdkLogger();
 export class GalileoOTLPExporter implements SpanExporterLike {
   private _innerExporter: SpanExporterLike;
   private _headers: Record<string, string>;
-  private _ResourceClass: (new (attrs: Record<string, unknown>) => unknown) | null =
-    null;
+  private _ResourceClass:
+    | (new (attrs: Record<string, unknown>) => unknown)
+    | null = null;
 
   readonly project: string;
   readonly logstream: string;
@@ -42,8 +43,7 @@ export class GalileoOTLPExporter implements SpanExporterLike {
     // (handles consoleUrl→apiUrl rewriting, env var fallbacks, etc.)
     const galileoConfig = GalileoConfig.get();
     const apiUrl = config?.apiUrl ?? galileoConfig.getApiUrl();
-    const apiKey =
-      config?.apiKey ?? galileoConfig.getAuthCredentials().apiKey;
+    const apiKey = config?.apiKey ?? galileoConfig.getAuthCredentials().apiKey;
 
     if (!apiKey) {
       throw new Error(
@@ -51,8 +51,7 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       );
     }
 
-    this.project =
-      config?.project ?? galileoConfig.projectName ?? 'default';
+    this.project = config?.project ?? galileoConfig.projectName ?? 'default';
     this.logstream =
       config?.logstream ?? galileoConfig.logStreamName ?? 'default';
 

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -30,7 +30,6 @@ const sdkLogger = getSdkLogger();
  */
 export class GalileoOTLPExporter implements SpanExporterLike {
   private _innerExporter: SpanExporterLike;
-  private _headers: Record<string, string>;
   private _ResourceClass:
     | (new (attrs: Record<string, unknown>) => unknown)
     | null = null;
@@ -39,8 +38,6 @@ export class GalileoOTLPExporter implements SpanExporterLike {
   readonly logstream: string;
 
   constructor(config?: GalileoOTLPExporterConfig) {
-    // Use GalileoConfig singleton for consistent URL/credential resolution
-    // (handles consoleUrl→apiUrl rewriting, env var fallbacks, etc.)
     const galileoConfig = GalileoConfig.get();
     const apiUrl = config?.apiUrl ?? galileoConfig.getApiUrl();
     const apiKey = config?.apiKey ?? galileoConfig.getAuthCredentials().apiKey;
@@ -56,11 +53,6 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       config?.logstream ?? galileoConfig.logStreamName ?? 'default';
 
     const endpoint = `${apiUrl.replace(/\/$/, '')}/otel/traces`;
-    this._headers = {
-      'Galileo-API-Key': apiKey,
-      project: this.project,
-      logstream: this.logstream
-    };
 
     let OTLPTraceExporter: new (
       config: Record<string, unknown>
@@ -76,7 +68,6 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       );
     }
 
-    // Cache Resource class at construction time, not per-export
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const resourcesMod = require('@opentelemetry/resources');
@@ -90,7 +81,11 @@ export class GalileoOTLPExporter implements SpanExporterLike {
 
     this._innerExporter = new OTLPTraceExporter({
       url: endpoint,
-      headers: this._headers
+      headers: {
+        'Galileo-API-Key': apiKey,
+        project: this.project,
+        logstream: this.logstream
+      }
     });
   }
 
@@ -168,6 +163,7 @@ export class GalileoOTLPExporter implements SpanExporterLike {
           const newResource = span.resource.merge(
             new this._ResourceClass(resourceAttrs)
           );
+          // _resource is an internal property on OTel SDK's Span (verified against @opentelemetry/sdk-trace-base ^1.x)
           if ('_resource' in span) {
             (span as { _resource?: unknown })._resource = newResource;
           }
@@ -177,7 +173,6 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       }
     }
 
-    // Update headers for this batch
     if (spans.length > 0) {
       const lastSpan = spans[spans.length - 1];
       const batchProject = lastSpan.attributes[
@@ -187,17 +182,25 @@ export class GalileoOTLPExporter implements SpanExporterLike {
         GALILEO_ATTRIBUTES.LOGSTREAM_NAME
       ] as string | undefined;
 
-      if (batchProject) this._headers['project'] = batchProject;
-      if (batchLogstream) this._headers['logstream'] = batchLogstream;
+      const innerHeaders = (
+        this._innerExporter as unknown as {
+          headers: Record<string, string>;
+        }
+      ).headers;
+
+      if (batchProject) innerHeaders['project'] = batchProject;
 
       if (isExperiment) {
         const experimentId = lastSpan.attributes[
           GALILEO_ATTRIBUTES.EXPERIMENT_ID
         ] as string | undefined;
         if (experimentId) {
-          this._headers['experimentid'] = experimentId;
+          innerHeaders['experimentid'] = experimentId;
         }
-        delete this._headers['logstream'];
+        delete innerHeaders['logstream'];
+      } else {
+        if (batchLogstream) innerHeaders['logstream'] = batchLogstream;
+        delete innerHeaders['experimentid'];
       }
     }
 

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -1,0 +1,215 @@
+import type {
+  GalileoOTLPExporterConfig,
+  ReadableSpanLike,
+  ExportResultLike,
+  SpanExporterLike
+} from './types';
+import { GALILEO_ATTRIBUTES } from './types';
+import { GalileoConfig, getSdkLogger } from 'galileo-generated';
+
+const sdkLogger = getSdkLogger();
+
+/**
+ * OpenTelemetry OTLP span exporter preconfigured for Galileo platform integration.
+ *
+ * This exporter wraps the standard OTLPTraceExporter with Galileo-specific
+ * configuration and authentication. It injects Galileo resource attributes
+ * and updates HTTP headers per export batch.
+ *
+ * For most applications, use GalileoSpanProcessor instead, which provides
+ * a complete tracing solution including this exporter.
+ *
+ * @example
+ * ```typescript
+ * import { GalileoOTLPExporter } from 'galileo';
+ * import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+ *
+ * const exporter = new GalileoOTLPExporter({ project: 'my-project' });
+ * const processor = new BatchSpanProcessor(exporter);
+ * ```
+ */
+export class GalileoOTLPExporter implements SpanExporterLike {
+  private _innerExporter: SpanExporterLike;
+  private _headers: Record<string, string>;
+  private _ResourceClass: (new (attrs: Record<string, unknown>) => unknown) | null =
+    null;
+
+  readonly project: string;
+  readonly logstream: string;
+
+  constructor(config?: GalileoOTLPExporterConfig) {
+    // Use GalileoConfig singleton for consistent URL/credential resolution
+    // (handles consoleUrl→apiUrl rewriting, env var fallbacks, etc.)
+    const galileoConfig = GalileoConfig.get();
+    const apiUrl = config?.apiUrl ?? galileoConfig.getApiUrl();
+    const apiKey =
+      config?.apiKey ?? galileoConfig.getAuthCredentials().apiKey;
+
+    if (!apiKey) {
+      throw new Error(
+        'Galileo API key is required. Set GALILEO_API_KEY environment variable or pass apiKey in config.'
+      );
+    }
+
+    this.project =
+      config?.project ?? galileoConfig.projectName ?? 'default';
+    this.logstream =
+      config?.logstream ?? galileoConfig.logStreamName ?? 'default';
+
+    const endpoint = `${apiUrl.replace(/\/$/, '')}/otel/traces`;
+    this._headers = {
+      'Galileo-API-Key': apiKey,
+      project: this.project,
+      logstream: this.logstream
+    };
+
+    let OTLPTraceExporter: new (
+      config: Record<string, unknown>
+    ) => SpanExporterLike;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('@opentelemetry/exporter-trace-otlp-http');
+      OTLPTraceExporter = mod.OTLPTraceExporter;
+    } catch {
+      throw new Error(
+        '@opentelemetry/exporter-trace-otlp-http is not installed. ' +
+          'Install it with: npm install @opentelemetry/exporter-trace-otlp-http'
+      );
+    }
+
+    // Cache Resource class at construction time, not per-export
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const resourcesMod = require('@opentelemetry/resources');
+      this._ResourceClass = resourcesMod.Resource ?? null;
+    } catch {
+      sdkLogger.warn(
+        '@opentelemetry/resources is not installed. ' +
+          'Resource attributes will not be merged onto exported spans.'
+      );
+    }
+
+    this._innerExporter = new OTLPTraceExporter({
+      url: endpoint,
+      headers: this._headers
+    });
+  }
+
+  /**
+   * Export spans to Galileo, injecting resource attributes from span attributes.
+   *
+   * For each span, reads galileo.* attributes (set by GalileoSpanProcessor.onStart)
+   * and merges them into the span's resource. Also updates HTTP headers per batch.
+   */
+  export(
+    spans: ReadableSpanLike[],
+    resultCallback: (result: ExportResultLike) => void
+  ): void {
+    let isExperiment = false;
+
+    for (const span of spans) {
+      const attrs = span.attributes;
+      const project = attrs[GALILEO_ATTRIBUTES.PROJECT_NAME] as
+        | string
+        | undefined;
+      const logstream = attrs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME] as
+        | string
+        | undefined;
+      const sessionId = attrs[GALILEO_ATTRIBUTES.SESSION_ID] as
+        | string
+        | undefined;
+      const experimentId = attrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID] as
+        | string
+        | undefined;
+      const datasetInput = attrs[GALILEO_ATTRIBUTES.DATASET_INPUT] as
+        | string
+        | undefined;
+      const datasetOutput = attrs[GALILEO_ATTRIBUTES.DATASET_OUTPUT] as
+        | string
+        | undefined;
+      const datasetMetadata = attrs[GALILEO_ATTRIBUTES.DATASET_METADATA] as
+        | string
+        | undefined;
+
+      const resourceAttrs: Record<string, string> = {};
+      let hasResourceAttrs = false;
+
+      if (project) {
+        resourceAttrs[GALILEO_ATTRIBUTES.PROJECT_NAME] = project;
+        hasResourceAttrs = true;
+      }
+      if (logstream && !experimentId) {
+        resourceAttrs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME] = logstream;
+        hasResourceAttrs = true;
+      }
+      if (sessionId) {
+        resourceAttrs[GALILEO_ATTRIBUTES.SESSION_ID] = sessionId;
+        hasResourceAttrs = true;
+      }
+      if (experimentId) {
+        resourceAttrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID] = experimentId;
+        isExperiment = true;
+        hasResourceAttrs = true;
+      }
+      if (datasetInput) {
+        resourceAttrs[GALILEO_ATTRIBUTES.DATASET_INPUT] = datasetInput;
+        hasResourceAttrs = true;
+      }
+      if (datasetOutput) {
+        resourceAttrs[GALILEO_ATTRIBUTES.DATASET_OUTPUT] = datasetOutput;
+        hasResourceAttrs = true;
+      }
+      if (datasetMetadata) {
+        resourceAttrs[GALILEO_ATTRIBUTES.DATASET_METADATA] = datasetMetadata;
+        hasResourceAttrs = true;
+      }
+
+      if (hasResourceAttrs && this._ResourceClass) {
+        try {
+          const newResource = span.resource.merge(
+            new this._ResourceClass(resourceAttrs)
+          );
+          if ('_resource' in span) {
+            (span as { _resource?: unknown })._resource = newResource;
+          }
+        } catch (err) {
+          sdkLogger.warn('Failed to merge resource attributes:', err);
+        }
+      }
+    }
+
+    // Update headers for this batch
+    if (spans.length > 0) {
+      const lastSpan = spans[spans.length - 1];
+      const batchProject = lastSpan.attributes[
+        GALILEO_ATTRIBUTES.PROJECT_NAME
+      ] as string | undefined;
+      const batchLogstream = lastSpan.attributes[
+        GALILEO_ATTRIBUTES.LOGSTREAM_NAME
+      ] as string | undefined;
+
+      if (batchProject) this._headers['project'] = batchProject;
+      if (batchLogstream) this._headers['logstream'] = batchLogstream;
+
+      if (isExperiment) {
+        const experimentId = lastSpan.attributes[
+          GALILEO_ATTRIBUTES.EXPERIMENT_ID
+        ] as string | undefined;
+        if (experimentId) {
+          this._headers['experimentid'] = experimentId;
+        }
+        delete this._headers['logstream'];
+      }
+    }
+
+    this._innerExporter.export(spans, resultCallback);
+  }
+
+  async shutdown(): Promise<void> {
+    return this._innerExporter.shutdown();
+  }
+
+  async forceFlush(): Promise<void> {
+    return this._innerExporter.forceFlush?.();
+  }
+}

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -59,13 +59,19 @@ export class GalileoOTLPExporter implements SpanExporterLike {
     ) => SpanExporterLike;
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const mod = require('@opentelemetry/exporter-trace-otlp-http');
+      const mod = require('@opentelemetry/exporter-trace-otlp-proto');
       OTLPTraceExporter = mod.OTLPTraceExporter;
     } catch {
-      throw new Error(
-        '@opentelemetry/exporter-trace-otlp-http is not installed. ' +
-          'Install it with: npm install @opentelemetry/exporter-trace-otlp-http'
-      );
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        const mod = require('@opentelemetry/exporter-trace-otlp-http');
+        OTLPTraceExporter = mod.OTLPTraceExporter;
+      } catch {
+        throw new Error(
+          '@opentelemetry/exporter-trace-otlp-proto (or @opentelemetry/exporter-trace-otlp-http) is not installed. ' +
+            'Install it with: npm install @opentelemetry/exporter-trace-otlp-proto'
+        );
+      }
     }
 
     try {
@@ -99,31 +105,34 @@ export class GalileoOTLPExporter implements SpanExporterLike {
     spans: ReadableSpanLike[],
     resultCallback: (result: ExportResultLike) => void
   ): void {
-    let isExperiment = false;
+    let batchExperimentId: string | undefined;
 
     for (const span of spans) {
       const attrs = span.attributes;
-      const project = attrs[GALILEO_ATTRIBUTES.PROJECT_NAME] as
-        | string
-        | undefined;
-      const logstream = attrs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME] as
-        | string
-        | undefined;
-      const sessionId = attrs[GALILEO_ATTRIBUTES.SESSION_ID] as
-        | string
-        | undefined;
-      const experimentId = attrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID] as
-        | string
-        | undefined;
-      const datasetInput = attrs[GALILEO_ATTRIBUTES.DATASET_INPUT] as
-        | string
-        | undefined;
-      const datasetOutput = attrs[GALILEO_ATTRIBUTES.DATASET_OUTPUT] as
-        | string
-        | undefined;
-      const datasetMetadata = attrs[GALILEO_ATTRIBUTES.DATASET_METADATA] as
-        | string
-        | undefined;
+      const rawProject = attrs[GALILEO_ATTRIBUTES.PROJECT_NAME];
+      const project = typeof rawProject === 'string' ? rawProject : undefined;
+      const rawLogstream = attrs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME];
+      const logstream =
+        typeof rawLogstream === 'string' ? rawLogstream : undefined;
+      const rawSessionId = attrs[GALILEO_ATTRIBUTES.SESSION_ID];
+      const sessionId =
+        typeof rawSessionId === 'string' ? rawSessionId : undefined;
+      const rawExperimentId = attrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID];
+      const experimentId =
+        typeof rawExperimentId === 'string' ? rawExperimentId : undefined;
+      const rawDatasetInput = attrs[GALILEO_ATTRIBUTES.DATASET_INPUT];
+      const datasetInput =
+        typeof rawDatasetInput === 'string' ? rawDatasetInput : undefined;
+      const rawDatasetOutput = attrs[GALILEO_ATTRIBUTES.DATASET_OUTPUT];
+      const datasetOutput =
+        typeof rawDatasetOutput === 'string' ? rawDatasetOutput : undefined;
+      const rawDatasetMetadata = attrs[GALILEO_ATTRIBUTES.DATASET_METADATA];
+      const datasetMetadata =
+        typeof rawDatasetMetadata === 'string' ? rawDatasetMetadata : undefined;
+
+      if (experimentId) {
+        batchExperimentId = experimentId;
+      }
 
       const resourceAttrs: Record<string, string> = {};
       let hasResourceAttrs = false;
@@ -142,7 +151,6 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       }
       if (experimentId) {
         resourceAttrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID] = experimentId;
-        isExperiment = true;
         hasResourceAttrs = true;
       }
       if (datasetInput) {
@@ -163,9 +171,9 @@ export class GalileoOTLPExporter implements SpanExporterLike {
           const newResource = span.resource.merge(
             new this._ResourceClass(resourceAttrs)
           );
-          // _resource is an internal property on OTel SDK's Span (verified against @opentelemetry/sdk-trace-base ^1.x)
-          if ('_resource' in span) {
-            (span as { _resource?: unknown })._resource = newResource;
+          // OTel SDK's Span exposes `resource` as a public property in the TS API (verified against @opentelemetry/sdk-trace-base ^1.x)
+          if ('resource' in span) {
+            (span as { resource?: unknown }).resource = newResource;
           }
         } catch (err) {
           sdkLogger.warn('Failed to merge resource attributes:', err);
@@ -175,12 +183,14 @@ export class GalileoOTLPExporter implements SpanExporterLike {
 
     if (spans.length > 0) {
       const lastSpan = spans[spans.length - 1];
-      const batchProject = lastSpan.attributes[
-        GALILEO_ATTRIBUTES.PROJECT_NAME
-      ] as string | undefined;
-      const batchLogstream = lastSpan.attributes[
-        GALILEO_ATTRIBUTES.LOGSTREAM_NAME
-      ] as string | undefined;
+      const rawBatchProject =
+        lastSpan.attributes[GALILEO_ATTRIBUTES.PROJECT_NAME];
+      const batchProject =
+        typeof rawBatchProject === 'string' ? rawBatchProject : undefined;
+      const rawBatchLogstream =
+        lastSpan.attributes[GALILEO_ATTRIBUTES.LOGSTREAM_NAME];
+      const batchLogstream =
+        typeof rawBatchLogstream === 'string' ? rawBatchLogstream : undefined;
 
       const innerHeaders = (
         this._innerExporter as unknown as {
@@ -188,18 +198,13 @@ export class GalileoOTLPExporter implements SpanExporterLike {
         }
       ).headers;
 
-      if (batchProject) innerHeaders['project'] = batchProject;
+      innerHeaders['project'] = batchProject ?? this.project;
 
-      if (isExperiment) {
-        const experimentId = lastSpan.attributes[
-          GALILEO_ATTRIBUTES.EXPERIMENT_ID
-        ] as string | undefined;
-        if (experimentId) {
-          innerHeaders['experimentid'] = experimentId;
-        }
+      if (batchExperimentId) {
+        innerHeaders['experimentid'] = batchExperimentId;
         delete innerHeaders['logstream'];
       } else {
-        if (batchLogstream) innerHeaders['logstream'] = batchLogstream;
+        innerHeaders['logstream'] = batchLogstream ?? this.logstream;
         delete innerHeaders['experimentid'];
       }
     }

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -9,6 +9,14 @@ import { GalileoConfig, getSdkLogger } from 'galileo-generated';
 
 const sdkLogger = getSdkLogger();
 
+function strAttr(
+  attrs: Record<string, unknown>,
+  key: string
+): string | undefined {
+  const v = attrs[key];
+  return typeof v === 'string' ? v : undefined;
+}
+
 /**
  * OpenTelemetry OTLP span exporter preconfigured for Galileo platform integration.
  *
@@ -106,75 +114,45 @@ export class GalileoOTLPExporter implements SpanExporterLike {
     resultCallback: (result: ExportResultLike) => void
   ): void {
     let batchExperimentId: string | undefined;
+    let batchProject: string | undefined;
+    let batchLogstream: string | undefined;
 
     for (const span of spans) {
       const attrs = span.attributes;
-      const rawProject = attrs[GALILEO_ATTRIBUTES.PROJECT_NAME];
-      const project = typeof rawProject === 'string' ? rawProject : undefined;
-      const rawLogstream = attrs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME];
-      const logstream =
-        typeof rawLogstream === 'string' ? rawLogstream : undefined;
-      const rawSessionId = attrs[GALILEO_ATTRIBUTES.SESSION_ID];
-      const sessionId =
-        typeof rawSessionId === 'string' ? rawSessionId : undefined;
-      const rawExperimentId = attrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID];
-      const experimentId =
-        typeof rawExperimentId === 'string' ? rawExperimentId : undefined;
-      const rawDatasetInput = attrs[GALILEO_ATTRIBUTES.DATASET_INPUT];
-      const datasetInput =
-        typeof rawDatasetInput === 'string' ? rawDatasetInput : undefined;
-      const rawDatasetOutput = attrs[GALILEO_ATTRIBUTES.DATASET_OUTPUT];
-      const datasetOutput =
-        typeof rawDatasetOutput === 'string' ? rawDatasetOutput : undefined;
-      const rawDatasetMetadata = attrs[GALILEO_ATTRIBUTES.DATASET_METADATA];
-      const datasetMetadata =
-        typeof rawDatasetMetadata === 'string' ? rawDatasetMetadata : undefined;
+      const project = strAttr(attrs, GALILEO_ATTRIBUTES.PROJECT_NAME);
+      const logstream = strAttr(attrs, GALILEO_ATTRIBUTES.LOGSTREAM_NAME);
+      const sessionId = strAttr(attrs, GALILEO_ATTRIBUTES.SESSION_ID);
+      const experimentId = strAttr(attrs, GALILEO_ATTRIBUTES.EXPERIMENT_ID);
+      const datasetInput = strAttr(attrs, GALILEO_ATTRIBUTES.DATASET_INPUT);
+      const datasetOutput = strAttr(attrs, GALILEO_ATTRIBUTES.DATASET_OUTPUT);
+      const datasetMetadata = strAttr(
+        attrs,
+        GALILEO_ATTRIBUTES.DATASET_METADATA
+      );
 
-      if (experimentId) {
-        batchExperimentId = experimentId;
-      }
+      if (experimentId) batchExperimentId = experimentId;
+      batchProject = project ?? batchProject;
+      batchLogstream = logstream ?? batchLogstream;
 
       const resourceAttrs: Record<string, string> = {};
-      let hasResourceAttrs = false;
-
-      if (project) {
-        resourceAttrs[GALILEO_ATTRIBUTES.PROJECT_NAME] = project;
-        hasResourceAttrs = true;
-      }
-      if (logstream && !experimentId) {
+      if (project) resourceAttrs[GALILEO_ATTRIBUTES.PROJECT_NAME] = project;
+      if (logstream && !experimentId)
         resourceAttrs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME] = logstream;
-        hasResourceAttrs = true;
-      }
-      if (sessionId) {
-        resourceAttrs[GALILEO_ATTRIBUTES.SESSION_ID] = sessionId;
-        hasResourceAttrs = true;
-      }
-      if (experimentId) {
+      if (sessionId) resourceAttrs[GALILEO_ATTRIBUTES.SESSION_ID] = sessionId;
+      if (experimentId)
         resourceAttrs[GALILEO_ATTRIBUTES.EXPERIMENT_ID] = experimentId;
-        hasResourceAttrs = true;
-      }
-      if (datasetInput) {
+      if (datasetInput)
         resourceAttrs[GALILEO_ATTRIBUTES.DATASET_INPUT] = datasetInput;
-        hasResourceAttrs = true;
-      }
-      if (datasetOutput) {
+      if (datasetOutput)
         resourceAttrs[GALILEO_ATTRIBUTES.DATASET_OUTPUT] = datasetOutput;
-        hasResourceAttrs = true;
-      }
-      if (datasetMetadata) {
+      if (datasetMetadata)
         resourceAttrs[GALILEO_ATTRIBUTES.DATASET_METADATA] = datasetMetadata;
-        hasResourceAttrs = true;
-      }
 
-      if (hasResourceAttrs && this._ResourceClass) {
+      if (Object.keys(resourceAttrs).length > 0 && this._ResourceClass) {
         try {
-          const newResource = span.resource.merge(
+          (span as { resource: unknown }).resource = span.resource.merge(
             new this._ResourceClass(resourceAttrs)
           );
-          // OTel SDK's Span exposes `resource` as a public property in the TS API (verified against @opentelemetry/sdk-trace-base ^1.x)
-          if ('resource' in span) {
-            (span as { resource?: unknown }).resource = newResource;
-          }
         } catch (err) {
           sdkLogger.warn('Failed to merge resource attributes:', err);
         }
@@ -182,16 +160,6 @@ export class GalileoOTLPExporter implements SpanExporterLike {
     }
 
     if (spans.length > 0) {
-      const lastSpan = spans[spans.length - 1];
-      const rawBatchProject =
-        lastSpan.attributes[GALILEO_ATTRIBUTES.PROJECT_NAME];
-      const batchProject =
-        typeof rawBatchProject === 'string' ? rawBatchProject : undefined;
-      const rawBatchLogstream =
-        lastSpan.attributes[GALILEO_ATTRIBUTES.LOGSTREAM_NAME];
-      const batchLogstream =
-        typeof rawBatchLogstream === 'string' ? rawBatchLogstream : undefined;
-
       const innerHeaders = (
         this._innerExporter as unknown as {
           headers: Record<string, string>;

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -166,14 +166,24 @@ export class GalileoOTLPExporter implements SpanExporterLike {
         }
       ).headers;
 
-      innerHeaders['project'] = batchProject ?? this.project;
+      if (
+        innerHeaders &&
+        typeof innerHeaders === 'object' &&
+        !Object.isFrozen(innerHeaders)
+      ) {
+        innerHeaders['project'] = batchProject ?? this.project;
 
-      if (batchExperimentId) {
-        innerHeaders['experimentid'] = batchExperimentId;
-        delete innerHeaders['logstream'];
+        if (batchExperimentId) {
+          innerHeaders['experimentid'] = batchExperimentId;
+          delete innerHeaders['logstream'];
+        } else {
+          innerHeaders['logstream'] = batchLogstream ?? this.logstream;
+          delete innerHeaders['experimentid'];
+        }
       } else {
-        innerHeaders['logstream'] = batchLogstream ?? this.logstream;
-        delete innerHeaders['experimentid'];
+        sdkLogger.warn(
+          'Could not update inner exporter headers — the OTLPTraceExporter implementation may have changed.'
+        );
       }
     }
 

--- a/src/handlers/otel/index.ts
+++ b/src/handlers/otel/index.ts
@@ -1,0 +1,30 @@
+import type { GalileoSpanProcessor } from './processor';
+
+export { GalileoSpanProcessor } from './processor';
+export { GalileoOTLPExporter } from './exporter';
+export type {
+  GalileoSpanProcessorConfig,
+  GalileoOTLPExporterConfig
+} from './types';
+export { GALILEO_ATTRIBUTES } from './types';
+
+/**
+ * Add a GalileoSpanProcessor to an OpenTelemetry TracerProvider.
+ *
+ * @example
+ * ```typescript
+ * import { addGalileoSpanProcessor, GalileoSpanProcessor } from 'galileo';
+ * import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+ *
+ * const provider = new NodeTracerProvider();
+ * const processor = new GalileoSpanProcessor({ project: 'my-project' });
+ * addGalileoSpanProcessor(provider, processor);
+ * provider.register();
+ * ```
+ */
+export function addGalileoSpanProcessor(
+  tracerProvider: { addSpanProcessor(processor: unknown): void },
+  processor: GalileoSpanProcessor
+): void {
+  tracerProvider.addSpanProcessor(processor);
+}

--- a/src/handlers/otel/processor.ts
+++ b/src/handlers/otel/processor.ts
@@ -1,0 +1,128 @@
+import { experimentContext } from '../../singleton';
+import { GalileoOTLPExporter } from './exporter';
+import type { GalileoSpanProcessorConfig } from './types';
+import type {
+  SpanLike,
+  ReadableSpanLike,
+  ContextLike,
+  SpanProcessorLike
+} from './types';
+import { GALILEO_ATTRIBUTES } from './types';
+import { getSdkLogger } from 'galileo-generated';
+
+const sdkLogger = getSdkLogger();
+
+/**
+ * Complete OpenTelemetry span processor with integrated Galileo export functionality.
+ *
+ * This processor combines span processing and export capabilities into a single
+ * component that can be directly attached to any OpenTelemetry TracerProvider.
+ *
+ * On span start, it reads Galileo context from AsyncLocalStorage (set by `init()`,
+ * `galileoContext`, or experiment context) and stamps galileo.* attributes onto each span.
+ * These attributes are then read by the GalileoOTLPExporter at export time.
+ *
+ * @example
+ * ```typescript
+ * import { GalileoSpanProcessor, addGalileoSpanProcessor } from 'galileo';
+ * import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
+ *
+ * const provider = new NodeTracerProvider();
+ * const processor = new GalileoSpanProcessor({ project: 'my-project' });
+ * addGalileoSpanProcessor(provider, processor);
+ * provider.register();
+ *
+ * const tracer = provider.getTracer('my-service');
+ * const span = tracer.startSpan('my-operation');
+ * span.end();
+ * ```
+ */
+export class GalileoSpanProcessor implements SpanProcessorLike {
+  private _processor: SpanProcessorLike;
+  private _exporter: GalileoOTLPExporter;
+  private _experimentId?: string;
+  private _sessionId?: string;
+
+  constructor(config?: GalileoSpanProcessorConfig) {
+    this._experimentId = config?.experimentId;
+    this._sessionId = config?.sessionId;
+
+    this._exporter = new GalileoOTLPExporter({
+      project: config?.project,
+      logstream: config?.logstream,
+      apiKey: config?.apiKey,
+      apiUrl: config?.apiUrl
+    });
+
+    let BatchSpanProcessor: new (
+      exporter: GalileoOTLPExporter
+    ) => SpanProcessorLike;
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const mod = require('@opentelemetry/sdk-trace-base');
+      BatchSpanProcessor = mod.BatchSpanProcessor;
+    } catch {
+      throw new Error(
+        '@opentelemetry/sdk-trace-base is not installed. ' +
+          'Install it with: npm install @opentelemetry/sdk-trace-base'
+      );
+    }
+
+    this._processor = new BatchSpanProcessor(this._exporter);
+  }
+
+  /**
+   * Inject Galileo context attributes onto each span at creation time.
+   *
+   * Reads context from AsyncLocalStorage (experimentContext from singleton.ts),
+   * falls back to constructor config, then environment variables.
+   * Experiment ID takes priority over logstream when both are present.
+   */
+  onStart(span: SpanLike, parentContext: ContextLike): void {
+    const ctx = experimentContext.getStore();
+
+    const project = ctx?.projectName ?? this._exporter.project;
+    const logStream = ctx?.logStreamName ?? this._exporter.logstream;
+    const experimentId = ctx?.experimentId ?? this._experimentId;
+    const sessionId = ctx?.sessionId ?? this._sessionId;
+
+    if (project) {
+      span.setAttribute(GALILEO_ATTRIBUTES.PROJECT_NAME, project);
+    }
+    if (logStream && !experimentId) {
+      span.setAttribute(GALILEO_ATTRIBUTES.LOGSTREAM_NAME, logStream);
+    }
+    if (experimentId) {
+      span.setAttribute(GALILEO_ATTRIBUTES.EXPERIMENT_ID, experimentId);
+    }
+    if (sessionId) {
+      span.setAttribute(GALILEO_ATTRIBUTES.SESSION_ID, sessionId);
+    }
+
+    this._processor.onStart(span, parentContext);
+  }
+
+  onEnd(span: ReadableSpanLike): void {
+    this._processor.onEnd(span);
+  }
+
+  async shutdown(): Promise<void> {
+    await this._processor.shutdown();
+    sdkLogger.info(
+      `Galileo span processor shutdown for project "${this._exporter.project}" ` +
+        `and logstream "${this._exporter.logstream}"`
+    );
+  }
+
+  async forceFlush(): Promise<void> {
+    return this._processor.forceFlush();
+  }
+
+  get exporter(): GalileoOTLPExporter {
+    return this._exporter;
+  }
+
+  get processor(): SpanProcessorLike {
+    return this._processor;
+  }
+}

--- a/src/handlers/otel/types.ts
+++ b/src/handlers/otel/types.ts
@@ -1,0 +1,80 @@
+/**
+ * Configuration and shared type interfaces for Galileo OpenTelemetry integration.
+ */
+
+/**
+ * Configuration for the GalileoOTLPExporter.
+ */
+export interface GalileoOTLPExporterConfig {
+  /** Target Galileo project name. Falls back to GALILEO_PROJECT env var, then 'default'. */
+  project?: string;
+  /** Target logstream name. Falls back to GALILEO_LOG_STREAM env var, then 'default'. */
+  logstream?: string;
+  /** Galileo API key. Falls back to GALILEO_API_KEY env var. */
+  apiKey?: string;
+  /** Galileo API URL. Falls back to GALILEO_CONSOLE_URL env var, then 'https://app.galileo.ai'. */
+  apiUrl?: string;
+}
+
+/**
+ * Configuration for the GalileoSpanProcessor.
+ */
+export interface GalileoSpanProcessorConfig extends GalileoOTLPExporterConfig {
+  /** Experiment ID for experiment mode. When set, logstream is not used. */
+  experimentId?: string;
+  /** Session ID for session tracking. */
+  sessionId?: string;
+}
+
+/**
+ * Galileo-specific span attribute keys set by the processor and read by the exporter.
+ */
+export const GALILEO_ATTRIBUTES = {
+  PROJECT_NAME: 'galileo.project.name',
+  LOGSTREAM_NAME: 'galileo.logstream.name',
+  EXPERIMENT_ID: 'galileo.experiment.id',
+  SESSION_ID: 'galileo.session.id',
+  DATASET_INPUT: 'galileo.dataset.input',
+  DATASET_OUTPUT: 'galileo.dataset.output',
+  DATASET_METADATA: 'galileo.dataset.metadata'
+} as const;
+
+// --- Structural interfaces for optional OTel peer dependency types ---
+// These allow the implementation to compile without requiring OTel at import time.
+// At runtime, actual OTel objects are passed in.
+
+export interface SpanLike {
+  setAttribute(key: string, value: string): unknown;
+}
+
+export interface ReadableSpanLike {
+  readonly name: string;
+  readonly attributes: Record<string, unknown>;
+  readonly resource: { merge(other: unknown): unknown };
+  _resource?: unknown;
+}
+
+export interface ExportResultLike {
+  code: number;
+  error?: Error;
+}
+
+export interface ContextLike {
+  getValue(key: symbol): unknown;
+}
+
+export interface SpanExporterLike {
+  export(
+    spans: ReadableSpanLike[],
+    resultCallback: (result: ExportResultLike) => void
+  ): void;
+  shutdown(): Promise<void>;
+  forceFlush?(): Promise<void>;
+}
+
+export interface SpanProcessorLike {
+  onStart(span: SpanLike, parentContext: ContextLike): void;
+  onEnd(span: ReadableSpanLike): void;
+  shutdown(): Promise<void>;
+  forceFlush(): Promise<void>;
+}

--- a/src/handlers/otel/types.ts
+++ b/src/handlers/otel/types.ts
@@ -50,8 +50,7 @@ export interface SpanLike {
 export interface ReadableSpanLike {
   readonly name: string;
   readonly attributes: Record<string, unknown>;
-  readonly resource: { merge(other: unknown): unknown };
-  _resource?: unknown;
+  resource: { merge(other: unknown): unknown };
 }
 
 export interface ExportResultLike {

--- a/src/handlers/otel/types.ts
+++ b/src/handlers/otel/types.ts
@@ -44,7 +44,7 @@ export const GALILEO_ATTRIBUTES = {
 // At runtime, actual OTel objects are passed in.
 
 export interface SpanLike {
-  setAttribute(key: string, value: string): unknown;
+  setAttribute(key: string, value: string | number | boolean): unknown;
 }
 
 export interface ReadableSpanLike {

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,6 +148,12 @@ import {
   GalileoCustomSpan,
   registerGalileoTraceProcessor
 } from './handlers/openai-agents';
+import {
+  GalileoSpanProcessor,
+  GalileoOTLPExporter,
+  addGalileoSpanProcessor,
+  GALILEO_ATTRIBUTES
+} from './handlers/otel';
 import { getSessions, getSpans, getTraces, RecordType } from './utils/search';
 export {
   // Legacy clients
@@ -170,6 +176,11 @@ export {
   GalileoTracingProcessor,
   GalileoCustomSpan,
   registerGalileoTraceProcessor,
+  // OpenTelemetry
+  GalileoSpanProcessor,
+  GalileoOTLPExporter,
+  addGalileoSpanProcessor,
+  GALILEO_ATTRIBUTES,
   // Datasets
   Dataset,
   Datasets,
@@ -303,6 +314,11 @@ export type {
 };
 
 export type { StartSessionOptions } from './types/logging/logger.types';
+
+export type {
+  GalileoSpanProcessorConfig,
+  GalileoOTLPExporterConfig
+} from './handlers/otel';
 
 export {
   APIException,

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -3,24 +3,34 @@ import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
 import { GalileoConfig } from 'galileo-generated';
 import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
-// Mock OTel dependencies
+// Mock OTel dependencies — source tries proto first, falls back to http
 const mockExport = jest.fn();
 const mockExporterShutdown = jest.fn().mockResolvedValue(undefined);
 const mockExporterForceFlush = jest.fn().mockResolvedValue(undefined);
 let mockInnerHeaders: Record<string, string> = {};
 
+const mockExporterFactory = jest
+  .fn()
+  .mockImplementation((config: { headers: Record<string, string> }) => {
+    mockInnerHeaders = { ...config.headers };
+    return {
+      export: mockExport,
+      shutdown: mockExporterShutdown,
+      forceFlush: mockExporterForceFlush,
+      headers: mockInnerHeaders
+    };
+  });
+
+jest.mock(
+  '@opentelemetry/exporter-trace-otlp-proto',
+  () => ({
+    OTLPTraceExporter: mockExporterFactory
+  }),
+  { virtual: true }
+);
+
 jest.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
-  OTLPTraceExporter: jest
-    .fn()
-    .mockImplementation((config: { headers: Record<string, string> }) => {
-      mockInnerHeaders = { ...config.headers };
-      return {
-        export: mockExport,
-        shutdown: mockExporterShutdown,
-        forceFlush: mockExporterForceFlush,
-        headers: mockInnerHeaders
-      };
-    })
+  OTLPTraceExporter: mockExporterFactory
 }));
 
 const MockResource = jest
@@ -51,8 +61,7 @@ function createMockSpan(
   return {
     name: 'test-span',
     attributes,
-    resource,
-    _resource: resource
+    resource
   };
 }
 
@@ -90,7 +99,7 @@ describe('GalileoOTLPExporter', () => {
     expect(exporter.logstream).toBe('my-logstream');
 
     // Then: OTLPTraceExporter was created with correct endpoint and headers
-    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+    expect(mockExporterFactory).toHaveBeenCalledWith({
       url: 'https://custom.galileo.ai/otel/traces',
       headers: {
         'Galileo-API-Key': 'my-key',
@@ -109,7 +118,7 @@ describe('GalileoOTLPExporter', () => {
     });
 
     // Then: endpoint has no double slash
-    expect(OTLPTraceExporter).toHaveBeenCalledWith(
+    expect(mockExporterFactory).toHaveBeenCalledWith(
       expect.objectContaining({
         url: 'https://custom.galileo.ai/otel/traces'
       })

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -7,13 +7,20 @@ import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 const mockExport = jest.fn();
 const mockExporterShutdown = jest.fn().mockResolvedValue(undefined);
 const mockExporterForceFlush = jest.fn().mockResolvedValue(undefined);
+let mockInnerHeaders: Record<string, string> = {};
 
 jest.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
-  OTLPTraceExporter: jest.fn().mockImplementation(() => ({
-    export: mockExport,
-    shutdown: mockExporterShutdown,
-    forceFlush: mockExporterForceFlush
-  }))
+  OTLPTraceExporter: jest
+    .fn()
+    .mockImplementation((config: { headers: Record<string, string> }) => {
+      mockInnerHeaders = { ...config.headers };
+      return {
+        export: mockExport,
+        shutdown: mockExporterShutdown,
+        forceFlush: mockExporterForceFlush,
+        headers: mockInnerHeaders
+      };
+    })
 }));
 
 const MockResource = jest
@@ -54,7 +61,7 @@ describe('GalileoOTLPExporter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // Reset the GalileoConfig singleton so env var changes take effect
+    mockInnerHeaders = {};
     GalileoConfig.reset();
     process.env = {
       ...originalEnv,
@@ -244,5 +251,51 @@ describe('GalileoOTLPExporter', () => {
 
     // Then: inner exporter is still called
     expect(mockExport).toHaveBeenCalledWith([], callback);
+  });
+
+  test('test export updates inner exporter headers for experiment mode', () => {
+    // Given: an exporter
+    const exporter = new GalileoOTLPExporter({
+      project: 'my-project',
+      logstream: 'my-logstream'
+    });
+    const span = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'exp-project',
+      [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-789'
+    });
+    const callback = jest.fn();
+
+    // When: exporting spans with experiment ID
+    exporter.export([span], callback);
+
+    // Then: inner exporter headers are updated with experiment ID and logstream is removed
+    expect(mockInnerHeaders['experimentid']).toBe('exp-789');
+    expect(mockInnerHeaders['project']).toBe('exp-project');
+    expect(mockInnerHeaders['logstream']).toBeUndefined();
+  });
+
+  test('test export cleans up experiment headers for non-experiment batch', () => {
+    // Given: an exporter that previously exported an experiment batch
+    const exporter = new GalileoOTLPExporter({
+      project: 'my-project',
+      logstream: 'my-logstream'
+    });
+    const experimentSpan = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'exp-project',
+      [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-789'
+    });
+    exporter.export([experimentSpan], jest.fn());
+
+    // When: exporting a non-experiment batch
+    const normalSpan = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'normal-project',
+      [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'normal-logstream'
+    });
+    exporter.export([normalSpan], jest.fn());
+
+    // Then: experiment ID is cleaned up and logstream is restored
+    expect(mockInnerHeaders['experimentid']).toBeUndefined();
+    expect(mockInnerHeaders['logstream']).toBe('normal-logstream');
+    expect(mockInnerHeaders['project']).toBe('normal-project');
   });
 });

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -1,0 +1,253 @@
+import { GalileoOTLPExporter } from '../../../src/handlers/otel/exporter';
+import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
+import { GalileoConfig } from 'galileo-generated';
+
+// Mock OTel dependencies
+const mockExport = jest.fn();
+const mockExporterShutdown = jest.fn().mockResolvedValue(undefined);
+const mockExporterForceFlush = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
+  OTLPTraceExporter: jest.fn().mockImplementation(() => ({
+    export: mockExport,
+    shutdown: mockExporterShutdown,
+    forceFlush: mockExporterForceFlush
+  }))
+}));
+
+const MockResource = jest
+  .fn()
+  .mockImplementation((attrs: Record<string, unknown>) => ({
+    attributes: attrs,
+    merge: jest.fn().mockReturnThis()
+  }));
+
+jest.mock('@opentelemetry/resources', () => ({
+  Resource: MockResource
+}));
+
+function createMockSpan(
+  attributes: Record<string, unknown> = {},
+  resourceAttrs: Record<string, unknown> = {}
+) {
+  const resource = {
+    attributes: resourceAttrs,
+    merge: jest
+      .fn()
+      .mockImplementation((other: { attributes: Record<string, unknown> }) => ({
+        ...resource,
+        attributes: { ...resourceAttrs, ...other.attributes }
+      }))
+  };
+
+  return {
+    name: 'test-span',
+    attributes,
+    resource,
+    _resource: resource
+  };
+}
+
+describe('GalileoOTLPExporter', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Reset the GalileoConfig singleton so env var changes take effect
+    GalileoConfig.reset();
+    process.env = {
+      ...originalEnv,
+      GALILEO_API_KEY: 'test-api-key',
+      GALILEO_CONSOLE_URL: 'https://test.galileo.ai'
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    GalileoConfig.reset();
+  });
+
+  test('test constructor builds correct endpoint and headers', () => {
+    // Given: explicit config overriding all values
+    // When: creating an exporter
+    const exporter = new GalileoOTLPExporter({
+      project: 'my-project',
+      logstream: 'my-logstream',
+      apiKey: 'my-key',
+      apiUrl: 'https://custom.galileo.ai'
+    });
+
+    // Then: project and logstream are set correctly
+    expect(exporter.project).toBe('my-project');
+    expect(exporter.logstream).toBe('my-logstream');
+
+    // Then: OTLPTraceExporter was created with correct endpoint and headers
+    const OTLPTraceExporter =
+      require('@opentelemetry/exporter-trace-otlp-http').OTLPTraceExporter;
+    expect(OTLPTraceExporter).toHaveBeenCalledWith({
+      url: 'https://custom.galileo.ai/otel/traces',
+      headers: {
+        'Galileo-API-Key': 'my-key',
+        project: 'my-project',
+        logstream: 'my-logstream'
+      }
+    });
+  });
+
+  test('test constructor strips trailing slash from apiUrl', () => {
+    // Given: apiUrl with trailing slash
+    // When: creating an exporter
+    new GalileoOTLPExporter({
+      apiKey: 'my-key',
+      apiUrl: 'https://custom.galileo.ai/'
+    });
+
+    // Then: endpoint has no double slash
+    const OTLPTraceExporter =
+      require('@opentelemetry/exporter-trace-otlp-http').OTLPTraceExporter;
+    expect(OTLPTraceExporter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: 'https://custom.galileo.ai/otel/traces'
+      })
+    );
+  });
+
+  test('test constructor throws without API key', () => {
+    // Given: no API key in environment
+    delete process.env.GALILEO_API_KEY;
+    GalileoConfig.reset();
+
+    // When/Then: creating an exporter throws
+    expect(() => new GalileoOTLPExporter()).toThrow(
+      'Galileo API key is required'
+    );
+  });
+
+  test('test constructor resolves project and logstream from GalileoConfig', () => {
+    // Given: project and logstream set via env vars (resolved by GalileoConfig)
+    process.env.GALILEO_PROJECT = 'env-project';
+    process.env.GALILEO_LOG_STREAM = 'env-logstream';
+    GalileoConfig.reset();
+
+    // When: creating an exporter without explicit config
+    const exporter = new GalileoOTLPExporter();
+
+    // Then: values come from GalileoConfig (which reads env vars)
+    expect(exporter.project).toBe('env-project');
+    expect(exporter.logstream).toBe('env-logstream');
+  });
+
+  test('test export delegates to inner exporter', () => {
+    // Given: an exporter and a span with no galileo attributes
+    const exporter = new GalileoOTLPExporter();
+    const span = createMockSpan();
+    const callback = jest.fn();
+
+    // When: exporting spans
+    exporter.export([span], callback);
+
+    // Then: inner exporter's export is called
+    expect(mockExport).toHaveBeenCalledWith([span], callback);
+  });
+
+  test('test export merges resource attributes from span attributes', () => {
+    // Given: an exporter and a span with galileo attributes
+    const exporter = new GalileoOTLPExporter();
+    const span = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'span-project',
+      [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'span-logstream',
+      [GALILEO_ATTRIBUTES.SESSION_ID]: 'session-123'
+    });
+    const callback = jest.fn();
+
+    // When: exporting spans
+    exporter.export([span], callback);
+
+    // Then: resource.merge is called with galileo attributes
+    expect(span.resource.merge).toHaveBeenCalled();
+    // Then: inner exporter receives the spans
+    expect(mockExport).toHaveBeenCalledWith([span], callback);
+  });
+
+  test('test export handles experiment mode by removing logstream', () => {
+    // Given: an exporter
+    const exporter = new GalileoOTLPExporter();
+    const span = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'span-project',
+      [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'span-logstream',
+      [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-456'
+    });
+    const callback = jest.fn();
+
+    // When: exporting spans with experiment ID
+    exporter.export([span], callback);
+
+    // Then: Resource was created without logstream (experiment takes priority)
+    const resourceCallArgs = MockResource.mock.calls[0][0];
+    expect(resourceCallArgs[GALILEO_ATTRIBUTES.EXPERIMENT_ID]).toBe('exp-456');
+    expect(
+      resourceCallArgs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME]
+    ).toBeUndefined();
+  });
+
+  test('test export includes dataset attributes in resource', () => {
+    // Given: a span with dataset attributes
+    const exporter = new GalileoOTLPExporter();
+    const span = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'my-project',
+      [GALILEO_ATTRIBUTES.DATASET_INPUT]: 'test input',
+      [GALILEO_ATTRIBUTES.DATASET_OUTPUT]: 'test output',
+      [GALILEO_ATTRIBUTES.DATASET_METADATA]: '{"key": "value"}'
+    });
+    const callback = jest.fn();
+
+    // When: exporting spans
+    exporter.export([span], callback);
+
+    // Then: dataset attributes are included in the resource
+    const resourceCallArgs = MockResource.mock.calls[0][0];
+    expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_INPUT]).toBe(
+      'test input'
+    );
+    expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_OUTPUT]).toBe(
+      'test output'
+    );
+    expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_METADATA]).toBe(
+      '{"key": "value"}'
+    );
+  });
+
+  test('test shutdown delegates to inner exporter', async () => {
+    // Given: an exporter
+    const exporter = new GalileoOTLPExporter();
+
+    // When: shutdown is called
+    await exporter.shutdown();
+
+    // Then: inner exporter's shutdown is called
+    expect(mockExporterShutdown).toHaveBeenCalled();
+  });
+
+  test('test forceFlush delegates to inner exporter', async () => {
+    // Given: an exporter
+    const exporter = new GalileoOTLPExporter();
+
+    // When: forceFlush is called
+    await exporter.forceFlush();
+
+    // Then: inner exporter's forceFlush is called
+    expect(mockExporterForceFlush).toHaveBeenCalled();
+  });
+
+  test('test export with empty spans array does not update headers', () => {
+    // Given: an exporter
+    const exporter = new GalileoOTLPExporter();
+    const callback = jest.fn();
+
+    // When: exporting empty array
+    exporter.export([], callback);
+
+    // Then: inner exporter is still called
+    expect(mockExport).toHaveBeenCalledWith([], callback);
+  });
+});

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -309,6 +309,7 @@ describe('GalileoOTLPExporter', () => {
 
   test('test export warns when inner exporter headers are not accessible', () => {
     // Given: an exporter whose inner exporter has no headers property
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const exporter = new GalileoOTLPExporter();
     const origFactory = mockExporterFactory.getMockImplementation()!;
     mockExporterFactory.mockImplementationOnce(

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -1,7 +1,6 @@
 import { GalileoOTLPExporter } from '../../../src/handlers/otel/exporter';
 import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
 import { GalileoConfig } from 'galileo-generated';
-import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 // Mock OTel dependencies — source tries proto first, falls back to http
 const mockExport = jest.fn();

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -182,9 +182,7 @@ describe('GalileoOTLPExporter', () => {
     // Then: Resource was created without logstream (experiment takes priority)
     const resourceCallArgs = MockResource.mock.calls[0][0];
     expect(resourceCallArgs[GALILEO_ATTRIBUTES.EXPERIMENT_ID]).toBe('exp-456');
-    expect(
-      resourceCallArgs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME]
-    ).toBeUndefined();
+    expect(resourceCallArgs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME]).toBeUndefined();
   });
 
   test('test export includes dataset attributes in resource', () => {

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -1,6 +1,7 @@
 import { GalileoOTLPExporter } from '../../../src/handlers/otel/exporter';
 import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
 import { GalileoConfig } from 'galileo-generated';
+import { OTLPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 
 // Mock OTel dependencies
 const mockExport = jest.fn();
@@ -82,8 +83,6 @@ describe('GalileoOTLPExporter', () => {
     expect(exporter.logstream).toBe('my-logstream');
 
     // Then: OTLPTraceExporter was created with correct endpoint and headers
-    const OTLPTraceExporter =
-      require('@opentelemetry/exporter-trace-otlp-http').OTLPTraceExporter;
     expect(OTLPTraceExporter).toHaveBeenCalledWith({
       url: 'https://custom.galileo.ai/otel/traces',
       headers: {
@@ -103,8 +102,6 @@ describe('GalileoOTLPExporter', () => {
     });
 
     // Then: endpoint has no double slash
-    const OTLPTraceExporter =
-      require('@opentelemetry/exporter-trace-otlp-http').OTLPTraceExporter;
     expect(OTLPTraceExporter).toHaveBeenCalledWith(
       expect.objectContaining({
         url: 'https://custom.galileo.ai/otel/traces'

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -306,4 +306,55 @@ describe('GalileoOTLPExporter', () => {
     expect(mockInnerHeaders['logstream']).toBe('normal-logstream');
     expect(mockInnerHeaders['project']).toBe('normal-project');
   });
+
+  test('test export warns when inner exporter headers are not accessible', () => {
+    // Given: an exporter whose inner exporter has no headers property
+    const exporter = new GalileoOTLPExporter();
+    const origFactory = mockExporterFactory.getMockImplementation()!;
+    mockExporterFactory.mockImplementationOnce(
+      (config: { headers: Record<string, string> }) => {
+        const inner = origFactory(config);
+        delete (inner as Record<string, unknown>).headers;
+        return inner;
+      }
+    );
+    const noHeadersExporter = new GalileoOTLPExporter();
+
+    const span = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'some-project'
+    });
+    const callback = jest.fn();
+
+    // When: exporting spans
+    noHeadersExporter.export([span], callback);
+
+    // Then: export still proceeds (delegates to inner exporter)
+    expect(mockExport).toHaveBeenCalledWith([span], callback);
+  });
+
+  test('test export warns when inner exporter headers are frozen', () => {
+    // Given: an exporter whose inner exporter has frozen headers
+    const origFactory = mockExporterFactory.getMockImplementation()!;
+    mockExporterFactory.mockImplementationOnce(
+      (config: { headers: Record<string, string> }) => {
+        const inner = origFactory(config);
+        (inner as Record<string, unknown>).headers = Object.freeze({
+          ...config.headers
+        });
+        return inner;
+      }
+    );
+    const frozenExporter = new GalileoOTLPExporter();
+
+    const span = createMockSpan({
+      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'some-project'
+    });
+    const callback = jest.fn();
+
+    // When: exporting spans
+    frozenExporter.export([span], callback);
+
+    // Then: export still proceeds without throwing
+    expect(mockExport).toHaveBeenCalledWith([span], callback);
+  });
 });

--- a/tests/handlers/otel/processor.test.ts
+++ b/tests/handlers/otel/processor.test.ts
@@ -1,0 +1,312 @@
+import { GalileoSpanProcessor } from '../../../src/handlers/otel/processor';
+import { experimentContext } from '../../../src/singleton';
+import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
+import { GalileoConfig } from 'galileo-generated';
+
+// Mock the OTel dependencies
+const mockOnStart = jest.fn();
+const mockOnEnd = jest.fn();
+const mockShutdown = jest.fn().mockResolvedValue(undefined);
+const mockForceFlush = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('@opentelemetry/sdk-trace-base', () => ({
+  BatchSpanProcessor: jest.fn().mockImplementation(() => ({
+    onStart: mockOnStart,
+    onEnd: mockOnEnd,
+    shutdown: mockShutdown,
+    forceFlush: mockForceFlush
+  }))
+}));
+
+jest.mock('@opentelemetry/exporter-trace-otlp-http', () => ({
+  OTLPTraceExporter: jest.fn().mockImplementation(() => ({
+    export: jest.fn(),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+    forceFlush: jest.fn().mockResolvedValue(undefined)
+  }))
+}));
+
+jest.mock('@opentelemetry/resources', () => ({
+  Resource: jest.fn().mockImplementation((attrs: Record<string, unknown>) => ({
+    attributes: attrs,
+    merge: jest.fn().mockReturnThis()
+  }))
+}));
+
+// Mock span that records setAttribute calls
+function createMockSpan(): {
+  setAttribute: jest.Mock;
+  attributes: Record<string, string>;
+} {
+  const attributes: Record<string, string> = {};
+  return {
+    attributes,
+    setAttribute: jest.fn((key: string, value: string) => {
+      attributes[key] = value;
+    })
+  };
+}
+
+const mockParentContext = { getValue: jest.fn() };
+
+describe('GalileoSpanProcessor', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    GalileoConfig.reset();
+    process.env = {
+      ...originalEnv,
+      GALILEO_API_KEY: 'test-api-key',
+      GALILEO_CONSOLE_URL: 'https://test.galileo.ai'
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    GalileoConfig.reset();
+  });
+
+  test('test constructor creates processor with default config', () => {
+    // Given: default environment with API key set
+    // When: creating a processor without explicit config
+    const processor = new GalileoSpanProcessor();
+
+    // Then: processor is created successfully
+    expect(processor).toBeDefined();
+    expect(processor.exporter).toBeDefined();
+    expect(processor.processor).toBeDefined();
+  });
+
+  test('test onStart sets galileo attributes from config', () => {
+    // Given: a processor configured with explicit project and logstream
+    const processor = new GalileoSpanProcessor({
+      project: 'my-project',
+      logstream: 'my-logstream'
+    });
+    const span = createMockSpan();
+
+    // When: a span starts
+    processor.onStart(span, mockParentContext);
+
+    // Then: galileo attributes are set on the span
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.PROJECT_NAME,
+      'my-project'
+    );
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.LOGSTREAM_NAME,
+      'my-logstream'
+    );
+    // Then: the inner processor's onStart is called
+    expect(mockOnStart).toHaveBeenCalledWith(span, mockParentContext);
+  });
+
+  test('test onStart sets experiment id and omits logstream', () => {
+    // Given: a processor configured with an experiment ID
+    const processor = new GalileoSpanProcessor({
+      project: 'my-project',
+      logstream: 'my-logstream',
+      experimentId: 'exp-123'
+    });
+    const span = createMockSpan();
+
+    // When: a span starts
+    processor.onStart(span, mockParentContext);
+
+    // Then: experiment ID is set
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.EXPERIMENT_ID,
+      'exp-123'
+    );
+    // Then: logstream is NOT set (experiment takes priority)
+    expect(span.setAttribute).not.toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.LOGSTREAM_NAME,
+      expect.anything()
+    );
+  });
+
+  test('test onStart sets session id', () => {
+    // Given: a processor configured with a session ID
+    const processor = new GalileoSpanProcessor({
+      project: 'my-project',
+      sessionId: 'session-456'
+    });
+    const span = createMockSpan();
+
+    // When: a span starts
+    processor.onStart(span, mockParentContext);
+
+    // Then: session ID is set on the span
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.SESSION_ID,
+      'session-456'
+    );
+  });
+
+  test('test onStart reads from experimentContext AsyncLocalStorage', (done) => {
+    // Given: a processor with default config
+    const processor = new GalileoSpanProcessor();
+    const span = createMockSpan();
+
+    // When: running inside an experimentContext with project and logstream set
+    experimentContext.run(
+      {
+        projectName: 'ctx-project',
+        logStreamName: 'ctx-logstream',
+        sessionId: 'ctx-session'
+      },
+      () => {
+        processor.onStart(span, mockParentContext);
+
+        // Then: attributes come from the AsyncLocalStorage context
+        expect(span.setAttribute).toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.PROJECT_NAME,
+          'ctx-project'
+        );
+        expect(span.setAttribute).toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.LOGSTREAM_NAME,
+          'ctx-logstream'
+        );
+        expect(span.setAttribute).toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.SESSION_ID,
+          'ctx-session'
+        );
+        done();
+      }
+    );
+  });
+
+  test('test onStart context overrides config defaults', (done) => {
+    // Given: a processor with explicit config
+    const processor = new GalileoSpanProcessor({
+      project: 'config-project',
+      logstream: 'config-logstream'
+    });
+    const span = createMockSpan();
+
+    // When: running inside an experimentContext that overrides the config values
+    experimentContext.run(
+      {
+        projectName: 'ctx-project',
+        logStreamName: 'ctx-logstream'
+      },
+      () => {
+        processor.onStart(span, mockParentContext);
+
+        // Then: AsyncLocalStorage context takes priority over constructor config
+        expect(span.setAttribute).toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.PROJECT_NAME,
+          'ctx-project'
+        );
+        expect(span.setAttribute).toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.LOGSTREAM_NAME,
+          'ctx-logstream'
+        );
+        done();
+      }
+    );
+  });
+
+  test('test onStart experiment from context overrides logstream', (done) => {
+    // Given: a processor with logstream config
+    const processor = new GalileoSpanProcessor({
+      project: 'my-project',
+      logstream: 'my-logstream'
+    });
+    const span = createMockSpan();
+
+    // When: running inside a context with an experiment ID
+    experimentContext.run(
+      {
+        projectName: 'my-project',
+        experimentId: 'ctx-exp-789'
+      },
+      () => {
+        processor.onStart(span, mockParentContext);
+
+        // Then: experiment ID is set and logstream is omitted
+        expect(span.setAttribute).toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.EXPERIMENT_ID,
+          'ctx-exp-789'
+        );
+        expect(span.setAttribute).not.toHaveBeenCalledWith(
+          GALILEO_ATTRIBUTES.LOGSTREAM_NAME,
+          expect.anything()
+        );
+        done();
+      }
+    );
+  });
+
+  test('test onEnd delegates to inner processor', () => {
+    // Given: a processor
+    const processor = new GalileoSpanProcessor();
+    const readableSpan = {
+      name: 'test-span',
+      attributes: {},
+      resource: { merge: jest.fn() }
+    };
+
+    // When: a span ends
+    processor.onEnd(readableSpan);
+
+    // Then: the inner processor's onEnd is called
+    expect(mockOnEnd).toHaveBeenCalledWith(readableSpan);
+  });
+
+  test('test shutdown delegates to inner processor', async () => {
+    // Given: a processor
+    const processor = new GalileoSpanProcessor();
+
+    // When: shutdown is called
+    await processor.shutdown();
+
+    // Then: the inner processor's shutdown is called
+    expect(mockShutdown).toHaveBeenCalled();
+  });
+
+  test('test forceFlush delegates to inner processor', async () => {
+    // Given: a processor
+    const processor = new GalileoSpanProcessor();
+
+    // When: forceFlush is called
+    await processor.forceFlush();
+
+    // Then: the inner processor's forceFlush is called
+    expect(mockForceFlush).toHaveBeenCalled();
+  });
+
+  test('test constructor throws without API key', () => {
+    // Given: no API key in environment
+    delete process.env.GALILEO_API_KEY;
+    GalileoConfig.reset();
+
+    // When/Then: creating a processor throws
+    expect(() => new GalileoSpanProcessor()).toThrow(
+      'Galileo API key is required'
+    );
+  });
+
+  test('test constructor uses env vars for project and logstream', () => {
+    // Given: project and logstream set via env vars
+    process.env.GALILEO_PROJECT = 'env-project';
+    process.env.GALILEO_LOG_STREAM = 'env-logstream';
+    GalileoConfig.reset();
+
+    // When: creating a processor without explicit config
+    const processor = new GalileoSpanProcessor();
+    const span = createMockSpan();
+    processor.onStart(span, mockParentContext);
+
+    // Then: attributes come from env vars
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.PROJECT_NAME,
+      'env-project'
+    );
+    expect(span.setAttribute).toHaveBeenCalledWith(
+      GALILEO_ATTRIBUTES.LOGSTREAM_NAME,
+      'env-logstream'
+    );
+  });
+});


### PR DESCRIPTION
# User description
sc-61277

## Summary

Add OpenTelemetry integration for the galileo-js SDK, allowing users with existing OTel-instrumented apps to send traces to Galileo without switching to the custom logger API.

### Changes

- **Optional peer dependencies**: Added `@opentelemetry/api`, `sdk-trace-base`, `exporter-trace-otlp-http`, and `resources` as optional peer deps
- **GalileoSpanProcessor**: Implements the OTel `SpanProcessor` interface, stamping `galileo.*` attributes (project, logstream, experiment, session) onto each span at creation time. Reads context from `AsyncLocalStorage` set by `init()`/`galileoContext`
- **GalileoOTLPExporter**: Wraps `OTLPTraceExporter` with Galileo-specific auth headers and resource attribute injection
- **Public API exports**: `GalileoSpanProcessor`, `GalileoOTLPExporter`, `addGalileoSpanProcessor`, `GALILEO_ATTRIBUTES`, and config types exported from main package entry
- **Tests**: 23 unit tests covering config resolution priority, experiment mode, session/dataset attribute injection, resource attribute merging, header updates, and lifecycle delegation

### Design decisions

- Uses composition over inheritance for OTel wrappers (lazy `require()` at construction time with clear error messages for missing deps)
- Follows the same optional peer dep pattern as `@openai/agents`
- Ported from the Python SDK (`galileo-python/otel.py`)

Related: [sc-61277]

---

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
addGalileoSpanProcessor_("addGalileoSpanProcessor"):::added
GalileoSpanProcessor_("GalileoSpanProcessor"):::added
GalileoOTLPExporter_("GalileoOTLPExporter"):::added
GalileoSpanProcessor_onStart_("GalileoSpanProcessor.onStart"):::added
GALILEO_ATTRIBUTES_("GALILEO_ATTRIBUTES"):::added
GALILEO_API_("GALILEO_API"):::added
addGalileoSpanProcessor_ -- "Adds helper to register GalileoSpanProcessor on tracer provider." --> GalileoSpanProcessor_
GalileoSpanProcessor_ -- "Constructs GalileoOTLPExporter and delegates via BatchSpanProcessor." --> GalileoOTLPExporter_
GalileoSpanProcessor_onStart_ -- "Sets GALILEO_* attributes from context/config on every span." --> GALILEO_ATTRIBUTES_
GalileoOTLPExporter_ -- "Reads GALILEO_* span attributes, merges resources, updates batch headers." --> GALILEO_ATTRIBUTES_
GalileoOTLPExporter_ -- "Exports OTLP batches to /otel/traces using Galileo-API-Key headers." --> GALILEO_API_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enable OpenTelemetry support for the Galileo SDK by wiring <code>GalileoSpanProcessor</code> and <code>GalileoOTLPExporter</code> into its tracing stack, ensuring spans can inherit Galileo context and resource metadata before being shipped through OTLP. Export these helpers and their configuration types alongside <code>GALILEO_ATTRIBUTES</code>, and adjust dependency metadata so the new exporters load optional OpenTelemetry peers without forcing installs for every consumer.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/551?tool=ast&topic=API+exports>API exports</a>
        </td><td>Explain how the main package entry now exposes the new OTel helpers plus <code>GALILEO_ATTRIBUTES</code> and config types, making it easy for integrators to attach Galileo tracing processing to their tracer providers alongside the legacy tracing utilities.<details><summary>Modified files (1)</summary><ul><li>src/index.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(handlers): Improv...</td><td>April 17, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/551?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>src/handlers/otel/index.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/551?tool=ast&topic=Tracing+flow>Tracing flow</a>
        </td><td>Describe how the custom <code>GalileoSpanProcessor</code>, <code>GalileoOTLPExporter</code>, and shared types orchestrate context propagation, resource attribute merging, lifecycle management, and unit tests covering experiment/session flows so OTel-instrumented apps can forward traces to Galileo with Galileo-specific metadata injected.<details><summary>Modified files (5)</summary><ul><li>src/handlers/otel/exporter.ts</li>
<li>src/handlers/otel/processor.ts</li>
<li>src/handlers/otel/types.ts</li>
<li>tests/handlers/otel/exporter.test.ts</li>
<li>tests/handlers/otel/processor.test.ts</li></ul></details><details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/551?tool=ast&topic=Dependencies>Dependencies</a>
        </td><td>Summarize npm manifest and lock updates that add the optional OpenTelemetry peer/dev dependencies (API, SDK, exporters, resources) so adopters can install the exact OTLP packages needed for Galileo integration without impacting default consumers.<details><summary>Modified files (2)</summary><ul><li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>chore(dependency): Upd...</td><td>April 27, 2026</td></tr>
<tr><td>quinn-galileo</td><td>chore: release 2.0.0 (...</td><td>April 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/551?tool=ast>(Baz)</a>.