### PR TITLE
fix(metadata): Created type to unify parameters for startSession functions, including metadata in missing case.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,6 +300,8 @@ export type {
   RunExperimentParams
 };
 
+export type { StartSessionOptions } from './types/logging/logger.types';
+
 export {
   APIException,
   ExperimentAPIException,

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -1,6 +1,9 @@
 import { AsyncLocalStorage } from 'async_hooks';
 import { GalileoLogger } from './utils/galileo-logger';
-import type { GalileoLoggerConfig } from './types/logging/logger.types';
+import type {
+  GalileoLoggerConfig,
+  StartSessionOptions
+} from './types/logging/logger.types';
 import type { LocalMetricConfig } from './types/metrics.types';
 import { StepWithChildSpans } from './types/logging/span.types';
 
@@ -375,13 +378,12 @@ const getLoggerFromContext = (): GalileoLogger => {
  * @param options.name - (Optional) The session name.
  * @param options.previousSessionId - (Optional) The previous session ID to link to.
  * @param options.externalId - (Optional) External ID for the session.
+ * @param options.metadata - (Optional) User metadata for the session as key-value string pairs. Only applied when creating a new session.
  * @returns A promise that resolves to the session ID.
  */
-export const startSession = async (options?: {
-  name?: string;
-  previousSessionId?: string;
-  externalId?: string;
-}): Promise<string> => {
+export const startSession = async (
+  options?: StartSessionOptions
+): Promise<string> => {
   const logger = getLoggerFromContext();
   return logger.startSession(options);
 };

--- a/src/types/logging/logger.types.ts
+++ b/src/types/logging/logger.types.ts
@@ -16,7 +16,7 @@ import type {
   LlmSpanAllowedOutputType,
   RetrieverSpanAllowedOutputType
 } from './step.types';
-import type { AgentType, Payload, ProtectResponse } from '../new-api.types';
+import type { AgentType, Payload, ProtectResponse } from 'galileo-generated';
 import type { JsonObject } from '../base.types';
 export interface GalileoLoggerConfig {
   projectName?: string;
@@ -79,6 +79,20 @@ export interface IGalileoLoggerCore {
 }
 
 /**
+ * Options for starting a new session.
+ */
+export interface StartSessionOptions {
+  /** (Optional) The name of the session. Only applied when creating a new session. */
+  name?: string;
+  /** (Optional) The ID of a previous session to link to. Creates a reference only; does not inherit metadata. Only applied when creating a new session. */
+  previousSessionId?: string;
+  /** (Optional) An external identifier for the session. If a session with this external ID already exists, it will be reused instead of creating a new session. */
+  externalId?: string;
+  /** (Optional) User metadata for the session as key-value string pairs. Only applied when creating a new session. */
+  metadata?: Record<string, string>;
+}
+
+/**
  * Session management operations.
  * Handles session creation, retrieval, and lifecycle management.
  */
@@ -97,12 +111,7 @@ export interface IGalileoLoggerSession {
    * @param options.metadata - (Optional) User metadata for the session as key-value string pairs. Only applied when creating a new session.
    * @returns A promise that resolves to the ID of the session (either newly created or existing).
    */
-  startSession(options?: {
-    name?: string;
-    previousSessionId?: string;
-    externalId?: string;
-    metadata?: Record<string, string>;
-  }): Promise<string>;
+  startSession(options?: StartSessionOptions): Promise<string>;
 
   /**
    * Sets the session ID for the logger.

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -32,14 +32,15 @@ import type {
   LogSpanUpdateRequest
 } from '../types/logging/trace.types';
 import { populateLocalMetrics } from '../utils/metrics';
-import type { Payload, ProtectResponse } from '../types/new-api.types';
+import type { Payload, ProtectResponse } from 'galileo-generated';
 import { handleGalileoHttpExceptionsForRetry, withRetry } from './retry-utils';
 import { TaskHandler } from './task-handler';
 import { getSdkLogger } from 'galileo-generated';
 import type {
   GalileoLoggerConfig,
   GalileoLoggerConfigExtended,
-  IGalileoLogger
+  IGalileoLogger,
+  StartSessionOptions
 } from '../types/logging/logger.types';
 
 const sdkLogger = getSdkLogger();
@@ -256,14 +257,7 @@ class GalileoLogger implements IGalileoLogger {
    * @param options.metadata - (Optional) User metadata for the session as key-value string pairs. Only applied when creating a new session.
    * @returns A promise that resolves to the ID of the session (either newly created or existing).
    */
-  async startSession(
-    options: {
-      name?: string;
-      previousSessionId?: string;
-      externalId?: string;
-      metadata?: Record<string, string>;
-    } = {}
-  ): Promise<string> {
+  async startSession(options: StartSessionOptions = {}): Promise<string> {
     await this.client.init({
       projectName: this.projectName,
       logStreamName: this.logStreamName,

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -902,10 +902,12 @@ describe('Singleton utility functions', () => {
         const mockLogger = (GalileoLogger as unknown as jest.Mock).mock.results[
           (GalileoLogger as unknown as jest.Mock).mock.results.length - 1
         ].value;
-        expect(mockLogger.startSession).toHaveBeenCalledWith({
-          name: 'session',
-          metadata
-        });
+        expect(mockLogger.startSession).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: 'session',
+            metadata
+          })
+        );
       });
     });
 

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -396,6 +396,20 @@ describe('Singleton utility functions', () => {
       });
     });
 
+    it('test startSession passes metadata to logger', async () => {
+      const logger = getLogger();
+      const metadata = { brand_id: 'acme', tier: 'premium' };
+      const id = await startSession({
+        name: 'meta-session',
+        metadata
+      });
+      expect(id).toBe('session-id');
+      expect(logger.startSession).toHaveBeenCalledWith({
+        name: 'meta-session',
+        metadata
+      });
+    });
+
     it('setSession should call logger.setSessionId', () => {
       const logger = getLogger();
       setSession('session-123');
@@ -873,6 +887,24 @@ describe('Singleton utility functions', () => {
           name: 'session',
           previousSessionId: 'prev',
           externalId: 'ext'
+        });
+      });
+
+      it('test init passes metadata to startSession', async () => {
+        const metadata = { brand_id: 'acme', tier: 'premium' };
+        await init({
+          projectName: 'test-project',
+          startNewSession: true,
+          sessionName: 'session',
+          metadata
+        });
+
+        const mockLogger = (GalileoLogger as unknown as jest.Mock).mock.results[
+          (GalileoLogger as unknown as jest.Mock).mock.results.length - 1
+        ].value;
+        expect(mockLogger.startSession).toHaveBeenCalledWith({
+          name: 'session',
+          metadata
         });
       });
     });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -396,7 +396,7 @@ describe('Singleton utility functions', () => {
       });
     });
 
-    it('test startSession passes metadata to logger', async () => {
+    test('test startSession passes metadata to logger', async () => {
       const logger = getLogger();
       const metadata = { brand_id: 'acme', tier: 'premium' };
       const id = await startSession({
@@ -890,7 +890,7 @@ describe('Singleton utility functions', () => {
         });
       });
 
-      it('test init passes metadata to startSession', async () => {
+      test('test init passes metadata to startSession', async () => {
         const metadata = { brand_id: 'acme', tier: 'premium' };
         await init({
           projectName: 'test-project',


### PR DESCRIPTION
# User description
#  galileo-js: singleton startSession options type missing metadata field -  [sc-62081](https://app.shortcut.com/galileo/story/62081/galileo-js-singleton-startsession-options-type-missing-metadata-field)

## Description
* Added new type to unify parameters for startSession functions;
* Refactored some imports from new-type (old type generation) to galileo-generated;

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Introduce the shared <code>StartSessionOptions</code> type so all startSession entry points consistently accept metadata when creating sessions. Update the singleton and <code>GalileoLogger</code> to forward this new option along with <code>galileo-generated</code> imports, and add coverage for metadata propagation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/560?tool=ast&topic=StartSession+tests>StartSession tests</a>
        </td><td>Validate metadata passing in startSession and init flows to ensure new options reach the logger.<details><summary>Modified files (1)</summary><ul><li>tests/singleton.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(wrapper): New fea...</td><td>February 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/560?tool=ast&topic=Session+options>Session options</a>
        </td><td>Introduce <code>StartSessionOptions</code> to unify startSession parameters, extend metadata support, and have singleton and <code>GalileoLogger</code> rely on the new type and updated imports.<details><summary>Modified files (4)</summary><ul><li>src/index.ts</li>
<li>src/singleton.ts</li>
<li>src/types/logging/logger.types.ts</li>
<li>src/utils/galileo-logger.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(langchain): Initi...</td><td>April 13, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/560?tool=ast>(Baz)</a>.