### PR TITLE
feat(handlers): Improved use of ingestionHook in handlers, fixed rootNode concurrency issue, updated docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,28 @@ console.log(result);
 await flush();
 ```
 
+Using `ingestionHook` with `wrapOpenAI` for custom trace handling:
+
+```js
+import { wrapOpenAI, flush } from 'galileo';
+import { OpenAI } from 'openai';
+
+const openai = wrapOpenAI(
+  new OpenAI({ apiKey: process.env.OPENAI_API_KEY }),
+  undefined, // no custom logger
+  async (request) => {
+    console.log(`Ingesting ${request.traces.length} traces`);
+  }
+);
+
+const result = await openai.chat.completions.create({
+  model: 'gpt-5-mini',
+  messages: [{ content: 'Say hello world!', role: 'user' }]
+});
+
+await flush();
+```
+
 Using the `log` function wrapper
 
 ```js
@@ -191,6 +213,26 @@ const callback = new GalileoCallback();
 const response = await model.invoke('Say hello!', { callbacks: [callback] });
 
 await flush();
+```
+
+#### OpenAI Agents SDK Integration
+
+Use `GalileoTracingProcessor` to log traces from the OpenAI Agents SDK. Requires `@openai/agents` as a peer dependency.
+
+```js
+import { GalileoTracingProcessor } from 'galileo';
+
+// Basic usage
+const processor = new GalileoTracingProcessor();
+
+// With custom ingestion hook
+const processorWithHook = new GalileoTracingProcessor(
+  undefined, // no custom logger
+  true, // flush on trace end
+  async (request) => {
+    console.log(`Ingesting ${request.traces.length} traces`);
+  }
+);
 ```
 
 #### Datasets

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ await flush();
 Using `ingestionHook` with `wrapOpenAI` for custom trace handling:
 
 ```js
-import { wrapOpenAI, flush } from 'galileo';
+import { wrapOpenAI } from 'galileo';
 import { OpenAI } from 'openai';
 
 const openai = wrapOpenAI(
@@ -80,12 +80,12 @@ const openai = wrapOpenAI(
   }
 );
 
+// Traces are automatically flushed to the ingestionHook after each call.
+// No need to call flush() — the hook receives the payload directly.
 const result = await openai.chat.completions.create({
   model: 'gpt-5-mini',
   messages: [{ content: 'Say hello world!', role: 'user' }]
 });
-
-await flush();
 ```
 
 Using the `log` function wrapper

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -18,7 +18,7 @@ import { GalileoLogger } from '../../utils/galileo-logger';
 import { toStringValue, toStringRecord } from '../../utils/serialization';
 import { getSdkLogger } from 'galileo-generated';
 import type { LogTracesIngestRequest } from '../../types/logging/trace.types';
-import { Node, LANGCHAIN_NODE_TYPE, rootNodeContext } from './node';
+import { Node, LANGCHAIN_NODE_TYPE } from './node';
 import {
   getNodeName,
   getAgentName,
@@ -26,8 +26,6 @@ import {
   updateRootToAgent
 } from './utils';
 import { logNodeTree } from './tree-logger';
-
-export { rootNodeContext } from './node';
 
 const sdkLogger = getSdkLogger();
 
@@ -66,6 +64,7 @@ export class GalileoCallback
   _galileoLogger: GalileoLogger;
   _startNewTrace: boolean;
   _flushOnChainEnd: boolean;
+  _rootNode: Node | null = null;
   _nodes: Record<string, Node> = {};
 
   public name = 'GalileoCallback';
@@ -105,7 +104,7 @@ export class GalileoCallback
         return;
       }
 
-      const root = rootNodeContext.get();
+      const root = this._rootNode;
       if (root === null) {
         sdkLogger.warn('Unable to add nodes to trace: Root node not set');
         return;
@@ -159,7 +158,7 @@ export class GalileoCallback
     } finally {
       // Always clear state, even if an exception occurs
       this._nodes = {};
-      rootNodeContext.set(null);
+      this._rootNode = null;
     }
   }
 
@@ -194,9 +193,9 @@ export class GalileoCallback
     this._nodes[nodeId] = node;
 
     // Set as root node if needed
-    if (!rootNodeContext.get()) {
+    if (!this._rootNode) {
       sdkLogger.debug(`Setting root node to ${nodeId}`);
-      rootNodeContext.set(node);
+      this._rootNode = node;
     }
 
     // Add to parent's children if parent exists
@@ -240,7 +239,7 @@ export class GalileoCallback
     Object.assign(node.spanParams, params);
 
     // Check if this is the root node and commit if so
-    const root = rootNodeContext.get();
+    const root = this._rootNode;
     if (root && node.runId === root.runId) {
       await this._commit();
     }

--- a/src/handlers/langchain/node.ts
+++ b/src/handlers/langchain/node.ts
@@ -30,13 +30,3 @@ export class Node {
     this.parentRunId = parentRunId;
   }
 }
-
-// Root node tracking
-let _rootNode: Node | null = null;
-
-export const rootNodeContext = {
-  get: (): Node | null => _rootNode,
-  set: (value: Node | null): void => {
-    _rootNode = value;
-  }
-};

--- a/src/handlers/openai-agents/index.ts
+++ b/src/handlers/openai-agents/index.ts
@@ -4,6 +4,7 @@ import { GalileoSingleton } from '../../singleton';
 import { calculateDurationNs } from '../../utils/utils';
 import { toStringRecord } from '../../utils/serialization';
 import type { JsonObject } from '../../types/base.types';
+import type { LogTracesIngestRequest } from '../../types/logging/trace.types';
 import { AgentType } from '../../types/new-api.types';
 import { type Node, createNode } from './node';
 import { mapSpanType, mapSpanName, GALILEO_CUSTOM_TYPE } from './span-mapping';
@@ -125,6 +126,8 @@ function extractAgentType(
  * - Falls back to trace name if no meaningful input is captured
  */
 export class GalileoTracingProcessor implements TracingProcessor {
+  private readonly _galileoLogger: GalileoLogger;
+  private readonly _flushOnTraceEnd: boolean;
   private _nodes = new Map<string, Node>();
   private _lastOutput: unknown = null;
   private _lastStatusCode: number | null = null;
@@ -133,13 +136,23 @@ export class GalileoTracingProcessor implements TracingProcessor {
 
   /**
    * Creates a new GalileoTracingProcessor.
-   * @param _galileoLogger - (Optional) The GalileoLogger instance to use. Defaults to singleton logger.
-   * @param _flushOnTraceEnd - (Optional) Whether to flush the logger after each trace ends. Defaults to true.
+   * @param galileoLogger - (Optional) The GalileoLogger instance to use. Defaults to singleton logger.
+   * @param flushOnTraceEnd - (Optional) Whether to flush the logger after each trace ends. Defaults to true.
+   * @param ingestionHook - (Optional) Async callback invoked with the trace ingest request payload before sending to the API. When provided without a galileoLogger, a new GalileoLogger is created with this hook.
    */
   constructor(
-    private readonly _galileoLogger: GalileoLogger = GalileoSingleton.getInstance().getClient(),
-    private readonly _flushOnTraceEnd: boolean = true
+    galileoLogger?: GalileoLogger,
+    flushOnTraceEnd: boolean = true,
+    ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void
   ) {
+    if (galileoLogger) {
+      this._galileoLogger = galileoLogger;
+    } else if (ingestionHook) {
+      this._galileoLogger = new GalileoLogger({ ingestionHook });
+    } else {
+      this._galileoLogger = GalileoSingleton.getInstance().getClient();
+    }
+    this._flushOnTraceEnd = flushOnTraceEnd;
     // Lazily check for @openai/agents-core package only when processor is instantiated
     if (!GalileoTracingProcessor._depCheckDone) {
       GalileoTracingProcessor._depCheckDone = true;
@@ -568,15 +581,18 @@ export class GalileoTracingProcessor implements TracingProcessor {
  * Requires @openai/agents-core to be installed.
  * @param galileoLogger - (Optional) The GalileoLogger instance to use.
  * @param flushOnTraceEnd - (Optional) Whether to flush after each trace ends.
+ * @param ingestionHook - (Optional) Async callback invoked with the trace ingest request before sending to the API.
  * @returns The created GalileoTracingProcessor instance.
  */
 export async function registerGalileoTraceProcessor(options?: {
   galileoLogger?: GalileoLogger;
   flushOnTraceEnd?: boolean;
+  ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void;
 }): Promise<GalileoTracingProcessor> {
   const processor = new GalileoTracingProcessor(
     options?.galileoLogger,
-    options?.flushOnTraceEnd
+    options?.flushOnTraceEnd,
+    options?.ingestionHook
   );
 
   const { addTraceProcessor } = (await import(

--- a/src/handlers/openai/index.ts
+++ b/src/handlers/openai/index.ts
@@ -13,6 +13,7 @@ import {
 } from './output-items';
 import { JsonObject } from 'src/types/base.types';
 import { LlmSpanAllowedInputType } from 'src/types';
+import type { LogTracesIngestRequest } from '../../types/logging/trace.types';
 import { getSdkLogger } from 'galileo-generated';
 const sdkLogger = getSdkLogger();
 
@@ -56,6 +57,7 @@ interface OpenAIType {
  * Wraps an OpenAI instance with logging.
  * @param openAIClient The OpenAI instance to wrap.
  * @param logger The logger to use. Defaults to a new GalileoLogger instance.
+ * @param ingestionHook - Optional async callback invoked with the trace ingest request payload before sending to the Galileo API. Use this to inspect or modify trace data before ingestion. When provided without a logger, a new GalileoLogger is created with this hook.
  * @returns The wrapped OpenAI instance.
  *
  * Usage:
@@ -73,7 +75,8 @@ interface OpenAIType {
  */
 export function wrapOpenAI<T extends OpenAIType>(
   openAIClient: T,
-  logger?: GalileoLogger
+  logger?: GalileoLogger,
+  ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void
 ): T {
   const handler: ProxyHandler<T> = {
     get(target, prop: string | symbol) {
@@ -84,7 +87,11 @@ export function wrapOpenAI<T extends OpenAIType>(
         typeof originalMethod === 'object' &&
         originalMethod !== null
       ) {
-        return generateChatCompletionProxy(originalMethod, logger);
+        return generateChatCompletionProxy(
+          originalMethod,
+          logger,
+          ingestionHook
+        );
       }
 
       if (
@@ -92,7 +99,7 @@ export function wrapOpenAI<T extends OpenAIType>(
         typeof originalMethod === 'object' &&
         originalMethod !== null
       ) {
-        return generateResponseApiProxy(originalMethod, logger);
+        return generateResponseApiProxy(originalMethod, logger, ingestionHook);
       }
 
       return originalMethod;
@@ -104,7 +111,8 @@ export function wrapOpenAI<T extends OpenAIType>(
 
 function generateChatCompletionProxy<T extends OpenAIType>(
   originalMethod: T[keyof T] & object,
-  logger: GalileoLogger | undefined
+  logger: GalileoLogger | undefined,
+  ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void
 ): T {
   return new Proxy(originalMethod, {
     get(chatTarget: any, chatProp: string | symbol) {
@@ -125,7 +133,11 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                 const OpenAISdkOptions = args.slice(1);
                 const startTime = new Date();
                 if (!logger) {
-                  logger = GalileoSingleton.getInstance().getClient();
+                  if (ingestionHook) {
+                    logger = new GalileoLogger({ ingestionHook });
+                  } else {
+                    logger = GalileoSingleton.getInstance().getClient();
+                  }
                 }
 
                 const normalizedInput = convertInputToMessages(
@@ -229,7 +241,8 @@ function generateChatCompletionProxy<T extends OpenAIType>(
 
 function generateResponseApiProxy<T extends OpenAIType>(
   originalMethod: T[keyof T] & object,
-  logger: GalileoLogger | undefined
+  logger: GalileoLogger | undefined,
+  ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void
 ): T {
   return new Proxy(originalMethod, {
     get(responsesTarget: any, responsesProp: string | symbol) {
@@ -244,7 +257,11 @@ function generateResponseApiProxy<T extends OpenAIType>(
           const OpenAISdkOptions = args.slice(1);
           const startTime = new Date();
           if (!logger) {
-            logger = GalileoSingleton.getInstance().getClient();
+            if (ingestionHook) {
+              logger = new GalileoLogger({ ingestionHook });
+            } else {
+              logger = GalileoSingleton.getInstance().getClient();
+            }
           }
 
           const normalizedInput = convertInputToMessages(requestData.input);
@@ -379,6 +396,7 @@ function processErrorSpan(
  *
  * @param azureOpenAIClient The AzureOpenAI instance to wrap
  * @param logger Optional GalileoLogger instance. If not provided, uses the singleton instance.
+ * @param ingestionHook - Optional async callback invoked with the trace ingest request payload before sending to the Galileo API. Use this to inspect or modify trace data before ingestion. When provided without a logger, a new GalileoLogger is created with this hook.
  * @returns The wrapped Azure OpenAI instance
  *
  */

--- a/src/handlers/openai/index.ts
+++ b/src/handlers/openai/index.ts
@@ -57,7 +57,7 @@ interface OpenAIType {
  * Wraps an OpenAI instance with logging.
  * @param openAIClient The OpenAI instance to wrap.
  * @param logger The logger to use. Defaults to a new GalileoLogger instance.
- * @param ingestionHook - Optional async callback invoked with the trace ingest request payload before sending to the Galileo API. Use this to inspect or modify trace data before ingestion. When provided without a logger, a new GalileoLogger is created with this hook.
+ * @param ingestionHook - Optional async callback invoked with the trace ingest request payload before sending to the Galileo API. Use this to inspect or modify trace data before ingestion. When provided without a logger, a new GalileoLogger is created with this hook and traces are automatically flushed to the hook after each completed call. No explicit flush() is needed.
  * @returns The wrapped OpenAI instance.
  *
  * Usage:
@@ -132,9 +132,11 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                 const [requestData] = args;
                 const OpenAISdkOptions = args.slice(1);
                 const startTime = new Date();
+                let selfManagedFlush = false;
                 if (!logger) {
                   if (ingestionHook) {
                     logger = new GalileoLogger({ ingestionHook });
+                    selfManagedFlush = true;
                   } else {
                     logger = GalileoSingleton.getInstance().getClient();
                   }
@@ -171,6 +173,9 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                       startTime,
                       normalizedInput
                     );
+                    if (selfManagedFlush) {
+                      await logger.flush();
+                    }
                   }
                   throw error;
                 }
@@ -184,7 +189,8 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                     logger,
                     startTime,
                     !isParentTraceValid, // Complete trace only if we started it (no parent)
-                    false // Chat Completions API, not Responses API
+                    false, // Chat Completions API, not Responses API
+                    selfManagedFlush // Auto-flush when proxy created the logger
                   );
                 }
 
@@ -225,6 +231,9 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                     output: JSON.stringify(output),
                     durationNs
                   });
+                  if (selfManagedFlush) {
+                    await logger.flush();
+                  }
                 }
 
                 return response;
@@ -256,9 +265,11 @@ function generateResponseApiProxy<T extends OpenAIType>(
           const [requestData] = args;
           const OpenAISdkOptions = args.slice(1);
           const startTime = new Date();
+          let selfManagedFlush = false;
           if (!logger) {
             if (ingestionHook) {
               logger = new GalileoLogger({ ingestionHook });
+              selfManagedFlush = true;
             } else {
               logger = GalileoSingleton.getInstance().getClient();
             }
@@ -292,6 +303,9 @@ function generateResponseApiProxy<T extends OpenAIType>(
                 startTime,
                 normalizedInput
               );
+              if (selfManagedFlush) {
+                await logger.flush();
+              }
             }
             throw error;
           }
@@ -305,7 +319,8 @@ function generateResponseApiProxy<T extends OpenAIType>(
               logger,
               startTime,
               !isParentTraceValid, // Complete trace only if we started it (no parent)
-              true // Responses API stream
+              true, // Responses API stream
+              selfManagedFlush // Auto-flush when proxy created the logger
             );
           } else {
             // Safely extract output items with fallback for invalid/unexpected response formats
@@ -341,6 +356,9 @@ function generateResponseApiProxy<T extends OpenAIType>(
                 output: JSON.stringify(consolidatedOutput),
                 durationNs: calculateDurationNs(startTime)
               });
+              if (selfManagedFlush) {
+                await logger.flush();
+              }
             }
 
             return response;
@@ -396,7 +414,7 @@ function processErrorSpan(
  *
  * @param azureOpenAIClient The AzureOpenAI instance to wrap
  * @param logger Optional GalileoLogger instance. If not provided, uses the singleton instance.
- * @param ingestionHook - Optional async callback invoked with the trace ingest request payload before sending to the Galileo API. Use this to inspect or modify trace data before ingestion. When provided without a logger, a new GalileoLogger is created with this hook.
+ * @param ingestionHook - Optional async callback invoked with the trace ingest request payload before sending to the Galileo API. Use this to inspect or modify trace data before ingestion. When provided without a logger, a new GalileoLogger is created with this hook and traces are automatically flushed to the hook after each completed call. No explicit flush() is needed.
  * @returns The wrapped Azure OpenAI instance
  *
  */
@@ -461,7 +479,8 @@ class StreamWrapper implements AsyncIterable<any> {
     private logger: GalileoLogger,
     private startTime: Date,
     private shouldCompleteTrace: boolean,
-    isResponsesApiStream: boolean = false
+    isResponsesApiStream: boolean = false,
+    private shouldAutoFlush: boolean = false
   ) {
     this.iterator = this.stream[Symbol.asyncIterator]();
     this.isResponsesApi = isResponsesApiStream;
@@ -489,26 +508,26 @@ class StreamWrapper implements AsyncIterable<any> {
             return result;
           } else {
             // Stream is done, finalize logging
-            this.finalize();
+            await this.finalize();
             return result;
           }
         } catch (error) {
           sdkLogger.error('Error in stream processing:', error);
           this.streamError =
             error instanceof Error ? error : new Error(String(error));
-          this.finalize();
+          await this.finalize();
           throw error;
         }
       },
       return: async (value: any): Promise<IteratorResult<any>> => {
-        this.finalize();
+        await this.finalize();
         return { done: true, value };
       },
       throw: async (error: any): Promise<IteratorResult<any>> => {
         sdkLogger.error('Error in stream processing:', error);
         this.streamError =
           error instanceof Error ? error : new Error(String(error));
-        this.finalize();
+        await this.finalize();
         throw error;
       }
     };
@@ -663,7 +682,7 @@ class StreamWrapper implements AsyncIterable<any> {
     return hasResponseEventType || hasOutputArray;
   }
 
-  private finalize() {
+  private async finalize() {
     if (this.finalized) return;
     this.finalized = true;
 
@@ -671,9 +690,9 @@ class StreamWrapper implements AsyncIterable<any> {
     const startTimeForMetrics = this.completionStartTime || this.startTime;
 
     if (this.isResponsesApi) {
-      this.finalizeResponsesApi(startTimeForMetrics, endTime);
+      await this.finalizeResponsesApi(startTimeForMetrics, endTime);
     } else {
-      this.finalizeChatCompletionApi(startTimeForMetrics, endTime);
+      await this.finalizeChatCompletionApi(startTimeForMetrics, endTime);
     }
   }
 
@@ -696,7 +715,7 @@ class StreamWrapper implements AsyncIterable<any> {
    * This is the authoritative source - we don't need to merge with any incrementally
    * collected data because the API provides everything we need in this final event.
    */
-  private finalizeResponsesApi(startTimeForMetrics: Date, endTime: Date) {
+  private async finalizeResponsesApi(startTimeForMetrics: Date, endTime: Date) {
     const extracted = extractRequestParameters(
       this.requestData as Record<string, unknown>
     );
@@ -728,6 +747,9 @@ class StreamWrapper implements AsyncIterable<any> {
           output: JSON.stringify({ content: `Error: ${errorMessage}` }),
           durationNs: calculateDurationNs(this.startTime, endTime)
         });
+        if (this.shouldAutoFlush) {
+          await this.logger.flush();
+        }
       }
     } else {
       // Process input items first
@@ -797,11 +819,17 @@ class StreamWrapper implements AsyncIterable<any> {
           output: JSON.stringify(consolidatedOutput),
           durationNs: calculateDurationNs(startTimeForMetrics, endTime)
         });
+        if (this.shouldAutoFlush) {
+          await this.logger.flush();
+        }
       }
     }
   }
 
-  private finalizeChatCompletionApi(startTimeForMetrics: Date, endTime: Date) {
+  private async finalizeChatCompletionApi(
+    startTimeForMetrics: Date,
+    endTime: Date
+  ) {
     const extracted = extractRequestParameters(
       this.requestData as Record<string, unknown>
     );
@@ -841,6 +869,9 @@ class StreamWrapper implements AsyncIterable<any> {
           output: JSON.stringify({ content: `Error: ${errorMessage}` }),
           durationNs: calculateDurationNs(this.startTime, endTime)
         });
+        if (this.shouldAutoFlush) {
+          await this.logger.flush();
+        }
       }
     } else {
       const finalOutput =
@@ -896,6 +927,9 @@ class StreamWrapper implements AsyncIterable<any> {
           output: JSON.stringify(finalOutput),
           durationNs: calculateDurationNs(this.startTime, endTime)
         });
+        if (this.shouldAutoFlush) {
+          await this.logger.flush();
+        }
       }
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -125,6 +125,7 @@ import {
 } from './utils/experiments';
 import { ExperimentTags } from './entities/experiment-tags';
 import { Experiments } from './entities/experiments';
+import type { LogTracesIngestRequest } from './types/logging/trace.types';
 import { GalileoLogger } from './utils/galileo-logger';
 import {
   init,
@@ -291,6 +292,7 @@ export type {
   LogRecordsFilter,
   LogRecordsExportRequest,
   LogRecordsMetricsQueryRequest,
+  LogTracesIngestRequest,
   DatasetRow,
   DatasetContent,
   DatasetFormat,

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -1227,6 +1227,8 @@ class GalileoLogger implements IGalileoLogger {
 
   /**
    * Flushes all traces to the server. Concludes any active traces before flushing.
+   * When an ingestionHook is configured, traces are sent to the hook instead of the
+   * API and client initialization is skipped (no API credentials required).
    * @returns A promise that resolves to an array of flushed traces.
    */
   async flush(): Promise<Trace[]> {
@@ -1254,14 +1256,18 @@ class GalileoLogger implements IGalileoLogger {
         });
       }
 
-      await this.client.init({
-        projectName: this.projectName,
-        projectId: this.projectId,
-        logStreamName: this.logStreamName,
-        logStreamId: this.logStreamId,
-        experimentId: this.experimentId,
-        sessionId: this.sessionId
-      });
+      // Skip API client initialization when using ingestionHook — the hook
+      // replaces the backend entirely, so no credentials or project setup needed.
+      if (!this.ingestionHook) {
+        await this.client.init({
+          projectName: this.projectName,
+          projectId: this.projectId,
+          logStreamName: this.logStreamName,
+          logStreamId: this.logStreamId,
+          experimentId: this.experimentId,
+          sessionId: this.sessionId
+        });
+      }
 
       // Compute local metrics if configured
       if (this.localMetrics && this.localMetrics.length > 0) {

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -1,7 +1,4 @@
-import {
-  GalileoCallback,
-  rootNodeContext
-} from '../../../src/handlers/langchain';
+import { GalileoCallback } from '../../../src/handlers/langchain';
 import { GalileoLogger } from '../../../src/utils/galileo-logger';
 import { AgentFinish } from '@langchain/core/agents';
 import {
@@ -70,8 +67,6 @@ describe('GalileoCallback', () => {
 
     galileoLogger = new GalileoLogger();
     callback = new GalileoCallback(galileoLogger, true, false);
-
-    rootNodeContext.set(null);
   });
 
   describe('Initialization', () => {
@@ -1254,9 +1249,6 @@ describe('GalileoCallback', () => {
       it('should handle missing root node gracefully', async () => {
         const runId = createId();
 
-        // Reset root node context
-        rootNodeContext.set(null);
-
         await callback.handleChainStart(
           {
             name: 'TestChain',
@@ -1279,8 +1271,6 @@ describe('GalileoCallback', () => {
       it('should handle node not in nodes map', async () => {
         const runId = createId();
         const parentId = createId();
-
-        rootNodeContext.set(null);
 
         // Start a chain to set as root
         await callback.handleChainStart(
@@ -1535,7 +1525,7 @@ describe('GalileoCallback', () => {
           name: 'OuterAgent',
           input: 'test'
         });
-        rootNodeContext.set(callback['_nodes'][parentId]);
+        callback['_rootNode'] = callback['_nodes'][parentId];
 
         // Start child that triggers agent detection via name 'Agent'
         await callback.handleChainStart(
@@ -2017,7 +2007,7 @@ describe('GalileoCallback', () => {
         }
 
         expect(flushCallback['_nodes']).toEqual({});
-        expect(rootNodeContext.get()).toBeNull();
+        expect(flushCallback['_rootNode']).toBeNull();
       });
     });
 

--- a/tests/handlers/langchain/node.test.ts
+++ b/tests/handlers/langchain/node.test.ts
@@ -1,6 +1,5 @@
 import {
   Node,
-  rootNodeContext,
   LANGCHAIN_NODE_TYPE
 } from '../../../src/handlers/langchain/node';
 
@@ -48,30 +47,5 @@ describe('Node', () => {
       const node = new Node(type, {}, `run-${type}`);
       expect(node.nodeType).toBe(type);
     }
-  });
-});
-
-describe('rootNodeContext', () => {
-  beforeEach(() => {
-    rootNodeContext.set(null);
-  });
-
-  it('test get returns null by default', () => {
-    expect(rootNodeContext.get()).toBeNull();
-  });
-
-  it('test set and get a node', () => {
-    const node = new Node('chain', {}, 'root-1');
-    rootNodeContext.set(node);
-
-    expect(rootNodeContext.get()).toBe(node);
-  });
-
-  it('test reset to null', () => {
-    const node = new Node('chain', {}, 'root-1');
-    rootNodeContext.set(node);
-    rootNodeContext.set(null);
-
-    expect(rootNodeContext.get()).toBeNull();
   });
 });

--- a/tests/handlers/openai-agents/ingestion-hook.test.ts
+++ b/tests/handlers/openai-agents/ingestion-hook.test.ts
@@ -1,0 +1,219 @@
+import { GalileoTracingProcessor } from '../../../src/handlers/openai-agents';
+import { GalileoLogger } from '../../../src/utils/galileo-logger';
+import type {
+  AgentTrace,
+  AgentSpan
+} from '../../../src/handlers/openai-agents';
+import type { LogTracesIngestRequest } from '../../../src/types/logging/trace.types';
+
+// Helper to build a mock AgentTrace
+function makeTrace(overrides: Partial<AgentTrace> = {}): AgentTrace {
+  return {
+    traceId: 'trace-001',
+    name: 'Test Agent Run',
+    metadata: {},
+    startedAt: new Date('2024-01-01T00:00:00Z').toISOString(),
+    endedAt: new Date('2024-01-01T00:00:10Z').toISOString(),
+    ...overrides
+  };
+}
+
+// Helper to build a mock AgentSpan
+function makeSpan(
+  overrides: Partial<AgentSpan> & { spanData: AgentSpan['spanData'] }
+): AgentSpan {
+  return {
+    spanId: 'span-001',
+    traceId: 'trace-001',
+    parentId: 'trace-001',
+    startedAt: new Date('2024-01-01T00:00:01Z').toISOString(),
+    endedAt: new Date('2024-01-01T00:00:05Z').toISOString(),
+    error: null,
+    ...overrides
+  };
+}
+
+// Create a mock GalileoLogger for testing
+function createMockLogger() {
+  return {
+    startTrace: jest.fn().mockReturnValue({}),
+    addLlmSpan: jest.fn().mockReturnValue({}),
+    addToolSpan: jest.fn().mockReturnValue({}),
+    addWorkflowSpan: jest.fn().mockReturnValue({}),
+    addAgentSpan: jest.fn().mockReturnValue({}),
+    conclude: jest.fn().mockReturnValue(undefined),
+    flush: jest.fn().mockResolvedValue(undefined)
+  };
+}
+
+describe('GalileoTracingProcessor ingestionHook', () => {
+  test('test constructor with explicit logger ignores ingestionHook', async () => {
+    const mockLogger = createMockLogger();
+    const mockHook = jest.fn();
+
+    // When an explicit logger is provided, ingestionHook is not used
+    const processor = new GalileoTracingProcessor(
+      mockLogger as never,
+      false,
+      mockHook
+    );
+
+    const trace = makeTrace();
+    await processor.onTraceStart(trace);
+    await processor.onTraceEnd(trace);
+
+    // The explicit mock logger should have been used
+    expect(mockLogger.startTrace).toHaveBeenCalledTimes(1);
+    expect(mockLogger.conclude).toHaveBeenCalled();
+    // The hook function should never be called because we gave a mock logger
+    expect(mockHook).not.toHaveBeenCalled();
+  });
+
+  test('test constructor with ingestionHook creates GalileoLogger with hook', () => {
+    const mockHook = jest
+      .fn<Promise<void>, [LogTracesIngestRequest]>()
+      .mockResolvedValue(undefined);
+
+    // Spy on GalileoLogger constructor
+    const constructorSpy = jest.spyOn(
+      GalileoLogger.prototype as never,
+      'initializeProperties' as never
+    );
+
+    new GalileoTracingProcessor(undefined, true, mockHook);
+
+    // GalileoLogger constructor was called with config containing ingestionHook
+    expect(constructorSpy).toHaveBeenCalledTimes(1);
+    const config = constructorSpy.mock.calls[0][0] as Record<string, unknown>;
+    expect(config.ingestionHook).toBe(mockHook);
+
+    constructorSpy.mockRestore();
+  });
+
+  test('test constructor without logger or hook falls back to singleton', () => {
+    // We can't easily test singleton fallback without initializing,
+    // but we can verify it throws or returns correctly.
+    // The singleton.getInstance().getClient() will be called.
+    // Since we haven't initialized, this may throw.
+    // The important thing is that the GalileoLogger constructor is NOT called
+    // with a config object.
+
+    const constructorSpy = jest.spyOn(
+      GalileoLogger.prototype as never,
+      'initializeProperties' as never
+    );
+
+    try {
+      new GalileoTracingProcessor(undefined, true, undefined);
+    } catch {
+      // Singleton may not be initialized in test environment, which is fine
+    }
+
+    // If singleton works, initializeProperties may be called (via singleton's getClient).
+    // If it throws, initializeProperties may not be called.
+    // In either case, the constructor should NOT pass ingestionHook.
+    if (constructorSpy.mock.calls.length > 0) {
+      const config = constructorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(config.ingestionHook).toBeUndefined();
+    }
+
+    constructorSpy.mockRestore();
+  });
+
+  test('test processor with ingestionHook runs trace and calls flush', async () => {
+    const mockHook = jest
+      .fn<Promise<void>, [LogTracesIngestRequest]>()
+      .mockResolvedValue(undefined);
+
+    // Create a processor with ingestionHook; it creates a real GalileoLogger.
+    // Instead of testing the full flush flow (which requires API mocking),
+    // verify the processor correctly uses the logger by tracking its method calls.
+    const processor = new GalileoTracingProcessor(undefined, false, mockHook);
+
+    // Access the internal logger to verify it was created
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internalLogger = (processor as any)._galileoLogger;
+    expect(internalLogger).toBeInstanceOf(GalileoLogger);
+
+    // Spy on the internal logger's flush method
+    const flushSpy = jest.spyOn(internalLogger, 'flush');
+
+    const trace = makeTrace();
+    const span = makeSpan({
+      spanId: 'llm-001',
+      parentId: 'trace-001',
+      spanData: {
+        type: 'generation',
+        model: 'gpt-4o',
+        input: [{ role: 'user', content: 'hello' }],
+        output: [{ role: 'assistant', content: 'hi' }],
+        usage: { input_tokens: 5, output_tokens: 3 }
+      }
+    });
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    // flushOnTraceEnd=false, so flush should not have been called yet
+    expect(flushSpy).not.toHaveBeenCalled();
+
+    // Verify trace was built — the logger should have traces
+    expect(internalLogger.traces.length).toBe(1);
+
+    flushSpy.mockRestore();
+  });
+
+  test('test processor with ingestionHook and flushOnTraceEnd calls flush', async () => {
+    const mockHook = jest
+      .fn<Promise<void>, [LogTracesIngestRequest]>()
+      .mockResolvedValue(undefined);
+
+    const processor = new GalileoTracingProcessor(undefined, true, mockHook);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internalLogger = (processor as any)._galileoLogger;
+    const flushSpy = jest.spyOn(internalLogger, 'flush');
+
+    const trace = makeTrace();
+    const span = makeSpan({
+      spanId: 'llm-001',
+      parentId: 'trace-001',
+      spanData: {
+        type: 'generation',
+        model: 'gpt-4o',
+        input: [{ role: 'user', content: 'hello' }],
+        output: [{ role: 'assistant', content: 'hi' }],
+        usage: { input_tokens: 5, output_tokens: 3 }
+      }
+    });
+
+    await processor.onTraceStart(trace);
+    await processor.onSpanStart(span);
+    await processor.onSpanEnd(span);
+    await processor.onTraceEnd(trace);
+
+    // flushOnTraceEnd=true, so flush should have been called
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+
+    flushSpy.mockRestore();
+  });
+
+  test('test shutdown calls flush on logger created with ingestionHook', async () => {
+    const mockHook = jest
+      .fn<Promise<void>, [LogTracesIngestRequest]>()
+      .mockResolvedValue(undefined);
+
+    const processor = new GalileoTracingProcessor(undefined, false, mockHook);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const internalLogger = (processor as any)._galileoLogger;
+    const flushSpy = jest.spyOn(internalLogger, 'flush');
+
+    await processor.shutdown();
+    expect(flushSpy).toHaveBeenCalledTimes(1);
+
+    flushSpy.mockRestore();
+  });
+});

--- a/tests/handlers/openai/ingestion-hook.test.ts
+++ b/tests/handlers/openai/ingestion-hook.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { wrapOpenAI } from '../../../src/handlers/openai';
+import { GalileoLogger } from '../../../src/utils/galileo-logger';
 import type { LogTracesIngestRequest } from '../../../src/types/logging/trace.types';
 
 /**
@@ -40,97 +41,356 @@ function createMockOpenAIClient() {
   };
 }
 
+/**
+ * Creates a mock OpenAI client that includes both chat.completions and responses.
+ */
+function createMockOpenAIClientWithResponses() {
+  const mockResponse = {
+    output: [
+      {
+        type: 'message',
+        content: 'The weather is sunny'
+      }
+    ],
+    model: 'gpt-4o',
+    usage: {
+      input_tokens: 15,
+      output_tokens: 8
+    }
+  };
+
+  return {
+    client: {
+      chat: {
+        completions: {
+          create: jest.fn()
+        }
+      },
+      responses: {
+        create: jest.fn().mockResolvedValue(mockResponse)
+      },
+      embeddings: {},
+      moderations: {}
+    },
+    mockResponse
+  };
+}
+
+/**
+ * Creates an async iterable that yields the given chunks, simulating a stream.
+ */
+function createMockStream(chunks: any[]) {
+  return {
+    [Symbol.asyncIterator]: () => {
+      let index = 0;
+      return {
+        next: async () => {
+          if (index < chunks.length) {
+            return { done: false, value: chunks[index++] };
+          }
+          return { done: true, value: undefined };
+        }
+      };
+    }
+  };
+}
+
 describe('wrapOpenAI ingestionHook', () => {
-  test('test wrapOpenAI forwards ingestionHook to logger and hook is called on flush', async () => {
-    const mockHook = jest
-      .fn<Promise<void>, [LogTracesIngestRequest]>()
-      .mockResolvedValue(undefined);
-    const mockClient = createMockOpenAIClient();
+  describe('Chat Completions API', () => {
+    test('test chat completions with ingestionHook creates GalileoLogger with hook', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+      const mockClient = createMockOpenAIClient();
 
-    const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
 
-    await wrapped.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: 'Hello!' }]
-    });
-
-    // The hook should have been called because:
-    // 1. No logger was provided, so wrapOpenAI creates a new GalileoLogger({ ingestionHook })
-    // 2. No parent trace exists, so the proxy starts a trace, adds an LLM span, and concludes
-    // 3. conclude does NOT auto-flush in batch mode, so we need to verify the trace was built
-    // The hook is called during flush(), which happens when the logger flushes.
-    // In the wrapOpenAI flow, flush is not called automatically for non-streaming.
-    // But the trace is built correctly. Let's verify the hook gets called
-    // by checking the mock was at least set up correctly.
-    // Actually, wrapOpenAI does NOT call flush() after conclude. So the hook won't be called yet.
-    // This is expected behavior - the caller is responsible for flushing.
-    // We can verify the hook will be called by checking that the wrapped client works.
-    expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
-  });
-
-  test('test wrapOpenAI with ingestionHook creates logger that uses hook on flush', async () => {
-    const hookCalls: LogTracesIngestRequest[] = [];
-    const mockHook = jest
-      .fn<Promise<void>, [LogTracesIngestRequest]>()
-      .mockImplementation(async (request) => {
-        hookCalls.push(request);
+      await wrapped.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello!' }]
       });
-    const mockClient = createMockOpenAIClient();
 
-    const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
-
-    // Make a call to trigger trace creation
-    await wrapped.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: 'Say hello!' }]
+      // The proxy should have created a GalileoLogger with ingestionHook
+      // (not used the singleton). Verify the call went through successfully.
+      expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
     });
 
-    // The internal logger has a trace now but flush hasn't been called yet.
-    // We can't easily access the internal logger to call flush() directly,
-    // but we can verify the proxy correctly forwarded the call and created spans.
-    expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+    test('test chat completions with ingestionHook builds trace correctly', async () => {
+      const hookCalls: LogTracesIngestRequest[] = [];
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockImplementation(async (request) => {
+          hookCalls.push(request);
+        });
+      const mockClient = createMockOpenAIClient();
 
-    // Verify the original call arguments were passed through
-    const callArgs = mockClient.chat.completions.create.mock.calls[0][0];
-    expect(callArgs.model).toBe('gpt-4o');
-  });
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
 
-  test('test wrapOpenAI without ingestionHook or logger does not error', async () => {
-    // This tests that when neither logger nor ingestionHook are provided,
-    // the proxy will attempt to use the singleton. This will fail in test
-    // environment because singleton isn't initialized, but it should not
-    // error during wrapping itself.
-    const mockClient = createMockOpenAIClient();
+      const result = await wrapped.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Say hello!' }]
+      });
 
-    // Wrapping should succeed regardless of singleton state
-    const wrapped = wrapOpenAI(mockClient as any);
-    expect(wrapped).toBeDefined();
-    expect(wrapped.chat).toBeDefined();
-    expect(wrapped.chat.completions).toBeDefined();
-  });
+      // Verify the response is passed through correctly
+      expect(result.choices[0].message.content).toBe(
+        'Hello! How can I help you?'
+      );
 
-  test('test wrapOpenAI with explicit logger ignores ingestionHook', async () => {
-    const mockHook = jest.fn();
-    const mockLogger = {
-      currentParent: jest.fn().mockReturnValue(null),
-      startTrace: jest.fn(),
-      addLlmSpan: jest.fn(),
-      conclude: jest.fn(),
-      flush: jest.fn().mockResolvedValue([])
-    };
-    const mockClient = createMockOpenAIClient();
-
-    const wrapped = wrapOpenAI(mockClient as any, mockLogger as any, mockHook);
-
-    await wrapped.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [{ role: 'user', content: 'Hello!' }]
+      // Verify the original call arguments were passed through
+      const callArgs = mockClient.chat.completions.create.mock.calls[0][0];
+      expect(callArgs.model).toBe('gpt-4o');
     });
 
-    // When an explicit logger is provided, it is used directly.
-    // The ingestionHook is not used to create a new logger.
-    expect(mockLogger.startTrace).toHaveBeenCalledTimes(1);
-    expect(mockLogger.addLlmSpan).toHaveBeenCalledTimes(1);
-    expect(mockLogger.conclude).toHaveBeenCalledTimes(1);
+    test('test chat completions streaming with ingestionHook creates logger and logs spans', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+
+      const streamChunks = [
+        { choices: [{ delta: { role: 'assistant' } }] },
+        { choices: [{ delta: { content: 'Hello ' } }] },
+        { choices: [{ delta: { content: 'world!' } }] }
+      ];
+
+      const mockClient = {
+        chat: {
+          completions: {
+            create: jest
+              .fn()
+              .mockResolvedValueOnce(createMockStream(streamChunks))
+          }
+        },
+        embeddings: {},
+        moderations: {}
+      };
+
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+      const stream = await wrapped.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello' }],
+        stream: true
+      });
+
+      // Consume the stream
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual(streamChunks);
+      expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+    });
+
+    test('test chat completions error with ingestionHook logs error span', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+
+      const mockClient = {
+        chat: {
+          completions: {
+            create: jest
+              .fn()
+              .mockRejectedValueOnce(new Error('API rate limit exceeded'))
+          }
+        },
+        embeddings: {},
+        moderations: {}
+      };
+
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+      await expect(
+        wrapped.chat.completions.create({
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: 'Hello' }]
+        })
+      ).rejects.toThrow('API rate limit exceeded');
+    });
+  });
+
+  describe('Responses API', () => {
+    test('test responses api with ingestionHook creates GalileoLogger with hook', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+      const { client, mockResponse } = createMockOpenAIClientWithResponses();
+
+      const wrapped = wrapOpenAI(client as any, undefined, mockHook);
+
+      const result = await wrapped.responses!.create({
+        model: 'gpt-4o',
+        input: [
+          { type: 'message', content: 'What is the weather?', role: 'user' }
+        ],
+        stream: false
+      });
+
+      expect(result).toEqual(mockResponse);
+      expect(client.responses.create).toHaveBeenCalledTimes(1);
+    });
+
+    test('test responses api with ingestionHook passes through call arguments', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+      const { client } = createMockOpenAIClientWithResponses();
+
+      const wrapped = wrapOpenAI(client as any, undefined, mockHook);
+
+      const requestData = {
+        model: 'gpt-4o',
+        input: [
+          { type: 'message', content: 'What is the weather?', role: 'user' }
+        ],
+        stream: false
+      };
+
+      await wrapped.responses!.create(requestData);
+
+      const callArgs = client.responses.create.mock.calls[0][0];
+      expect(callArgs.model).toBe('gpt-4o');
+    });
+
+    test('test responses api streaming with ingestionHook creates logger and logs spans', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+
+      const streamChunks = [
+        { type: 'response.created', response: { id: 'resp-1' } },
+        { type: 'response.output_text.delta', delta: 'Hello' },
+        {
+          type: 'response.completed',
+          response: {
+            output: [{ type: 'message', content: 'Hello world' }],
+            model: 'gpt-4o',
+            usage: { input_tokens: 5, output_tokens: 3 }
+          }
+        }
+      ];
+
+      const mockClient = {
+        chat: { completions: { create: jest.fn() } },
+        responses: {
+          create: jest
+            .fn()
+            .mockResolvedValueOnce(createMockStream(streamChunks))
+        },
+        embeddings: {},
+        moderations: {}
+      };
+
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+      const stream = await wrapped.responses!.create({
+        model: 'gpt-4o',
+        input: [{ type: 'message', content: 'Hello', role: 'user' }],
+        stream: true
+      });
+
+      // Consume the stream
+      const chunks = [];
+      for await (const chunk of stream) {
+        chunks.push(chunk);
+      }
+
+      expect(chunks).toEqual(streamChunks);
+      expect(mockClient.responses.create).toHaveBeenCalledTimes(1);
+    });
+
+    test('test responses api error with ingestionHook logs error span', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+
+      const mockClient = {
+        chat: { completions: { create: jest.fn() } },
+        responses: {
+          create: jest.fn().mockRejectedValueOnce(new Error('Model not found'))
+        },
+        embeddings: {},
+        moderations: {}
+      };
+
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+      await expect(
+        wrapped.responses!.create({
+          model: 'gpt-4o',
+          input: [{ type: 'message', content: 'Hello', role: 'user' }],
+          stream: false
+        })
+      ).rejects.toThrow('Model not found');
+    });
+  });
+
+  describe('Logger resolution order', () => {
+    test('test explicit logger takes precedence over ingestionHook', async () => {
+      const mockHook = jest.fn();
+      const mockLogger = {
+        currentParent: jest.fn().mockReturnValue(null),
+        startTrace: jest.fn(),
+        addLlmSpan: jest.fn(),
+        conclude: jest.fn(),
+        flush: jest.fn().mockResolvedValue([])
+      };
+      const mockClient = createMockOpenAIClient();
+
+      const wrapped = wrapOpenAI(
+        mockClient as any,
+        mockLogger as any,
+        mockHook
+      );
+
+      await wrapped.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello!' }]
+      });
+
+      // When an explicit logger is provided, it is used directly.
+      // The ingestionHook is not used to create a new logger.
+      expect(mockLogger.startTrace).toHaveBeenCalledTimes(1);
+      expect(mockLogger.addLlmSpan).toHaveBeenCalledTimes(1);
+      expect(mockLogger.conclude).toHaveBeenCalledTimes(1);
+    });
+
+    test('test wrapOpenAI without ingestionHook or logger does not error during wrapping', async () => {
+      const mockClient = createMockOpenAIClient();
+
+      // Wrapping should succeed regardless of singleton state
+      const wrapped = wrapOpenAI(mockClient as any);
+      expect(wrapped).toBeDefined();
+      expect(wrapped.chat).toBeDefined();
+      expect(wrapped.chat.completions).toBeDefined();
+    });
+
+    test('test ingestionHook logger is instance of GalileoLogger', async () => {
+      const mockHook = jest
+        .fn<Promise<void>, [LogTracesIngestRequest]>()
+        .mockResolvedValue(undefined);
+      const mockClient = createMockOpenAIClient();
+
+      // Spy on GalileoLogger constructor to verify it was called with ingestionHook
+      const constructorSpy = jest.spyOn(
+        GalileoLogger.prototype as never,
+        'initializeProperties' as never
+      );
+
+      const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+      await wrapped.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [{ role: 'user', content: 'Hello!' }]
+      });
+
+      // GalileoLogger constructor was called with config containing ingestionHook
+      expect(constructorSpy).toHaveBeenCalledTimes(1);
+      const config = constructorSpy.mock.calls[0][0] as Record<string, unknown>;
+      expect(config.ingestionHook).toBe(mockHook);
+
+      constructorSpy.mockRestore();
+    });
   });
 });

--- a/tests/handlers/openai/ingestion-hook.test.ts
+++ b/tests/handlers/openai/ingestion-hook.test.ts
@@ -1,0 +1,136 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { wrapOpenAI } from '../../../src/handlers/openai';
+import type { LogTracesIngestRequest } from '../../../src/types/logging/trace.types';
+
+/**
+ * Creates a minimal mock OpenAI client with chat.completions.create.
+ * Returns a non-streaming response by default.
+ */
+function createMockOpenAIClient() {
+  const mockResponse = {
+    id: 'chatcmpl-test-123',
+    object: 'chat.completion',
+    created: 1234567890,
+    model: 'gpt-4o',
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: 'assistant',
+          content: 'Hello! How can I help you?'
+        },
+        finish_reason: 'stop'
+      }
+    ],
+    usage: {
+      prompt_tokens: 10,
+      completion_tokens: 8,
+      total_tokens: 18
+    }
+  };
+
+  return {
+    chat: {
+      completions: {
+        create: jest.fn().mockResolvedValue(mockResponse)
+      }
+    },
+    embeddings: {},
+    moderations: {}
+  };
+}
+
+describe('wrapOpenAI ingestionHook', () => {
+  test('test wrapOpenAI forwards ingestionHook to logger and hook is called on flush', async () => {
+    const mockHook = jest
+      .fn<Promise<void>, [LogTracesIngestRequest]>()
+      .mockResolvedValue(undefined);
+    const mockClient = createMockOpenAIClient();
+
+    const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+    await wrapped.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello!' }]
+    });
+
+    // The hook should have been called because:
+    // 1. No logger was provided, so wrapOpenAI creates a new GalileoLogger({ ingestionHook })
+    // 2. No parent trace exists, so the proxy starts a trace, adds an LLM span, and concludes
+    // 3. conclude does NOT auto-flush in batch mode, so we need to verify the trace was built
+    // The hook is called during flush(), which happens when the logger flushes.
+    // In the wrapOpenAI flow, flush is not called automatically for non-streaming.
+    // But the trace is built correctly. Let's verify the hook gets called
+    // by checking the mock was at least set up correctly.
+    // Actually, wrapOpenAI does NOT call flush() after conclude. So the hook won't be called yet.
+    // This is expected behavior - the caller is responsible for flushing.
+    // We can verify the hook will be called by checking that the wrapped client works.
+    expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+  });
+
+  test('test wrapOpenAI with ingestionHook creates logger that uses hook on flush', async () => {
+    const hookCalls: LogTracesIngestRequest[] = [];
+    const mockHook = jest
+      .fn<Promise<void>, [LogTracesIngestRequest]>()
+      .mockImplementation(async (request) => {
+        hookCalls.push(request);
+      });
+    const mockClient = createMockOpenAIClient();
+
+    const wrapped = wrapOpenAI(mockClient as any, undefined, mockHook);
+
+    // Make a call to trigger trace creation
+    await wrapped.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Say hello!' }]
+    });
+
+    // The internal logger has a trace now but flush hasn't been called yet.
+    // We can't easily access the internal logger to call flush() directly,
+    // but we can verify the proxy correctly forwarded the call and created spans.
+    expect(mockClient.chat.completions.create).toHaveBeenCalledTimes(1);
+
+    // Verify the original call arguments were passed through
+    const callArgs = mockClient.chat.completions.create.mock.calls[0][0];
+    expect(callArgs.model).toBe('gpt-4o');
+  });
+
+  test('test wrapOpenAI without ingestionHook or logger does not error', async () => {
+    // This tests that when neither logger nor ingestionHook are provided,
+    // the proxy will attempt to use the singleton. This will fail in test
+    // environment because singleton isn't initialized, but it should not
+    // error during wrapping itself.
+    const mockClient = createMockOpenAIClient();
+
+    // Wrapping should succeed regardless of singleton state
+    const wrapped = wrapOpenAI(mockClient as any);
+    expect(wrapped).toBeDefined();
+    expect(wrapped.chat).toBeDefined();
+    expect(wrapped.chat.completions).toBeDefined();
+  });
+
+  test('test wrapOpenAI with explicit logger ignores ingestionHook', async () => {
+    const mockHook = jest.fn();
+    const mockLogger = {
+      currentParent: jest.fn().mockReturnValue(null),
+      startTrace: jest.fn(),
+      addLlmSpan: jest.fn(),
+      conclude: jest.fn(),
+      flush: jest.fn().mockResolvedValue([])
+    };
+    const mockClient = createMockOpenAIClient();
+
+    const wrapped = wrapOpenAI(mockClient as any, mockLogger as any, mockHook);
+
+    await wrapped.chat.completions.create({
+      model: 'gpt-4o',
+      messages: [{ role: 'user', content: 'Hello!' }]
+    });
+
+    // When an explicit logger is provided, it is used directly.
+    // The ingestionHook is not used to create a new logger.
+    expect(mockLogger.startTrace).toHaveBeenCalledTimes(1);
+    expect(mockLogger.addLlmSpan).toHaveBeenCalledTimes(1);
+    expect(mockLogger.conclude).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
# User description
# (TS SDK Parity Effort) Missing - Async Handlers - [sc-43798](https://app.shortcut.com/galileo/story/43798/ts-sdk-parity-effort-missing-async-handlers)

## Description
* Fixed a concurrency bug — The Langchain handler stored trace state in a shared module-level variable (rootNodeContext). If two traces ran at the same time, they'd overwrite each other. It was moved to an instance field so each callback owns its own state.
	- Deleted the shared global variable; put _rootNode on the class instance instead. Each instance now tracks its own root node.
* Added ingestionHook support to all handlers — wrapOpenAI, wrapAzureOpenAI, and GalileoTracingProcessor (OpenAI Agents) now accept an optional ingestionHook callback. This lets users intercept/transform log data before it's sent to Galileo.
	- Added it as an optional parameter to each handler's constructor/wrapper. When present, it's called before sending data. The resolution order is: explicit logger > ingestionHook > singleton fallback — consistent everywhere.
* Docs & types — JSDoc + README examples, and exported the LogTracesIngestRequest type so users can type their hook functions.

## Out-of-scope
An attempt was made to unify certain features shared by OpenAI (standard and Agents) and LangChain SDKs. Although it was doable to an extent, it was less than expected and could in the future require refactoring if the SDKs stranded in implementation. This attempt was excluded from the final PR, to be revisited if other handlers are included.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
wrapOpenAI_("wrapOpenAI"):::modified
generateChatCompletionProxy_("generateChatCompletionProxy"):::modified
generateResponseApiProxy_("generateResponseApiProxy"):::modified
GalileoLogger_flush_("GalileoLogger.flush"):::modified
GALILEO_API_("GALILEO_API"):::modified
registerGalileoTraceProcessor_("registerGalileoTraceProcessor"):::modified
GalileoTracingProcessor_constructor_("GalileoTracingProcessor.constructor"):::modified
wrapOpenAI_ -- "Passes ingestionHook to chat proxy; flushes logger per call." --> generateChatCompletionProxy_
wrapOpenAI_ -- "Passes ingestionHook to responses proxy; enables per-call flushing." --> generateResponseApiProxy_
generateChatCompletionProxy_ -- "Auto-flush traces after chat calls when ingestionHook-created logger used." --> GalileoLogger_flush_
generateResponseApiProxy_ -- "Auto-flush traces after responses calls when ingestionHook-created logger used." --> GalileoLogger_flush_
GalileoLogger_flush_ -- "Flush skips Galileo API client init when ingestionHook configured." --> GALILEO_API_
registerGalileoTraceProcessor_ -- "Constructor now accepts ingestionHook, creating GalileoLogger for trace ingestion." --> GalileoTracingProcessor_constructor_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Resolve concurrency issues in Langchain tracing by moving root node tracking onto each <code>GalileoCallback</code> instance and adjusting tests accordingly. Enable ingestion hooks across <code>wrapOpenAI</code>, <code>wrapAzureOpenAI</code>, and <code>GalileoTracingProcessor</code> so optional callbacks can inspect or modify trace payloads via <code>GalileoLogger</code> before the data is sent.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/564?tool=ast&topic=Ingestion+hook+flow>Ingestion hook flow</a>
        </td><td>Add ingestion hook plumbing to <code>wrapOpenAI</code>, <code>wrapAzureOpenAI</code>, <code>GalileoTracingProcessor</code>, and <code>GalileoLogger</code>, update the docs/types, and cover the new flow with tests so callbacks can intercept the <code>LogTracesIngestRequest</code> payload before any flush.<details><summary>Modified files (7)</summary><ul><li>README.md</li>
<li>src/handlers/openai-agents/index.ts</li>
<li>src/handlers/openai/index.ts</li>
<li>src/index.ts</li>
<li>src/utils/galileo-logger.ts</li>
<li>tests/handlers/openai-agents/ingestion-hook.test.ts</li>
<li>tests/handlers/openai/ingestion-hook.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(langchain): Initi...</td><td>April 13, 2026</td></tr>
<tr><td>jimbobbennett@mac.com</td><td>fix: Moving duration a...</td><td>July 09, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/564?tool=ast&topic=LangChain+tracing>LangChain tracing</a>
        </td><td>Move root node tracking onto each <code>GalileoCallback</code> instance and reset it during <code>_commit</code> to eliminate the shared <code>rootNodeContext</code> state, updating the accompanying tests for the new instance field.<details><summary>Modified files (4)</summary><ul><li>src/handlers/langchain/index.ts</li>
<li>src/handlers/langchain/node.ts</li>
<li>tests/handlers/langchain/callback.test.ts</li>
<li>tests/handlers/langchain/node.test.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(langchain): Initi...</td><td>April 13, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/564?tool=ast>(Baz)</a>.