### PR TITLE
chore(workflow): Updated workflow to support trusted publisher.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies


### PR DESCRIPTION
# User description
- Updated release workflow to guarantee npm version used during npm release supports trusted publisher (currently configured in npm for the ```publisher.yaml``` workflow).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Ensure the release workflow sets up Node.js 24 via <code>actions/setup-node</code> so the npm trusted publisher feature is supported. Align the workflow’s dependency installation steps with the same Node version used by the publisher configuration.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>fix(auth): Removed dep...</td><td>April 10, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/566?tool=ast>(Baz)</a>.