### PR TITLE
feat(terminate): Implemented logger termination.

### DIFF
--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -182,7 +182,15 @@ export class GalileoSingleton {
         process.env.GALILEO_LOG_STREAM_NAME,
       experimentId: options.experimentId ?? context?.experimentId,
       localMetrics: options.localMetrics,
-      mode: options.mode
+      mode: options.mode,
+      onTerminate: (terminated) => {
+        if (this.galileoLoggers.get(key) === terminated) {
+          this.galileoLoggers.delete(key);
+        }
+        if (this.lastAvailableLogger === terminated) {
+          this.lastAvailableLogger = null;
+        }
+      }
     };
 
     const logger = new GalileoLogger(config);
@@ -222,12 +230,9 @@ export class GalileoSingleton {
 
     const logger = this.galileoLoggers.get(key);
     if (logger) {
+      // terminate() triggers the onTerminate callback which removes the entry
+      // from galileoLoggers and clears lastAvailableLogger if needed.
       await logger.terminate();
-      this.galileoLoggers.delete(key);
-
-      if (this.lastAvailableLogger === logger) {
-        this.lastAvailableLogger = null;
-      }
     }
   }
 
@@ -236,10 +241,11 @@ export class GalileoSingleton {
    * @returns A promise that resolves when all loggers are reset
    */
   public async resetAll(): Promise<void> {
-    const resetPromises = Array.from(this.galileoLoggers.values()).map(
-      (logger) => logger.terminate()
-    );
-    await Promise.all(resetPromises);
+    // Snapshot values first — terminate() mutates galileoLoggers via the onTerminate callback.
+    const loggers = Array.from(this.galileoLoggers.values());
+    await Promise.all(loggers.map((logger) => logger.terminate()));
+    // Defensive backstop: clear any loggers that lacked an onTerminate hook
+    // (e.g., ones added via the legacy setClient path prior to this change).
     this.galileoLoggers.clear();
     this.lastAvailableLogger = null;
   }

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -233,6 +233,12 @@ export class GalileoSingleton {
       // terminate() triggers the onTerminate callback which removes the entry
       // from galileoLoggers and clears lastAvailableLogger if needed.
       await logger.terminate();
+      if (this.galileoLoggers.get(key) === logger) {
+        this.galileoLoggers.delete(key);
+      }
+      if (this.lastAvailableLogger === logger) {
+        this.lastAvailableLogger = null;
+      }
     }
   }
 

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -241,8 +241,7 @@ export class GalileoSingleton {
     if (logger) {
       // terminate() triggers the onTerminate callback which calls cleanupLogger().
       // The defensive call below is a backstop for cases where onTerminate doesn't
-      // fire (legacy setClient() loggers, or terminate() short-circuited by
-      // skipIfDisabledAsync when GALILEO_DISABLE_LOGGING is set).
+      // fire (e.g. legacy setClient() loggers that lack the hook).
       await logger.terminate();
       this.cleanupLogger(key, logger);
     }

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -183,8 +183,8 @@ export class GalileoSingleton {
       experimentId: options.experimentId ?? context?.experimentId,
       localMetrics: options.localMetrics,
       mode: options.mode,
-      onTerminate: (terminated) =>
-        this.cleanupLogger(key, terminated as GalileoLogger)
+      onTerminate: (terminatedLogger) =>
+        this.cleanupLogger(key, terminatedLogger as GalileoLogger)
     };
 
     const logger = new GalileoLogger(config);

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -183,14 +183,8 @@ export class GalileoSingleton {
       experimentId: options.experimentId ?? context?.experimentId,
       localMetrics: options.localMetrics,
       mode: options.mode,
-      onTerminate: (terminated) => {
-        if (this.galileoLoggers.get(key) === terminated) {
-          this.galileoLoggers.delete(key);
-        }
-        if (this.lastAvailableLogger === terminated) {
-          this.lastAvailableLogger = null;
-        }
-      }
+      onTerminate: (terminated) =>
+        this.cleanupLogger(key, terminated as GalileoLogger)
     };
 
     const logger = new GalileoLogger(config);
@@ -212,6 +206,21 @@ export class GalileoSingleton {
   }
 
   /**
+   * Removes a logger from internal tracking. Idempotent — only removes the
+   * map entry / clears lastAvailableLogger if they still reference the given
+   * logger, so it can be safely called from both the onTerminate hook and the
+   * reset() backstop.
+   */
+  private cleanupLogger(key: string, logger: GalileoLogger): void {
+    if (this.galileoLoggers.get(key) === logger) {
+      this.galileoLoggers.delete(key);
+    }
+    if (this.lastAvailableLogger === logger) {
+      this.lastAvailableLogger = null;
+    }
+  }
+
+  /**
    * Resets (terminates and removes) a GalileoLogger instance.
    * @param options - Configuration options to identify which logger to reset
    * @param options.projectName - (Optional) The project name
@@ -230,15 +239,12 @@ export class GalileoSingleton {
 
     const logger = this.galileoLoggers.get(key);
     if (logger) {
-      // terminate() triggers the onTerminate callback which removes the entry
-      // from galileoLoggers and clears lastAvailableLogger if needed.
+      // terminate() triggers the onTerminate callback which calls cleanupLogger().
+      // The defensive call below is a backstop for cases where onTerminate doesn't
+      // fire (legacy setClient() loggers, or terminate() short-circuited by
+      // skipIfDisabledAsync when GALILEO_DISABLE_LOGGING is set).
       await logger.terminate();
-      if (this.galileoLoggers.get(key) === logger) {
-        this.galileoLoggers.delete(key);
-      }
-      if (this.lastAvailableLogger === logger) {
-        this.lastAvailableLogger = null;
-      }
+      this.cleanupLogger(key, logger);
     }
   }
 

--- a/src/types/logging/logger.types.ts
+++ b/src/types/logging/logger.types.ts
@@ -29,6 +29,11 @@ export interface GalileoLoggerConfig {
   logStreamId?: string;
   ingestionHook?: (request: LogTracesIngestRequest) => Promise<void> | void;
   experimental?: { mode?: string };
+  /**
+   * @internal Callback invoked when terminate() completes. Used by GalileoSingleton to
+   * deregister the logger from its internal map and clear lastAvailableLogger if needed.
+   */
+  onTerminate?: (logger: IGalileoLogger) => void;
 }
 
 export interface GalileoLoggerConfigExtended extends GalileoLoggerConfig {
@@ -449,9 +454,18 @@ export interface IGalileoLoggerBatch {
 
   /**
    * Terminates the logger. In batch mode, flushes all traces. In streaming mode, waits for all tasks to complete.
+   * After termination, subsequent calls to mutating methods are no-ops that emit a warning, and a
+   * singleton-managed logger is removed from the singleton's registry.
+   * Calling terminate() more than once is a no-op on subsequent calls.
    * @returns A promise that resolves when termination is complete.
    */
   terminate(): Promise<void>;
+
+  /**
+   * Whether terminate() has completed on this logger. Once true, the logger will no-op on
+   * further mutating calls and has been deregistered from the singleton (if applicable).
+   */
+  readonly terminated: boolean;
 }
 
 /**

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -124,6 +124,16 @@ function skipIfTerminatedAsync<T, Args extends unknown[]>(
   };
 }
 
+type SyncGuard = <T, Args extends unknown[]>(
+  fn: (this: GalileoLogger, ...args: Args) => T,
+  defaultValueFn: (args: Args) => T
+) => (this: GalileoLogger, ...args: Args) => T;
+
+type AsyncGuard = <T, Args extends unknown[]>(
+  fn: (this: GalileoLogger, ...args: Args) => Promise<T>,
+  defaultValueFn: (args: Args) => T
+) => (this: GalileoLogger, ...args: Args) => Promise<T>;
+
 class GalileoLogger implements IGalileoLogger {
   private projectName?: string;
   private logStreamName?: string;
@@ -1459,7 +1469,7 @@ class GalileoLogger implements IGalileoLogger {
     }
   }
 
-  private wrapMethodsForDisabledLogging(): void {
+  private applySharedGuards(guard: SyncGuard, asyncGuard: AsyncGuard): void {
     const emptySpanData = {
       input: '',
       redactedInput: undefined,
@@ -1467,150 +1477,64 @@ class GalileoLogger implements IGalileoLogger {
       redactedOutput: undefined
     };
 
-    this.addChildSpanToParent = skipIfDisabled(
+    this.addChildSpanToParent = guard(
       this.addChildSpanToParent,
       () => undefined
     );
-
-    this.startTrace = skipIfDisabled(
-      this.startTrace,
-      () => new Trace(emptySpanData)
-    );
-
-    this.addSingleLlmSpanTrace = skipIfDisabled(
+    this.startTrace = guard(this.startTrace, () => new Trace(emptySpanData));
+    this.addSingleLlmSpanTrace = guard(
       this.addSingleLlmSpanTrace,
       () => new Trace(emptySpanData)
     );
-
-    this.addSingleRetrieverSpanTrace = skipIfDisabled(
+    this.addSingleRetrieverSpanTrace = guard(
       this.addSingleRetrieverSpanTrace,
       () => new Trace(emptySpanData)
     );
-
-    this.addSingleToolSpanTrace = skipIfDisabled(
+    this.addSingleToolSpanTrace = guard(
       this.addSingleToolSpanTrace,
       () => new Trace(emptySpanData)
     );
-
-    this.addSingleWorkflowSpanTrace = skipIfDisabled(
+    this.addSingleWorkflowSpanTrace = guard(
       this.addSingleWorkflowSpanTrace,
       () => new Trace(emptySpanData)
     );
-
-    this.addLlmSpan = skipIfDisabled(
-      this.addLlmSpan,
-      () => new LlmSpan(emptySpanData)
-    );
-
-    this.addRetrieverSpan = skipIfDisabled(
+    this.addLlmSpan = guard(this.addLlmSpan, () => new LlmSpan(emptySpanData));
+    this.addRetrieverSpan = guard(
       this.addRetrieverSpan,
       () => new RetrieverSpan(emptySpanData)
     );
-
-    this.addToolSpan = skipIfDisabled(
+    this.addToolSpan = guard(
       this.addToolSpan,
       () => new ToolSpan(emptySpanData)
     );
-
-    this.addProtectSpan = skipIfDisabled(
+    this.addProtectSpan = guard(
       this.addProtectSpan,
       () => new ToolSpan(emptySpanData)
     );
-
-    this.addWorkflowSpan = skipIfDisabled(
+    this.addWorkflowSpan = guard(
       this.addWorkflowSpan,
       () => new WorkflowSpan(emptySpanData)
     );
-
-    this.addAgentSpan = skipIfDisabled(
+    this.addAgentSpan = guard(
       this.addAgentSpan,
       () => new AgentSpan(emptySpanData)
     );
+    this.conclude = guard(this.conclude, () => undefined);
+    this.flush = asyncGuard(this.flush, () => []);
+    this.startSession = asyncGuard(this.startSession, () => '');
+    this.clearSession = guard(this.clearSession, () => undefined);
+    this.initTrace = asyncGuard(this.initTrace, () => undefined);
+    this.initSpan = asyncGuard(this.initSpan, () => undefined);
+  }
 
-    this.conclude = skipIfDisabled(this.conclude, () => undefined);
-    this.flush = skipIfDisabledAsync(this.flush, () => []);
+  private wrapMethodsForDisabledLogging(): void {
+    this.applySharedGuards(skipIfDisabled, skipIfDisabledAsync);
     this.terminate = skipIfDisabledAsync(this.terminate, () => undefined);
-    this.startSession = skipIfDisabledAsync(this.startSession, () => '');
-    this.clearSession = skipIfDisabled(this.clearSession, () => undefined);
-    this.initTrace = skipIfDisabledAsync(this.initTrace, () => undefined);
-    this.initSpan = skipIfDisabledAsync(this.initSpan, () => undefined);
   }
 
   private wrapMethodsForTerminated(): void {
-    const emptySpanData = {
-      input: '',
-      redactedInput: undefined,
-      output: '',
-      redactedOutput: undefined
-    };
-
-    this.addChildSpanToParent = skipIfTerminated(
-      this.addChildSpanToParent,
-      () => undefined
-    );
-
-    this.startTrace = skipIfTerminated(
-      this.startTrace,
-      () => new Trace(emptySpanData)
-    );
-
-    this.addSingleLlmSpanTrace = skipIfTerminated(
-      this.addSingleLlmSpanTrace,
-      () => new Trace(emptySpanData)
-    );
-
-    this.addSingleRetrieverSpanTrace = skipIfTerminated(
-      this.addSingleRetrieverSpanTrace,
-      () => new Trace(emptySpanData)
-    );
-
-    this.addSingleToolSpanTrace = skipIfTerminated(
-      this.addSingleToolSpanTrace,
-      () => new Trace(emptySpanData)
-    );
-
-    this.addSingleWorkflowSpanTrace = skipIfTerminated(
-      this.addSingleWorkflowSpanTrace,
-      () => new Trace(emptySpanData)
-    );
-
-    this.addLlmSpan = skipIfTerminated(
-      this.addLlmSpan,
-      () => new LlmSpan(emptySpanData)
-    );
-
-    this.addRetrieverSpan = skipIfTerminated(
-      this.addRetrieverSpan,
-      () => new RetrieverSpan(emptySpanData)
-    );
-
-    this.addToolSpan = skipIfTerminated(
-      this.addToolSpan,
-      () => new ToolSpan(emptySpanData)
-    );
-
-    this.addProtectSpan = skipIfTerminated(
-      this.addProtectSpan,
-      () => new ToolSpan(emptySpanData)
-    );
-
-    this.addWorkflowSpan = skipIfTerminated(
-      this.addWorkflowSpan,
-      () => new WorkflowSpan(emptySpanData)
-    );
-
-    this.addAgentSpan = skipIfTerminated(
-      this.addAgentSpan,
-      () => new AgentSpan(emptySpanData)
-    );
-
-    this.conclude = skipIfTerminated(this.conclude, () => undefined);
-    this.flush = skipIfTerminatedAsync(this.flush, () => []);
-    this.startSession = skipIfTerminatedAsync(this.startSession, () => '');
+    this.applySharedGuards(skipIfTerminated, skipIfTerminatedAsync);
     this.setSessionId = skipIfTerminated(this.setSessionId, () => undefined);
-    this.clearSession = skipIfTerminated(this.clearSession, () => undefined);
-    this.initTrace = skipIfTerminatedAsync(this.initTrace, () => undefined);
-    this.initSpan = skipIfTerminatedAsync(this.initSpan, () => undefined);
   }
 
   private registerCleanupHandlers(): void {

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -55,13 +55,16 @@ function skipIfDisabled<T, Args extends unknown[]>(
   fn: (this: GalileoLogger, ...args: Args) => T,
   defaultValueFn: (args: Args) => T
 ): (this: GalileoLogger, ...args: Args) => T {
-  return function (this: GalileoLogger, ...args: Args): T {
+  const fnName = fn.name || 'unknown';
+  const wrapper = function (this: GalileoLogger, ...args: Args): T {
     if (this.isLoggingDisabled()) {
-      sdkLogger.warn('Logging is disabled, skipping execution of', fn.name);
+      sdkLogger.warn('Logging is disabled, skipping execution of', fnName);
       return defaultValueFn(args);
     }
     return fn.apply(this, args);
   };
+  Object.defineProperty(wrapper, 'name', { value: fnName, configurable: true });
+  return wrapper;
 }
 
 /**
@@ -73,13 +76,19 @@ function skipIfDisabledAsync<T, Args extends unknown[]>(
   fn: (this: GalileoLogger, ...args: Args) => Promise<T>,
   defaultValueFn: (args: Args) => T
 ): (this: GalileoLogger, ...args: Args) => Promise<T> {
-  return async function (this: GalileoLogger, ...args: Args): Promise<T> {
+  const fnName = fn.name || 'unknown';
+  const wrapper = async function (
+    this: GalileoLogger,
+    ...args: Args
+  ): Promise<T> {
     if (this.isLoggingDisabled()) {
-      sdkLogger.warn('Logging is disabled, skipping execution of', fn.name);
+      sdkLogger.warn('Logging is disabled, skipping execution of', fnName);
       return defaultValueFn(args);
     }
     return await fn.apply(this, args);
   };
+  Object.defineProperty(wrapper, 'name', { value: fnName, configurable: true });
+  return wrapper;
 }
 
 /**
@@ -91,16 +100,19 @@ function skipIfTerminated<T, Args extends unknown[]>(
   fn: (this: GalileoLogger, ...args: Args) => T,
   defaultValueFn: (args: Args) => T
 ): (this: GalileoLogger, ...args: Args) => T {
-  return function (this: GalileoLogger, ...args: Args): T {
+  const fnName = fn.name || 'unknown';
+  const wrapper = function (this: GalileoLogger, ...args: Args): T {
     if (this.terminated) {
       sdkLogger.warn(
         'Logger has been terminated, skipping execution of',
-        fn.name
+        fnName
       );
       return defaultValueFn(args);
     }
     return fn.apply(this, args);
   };
+  Object.defineProperty(wrapper, 'name', { value: fnName, configurable: true });
+  return wrapper;
 }
 
 /**
@@ -112,16 +124,22 @@ function skipIfTerminatedAsync<T, Args extends unknown[]>(
   fn: (this: GalileoLogger, ...args: Args) => Promise<T>,
   defaultValueFn: (args: Args) => T
 ): (this: GalileoLogger, ...args: Args) => Promise<T> {
-  return async function (this: GalileoLogger, ...args: Args): Promise<T> {
+  const fnName = fn.name || 'unknown';
+  const wrapper = async function (
+    this: GalileoLogger,
+    ...args: Args
+  ): Promise<T> {
     if (this.terminated) {
       sdkLogger.warn(
         'Logger has been terminated, skipping execution of',
-        fn.name
+        fnName
       );
       return defaultValueFn(args);
     }
     return await fn.apply(this, args);
   };
+  Object.defineProperty(wrapper, 'name', { value: fnName, configurable: true });
+  return wrapper;
 }
 
 type SyncGuard = <T, Args extends unknown[]>(

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -82,6 +82,48 @@ function skipIfDisabledAsync<T, Args extends unknown[]>(
   };
 }
 
+/**
+ * Higher-order function that wraps a method to skip execution if the logger has been terminated.
+ * @param fn The original method
+ * @param defaultValueFn A function that returns the default value when the logger is terminated
+ */
+function skipIfTerminated<T, Args extends unknown[]>(
+  fn: (this: GalileoLogger, ...args: Args) => T,
+  defaultValueFn: (args: Args) => T
+): (this: GalileoLogger, ...args: Args) => T {
+  return function (this: GalileoLogger, ...args: Args): T {
+    if (this.terminated) {
+      sdkLogger.warn(
+        'Logger has been terminated, skipping execution of',
+        fn.name
+      );
+      return defaultValueFn(args);
+    }
+    return fn.apply(this, args);
+  };
+}
+
+/**
+ * Higher-order function that wraps an async method to skip execution if the logger has been terminated.
+ * @param fn The original async method
+ * @param defaultValueFn A function that returns the default value when the logger is terminated
+ */
+function skipIfTerminatedAsync<T, Args extends unknown[]>(
+  fn: (this: GalileoLogger, ...args: Args) => Promise<T>,
+  defaultValueFn: (args: Args) => T
+): (this: GalileoLogger, ...args: Args) => Promise<T> {
+  return async function (this: GalileoLogger, ...args: Args): Promise<T> {
+    if (this.terminated) {
+      sdkLogger.warn(
+        'Logger has been terminated, skipping execution of',
+        fn.name
+      );
+      return defaultValueFn(args);
+    }
+    return await fn.apply(this, args);
+  };
+}
+
 class GalileoLogger implements IGalileoLogger {
   private projectName?: string;
   private logStreamName?: string;
@@ -102,6 +144,16 @@ class GalileoLogger implements IGalileoLogger {
   private loggingDisabled: boolean = false;
   private taskHandler?: TaskHandler;
   private isTerminating = false;
+  private _terminated = false;
+  private onTerminate?: (logger: IGalileoLogger) => void;
+
+  /**
+   * Whether terminate() has completed on this logger. Once true, subsequent mutating calls no-op
+   * with a warning and the logger has been deregistered from the singleton (if applicable).
+   */
+  get terminated(): boolean {
+    return this._terminated;
+  }
 
   /**
    * Static factory method to create and initialize a logger.
@@ -177,6 +229,7 @@ class GalileoLogger implements IGalileoLogger {
     this.validateConfiguration();
     this.initializeLoggerState();
     this.wrapMethodsForDisabledLogging();
+    this.wrapMethodsForTerminated();
     this.registerCleanupHandlers();
   }
 
@@ -1312,9 +1365,12 @@ class GalileoLogger implements IGalileoLogger {
 
   /**
    * Terminates the logger. In batch mode, flushes all traces. In streaming mode, waits for all tasks to complete.
+   * After termination, subsequent mutating calls no-op with a warning, and loggers created through the
+   * singleton are removed from the singleton's registry. Calling terminate() again is a no-op.
    * @returns A promise that resolves when termination is complete.
    */
   async terminate(): Promise<void> {
+    if (this._terminated) return;
     try {
       if (this.mode !== 'streaming') {
         await this.flush();
@@ -1346,6 +1402,16 @@ class GalileoLogger implements IGalileoLogger {
     } catch (error) {
       sdkLogger.error('Error in terminate():', error);
       throw error;
+    } finally {
+      this._terminated = true;
+      try {
+        this.onTerminate?.(this);
+      } catch (hookError) {
+        sdkLogger.error(
+          'Error in onTerminate callback during terminate():',
+          hookError
+        );
+      }
     }
   }
 
@@ -1358,6 +1424,7 @@ class GalileoLogger implements IGalileoLogger {
     this.projectId = config.projectId;
     this.logStreamId = config.logStreamId;
     this.ingestionHook = config.ingestionHook;
+    this.onTerminate = config.onTerminate;
 
     this.mode = config.mode || config.experimental?.mode || 'batch';
   }
@@ -1467,6 +1534,83 @@ class GalileoLogger implements IGalileoLogger {
     this.clearSession = skipIfDisabled(this.clearSession, () => undefined);
     this.initTrace = skipIfDisabledAsync(this.initTrace, () => undefined);
     this.initSpan = skipIfDisabledAsync(this.initSpan, () => undefined);
+  }
+
+  private wrapMethodsForTerminated(): void {
+    const emptySpanData = {
+      input: '',
+      redactedInput: undefined,
+      output: '',
+      redactedOutput: undefined
+    };
+
+    this.addChildSpanToParent = skipIfTerminated(
+      this.addChildSpanToParent,
+      () => undefined
+    );
+
+    this.startTrace = skipIfTerminated(
+      this.startTrace,
+      () => new Trace(emptySpanData)
+    );
+
+    this.addSingleLlmSpanTrace = skipIfTerminated(
+      this.addSingleLlmSpanTrace,
+      () => new Trace(emptySpanData)
+    );
+
+    this.addSingleRetrieverSpanTrace = skipIfTerminated(
+      this.addSingleRetrieverSpanTrace,
+      () => new Trace(emptySpanData)
+    );
+
+    this.addSingleToolSpanTrace = skipIfTerminated(
+      this.addSingleToolSpanTrace,
+      () => new Trace(emptySpanData)
+    );
+
+    this.addSingleWorkflowSpanTrace = skipIfTerminated(
+      this.addSingleWorkflowSpanTrace,
+      () => new Trace(emptySpanData)
+    );
+
+    this.addLlmSpan = skipIfTerminated(
+      this.addLlmSpan,
+      () => new LlmSpan(emptySpanData)
+    );
+
+    this.addRetrieverSpan = skipIfTerminated(
+      this.addRetrieverSpan,
+      () => new RetrieverSpan(emptySpanData)
+    );
+
+    this.addToolSpan = skipIfTerminated(
+      this.addToolSpan,
+      () => new ToolSpan(emptySpanData)
+    );
+
+    this.addProtectSpan = skipIfTerminated(
+      this.addProtectSpan,
+      () => new ToolSpan(emptySpanData)
+    );
+
+    this.addWorkflowSpan = skipIfTerminated(
+      this.addWorkflowSpan,
+      () => new WorkflowSpan(emptySpanData)
+    );
+
+    this.addAgentSpan = skipIfTerminated(
+      this.addAgentSpan,
+      () => new AgentSpan(emptySpanData)
+    );
+
+    this.conclude = skipIfTerminated(this.conclude, () => undefined);
+    this.flush = skipIfTerminatedAsync(this.flush, () => []);
+    this.startSession = skipIfTerminatedAsync(this.startSession, () => '');
+    this.setSessionId = skipIfTerminated(this.setSessionId, () => undefined);
+    this.clearSession = skipIfTerminated(this.clearSession, () => undefined);
+    this.initTrace = skipIfTerminatedAsync(this.initTrace, () => undefined);
+    this.initSpan = skipIfTerminatedAsync(this.initSpan, () => undefined);
   }
 
   private registerCleanupHandlers(): void {

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -1547,7 +1547,10 @@ class GalileoLogger implements IGalileoLogger {
 
   private wrapMethodsForDisabledLogging(): void {
     this.applySharedGuards(skipIfDisabled, skipIfDisabledAsync);
-    this.terminate = skipIfDisabledAsync(this.terminate, () => undefined);
+    // terminate() is intentionally NOT wrapped: when logging is disabled the
+    // inner flush() / taskHandler work is already a no-op, but _terminated
+    // and the onTerminate hook still need to fire so the singleton can
+    // deregister the logger. See PR #573 (sc-52517) comment thread.
   }
 
   private wrapMethodsForTerminated(): void {

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -22,14 +22,31 @@ jest.mock('../src/utils/galileo-logger', () => {
   return {
     ...actual,
     GalileoLogger: jest.fn().mockImplementation((config) => {
-      const mockLogger = {
+      const mockLogger: {
+        projectName?: string;
+        logStreamName?: string;
+        experimentId?: string;
+        localMetrics?: unknown;
+        mode?: string;
+        terminated: boolean;
+        flush: jest.Mock;
+        terminate: jest.Mock;
+        startSession: jest.Mock;
+        setSessionId: jest.Mock;
+        clearSession: jest.Mock;
+      } = {
         projectName: config?.projectName,
         logStreamName: config?.logStreamName,
         experimentId: config?.experimentId,
         localMetrics: config?.localMetrics,
         mode: config?.mode,
+        terminated: false,
         flush: jest.fn().mockResolvedValue([]),
-        terminate: jest.fn().mockResolvedValue(undefined),
+        terminate: jest.fn().mockImplementation(async () => {
+          if (mockLogger.terminated) return;
+          mockLogger.terminated = true;
+          config?.onTerminate?.(mockLogger);
+        }),
         startSession: jest.fn().mockResolvedValue('session-id'),
         setSessionId: jest.fn(),
         clearSession: jest.fn()
@@ -1521,6 +1538,95 @@ describe('Singleton utility functions', () => {
           logStreamName: 'primary-var'
         })
       );
+    });
+  });
+
+  describe('Logger self-deregistration via terminate()', () => {
+    test('test direct terminate() removes logger from singleton map', async () => {
+      const logger = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-a'
+      });
+      expect(getAllLoggers().size).toBe(1);
+
+      await logger.terminate();
+
+      expect(getAllLoggers().size).toBe(0);
+    });
+
+    test('test direct terminate() nullifies lastAvailableLogger when it matched', async () => {
+      const logger = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-b'
+      });
+
+      await logger.terminate();
+
+      // getClient falls back to getLogger() when lastAvailableLogger is null —
+      // a fresh default instance would be created, confirming the field was cleared.
+      const instance = GalileoSingleton.getInstance();
+      expect(instance['lastAvailableLogger']).toBeNull();
+    });
+
+    test('test subsequent getLogger() with same key returns a fresh instance after terminate', async () => {
+      const logger = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-c'
+      });
+
+      await logger.terminate();
+
+      const fresh = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-c'
+      });
+      expect(fresh).not.toBe(logger);
+    });
+
+    test('test singleton reset() still works and does not double-remove', async () => {
+      const logger = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-d'
+      });
+
+      await expect(
+        reset({ projectName: 'direct-term', logstream: 'stream-d' })
+      ).resolves.not.toThrow();
+      expect(logger.terminate).toHaveBeenCalledTimes(1);
+      expect(getAllLoggers().size).toBe(0);
+    });
+
+    test('test singleton resetAll() still works end-to-end', async () => {
+      const l1 = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-e'
+      });
+      const l2 = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-f'
+      });
+
+      await resetAll();
+
+      expect(l1.terminate).toHaveBeenCalled();
+      expect(l2.terminate).toHaveBeenCalled();
+      expect(getAllLoggers().size).toBe(0);
+    });
+
+    test('test lastAvailableLogger unaffected when a non-last logger is terminated', async () => {
+      const first = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-g'
+      });
+      const last = getLogger({
+        projectName: 'direct-term',
+        logstream: 'stream-h'
+      });
+
+      await first.terminate();
+
+      const instance = GalileoSingleton.getInstance();
+      expect(instance['lastAvailableLogger']).toBe(last);
     });
   });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -1629,4 +1629,74 @@ describe('Singleton utility functions', () => {
       expect(instance['lastAvailableLogger']).toBe(last);
     });
   });
+
+  describe('reset() defensive backstop', () => {
+    test('test reset cleans up logger registered via setClient (no onTerminate hook)', async () => {
+      const mockLogger = {
+        flush: jest.fn().mockResolvedValue([]),
+        terminate: jest.fn().mockResolvedValue(undefined),
+        startSession: jest.fn().mockResolvedValue('session-id')
+      } as unknown as GalileoLogger;
+
+      const singleton = GalileoSingleton.getInstance();
+      singleton.setClient(mockLogger);
+      expect(getAllLoggers().size).toBe(1);
+      expect(singleton.getClient()).toBe(mockLogger);
+
+      await reset();
+
+      expect(mockLogger.terminate).toHaveBeenCalled();
+      expect(getAllLoggers().size).toBe(0);
+      expect(singleton['lastAvailableLogger']).toBeNull();
+    });
+
+    test('test reset cleans up logger when terminate suppresses onTerminate (disabled logging)', async () => {
+      const logger = getLogger({
+        projectName: 'disabled-proj',
+        logstream: 'disabled-stream'
+      });
+
+      // Simulate GALILEO_DISABLE_LOGGING: skipIfDisabledAsync wraps terminate()
+      // and returns immediately, so the finally block never sets _terminated
+      // and onTerminate never fires.
+      (logger.terminate as jest.Mock).mockImplementation(async () => undefined);
+
+      expect(getAllLoggers().size).toBe(1);
+      expect(GalileoSingleton.getInstance()['lastAvailableLogger']).toBe(
+        logger
+      );
+
+      await reset({
+        projectName: 'disabled-proj',
+        logstream: 'disabled-stream'
+      });
+
+      expect(logger.terminate).toHaveBeenCalled();
+      expect(getAllLoggers().size).toBe(0);
+      expect(GalileoSingleton.getInstance()['lastAvailableLogger']).toBeNull();
+    });
+
+    test('test reset backstop is idempotent when onTerminate already cleaned up', async () => {
+      const logger1 = getLogger({
+        projectName: 'idempotent',
+        logstream: 'stream-1'
+      });
+      const logger2 = getLogger({
+        projectName: 'idempotent',
+        logstream: 'stream-2'
+      });
+      expect(getAllLoggers().size).toBe(2);
+
+      // logger1 has onTerminate installed (created via getLogger), so the
+      // hook removes it; the backstop sees `get(key) === logger` is false
+      // and skips. logger2 must remain untouched.
+      await reset({ projectName: 'idempotent', logstream: 'stream-1' });
+
+      expect(logger1.terminate).toHaveBeenCalledTimes(1);
+      expect(getAllLoggers().size).toBe(1);
+      expect(GalileoSingleton.getInstance()['lastAvailableLogger']).toBe(
+        logger2
+      );
+    });
+  });
 });

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -1650,15 +1650,17 @@ describe('Singleton utility functions', () => {
       expect(singleton['lastAvailableLogger']).toBeNull();
     });
 
-    test('test reset cleans up logger when terminate suppresses onTerminate (disabled logging)', async () => {
+    test('test reset cleans up logger when terminate completes without firing onTerminate (defensive)', async () => {
       const logger = getLogger({
-        projectName: 'disabled-proj',
-        logstream: 'disabled-stream'
+        projectName: 'no-hook',
+        logstream: 'no-hook-stream'
       });
 
-      // Simulate GALILEO_DISABLE_LOGGING: skipIfDisabledAsync wraps terminate()
-      // and returns immediately, so the finally block never sets _terminated
-      // and onTerminate never fires.
+      // Simulate any path where terminate() completes without invoking the
+      // onTerminate hook (e.g. a future regression, a user-supplied logger
+      // mocking terminate, or a custom subclass). The reset() backstop must
+      // still drop the entry from galileoLoggers and null out
+      // lastAvailableLogger.
       (logger.terminate as jest.Mock).mockImplementation(async () => undefined);
 
       expect(getAllLoggers().size).toBe(1);
@@ -1667,8 +1669,8 @@ describe('Singleton utility functions', () => {
       );
 
       await reset({
-        projectName: 'disabled-proj',
-        logstream: 'disabled-stream'
+        projectName: 'no-hook',
+        logstream: 'no-hook-stream'
       });
 
       expect(logger.terminate).toHaveBeenCalled();

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -3815,5 +3815,21 @@ describe('GalileoLogger', () => {
       await expect(standalone.terminate()).resolves.toBeUndefined();
       expect(standalone.terminated).toBe(true);
     });
+
+    it('test guard wrappers preserve original method names through both wrap layers', () => {
+      // Both wrapMethodsForDisabledLogging and wrapMethodsForTerminated wrap each
+      // method, so the final reference is a wrapper of a wrapper. Without
+      // Object.defineProperty(name) on each guard, fn.name would be "" by the
+      // time the terminated guard logs its warning. Assert the original name
+      // survives the chain.
+      const standalone = new GalileoLogger({ mode: 'batch' });
+
+      expect(standalone.addLlmSpan.name).toBe('addLlmSpan');
+      expect(standalone.addWorkflowSpan.name).toBe('addWorkflowSpan');
+      expect(standalone.startTrace.name).toBe('startTrace');
+      expect(standalone.flush.name).toBe('flush');
+      expect(standalone.terminate.name).toBe('terminate');
+      expect(standalone.setSessionId.name).toBe('setSessionId');
+    });
   });
 });

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -3334,6 +3334,29 @@ describe('GalileoLogger', () => {
       it('should resolve without error when logging is disabled', async () => {
         await expect(logger.terminate()).resolves.toBeUndefined();
       });
+
+      it('should still flip terminated to true when logging is disabled', async () => {
+        // terminate() must run its lifecycle bookkeeping even when logging is
+        // disabled, so the singleton can deregister the logger via onTerminate.
+        // The inner flush()/taskHandler work is independently no-op'd by the
+        // disabled guard.
+        expect(logger.terminated).toBe(false);
+        await logger.terminate();
+        expect(logger.terminated).toBe(true);
+      });
+
+      it('should still fire onTerminate when logging is disabled', async () => {
+        const onTerminate = jest.fn();
+        const loggerWithHook = new GalileoLogger({
+          mode: 'batch',
+          onTerminate
+        });
+
+        await loggerWithHook.terminate();
+
+        expect(onTerminate).toHaveBeenCalledTimes(1);
+        expect(onTerminate).toHaveBeenCalledWith(loggerWithHook);
+      });
     });
 
     describe('startSession() with disabled logging', () => {

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -3650,4 +3650,170 @@ describe('GalileoLogger', () => {
       });
     });
   });
+
+  describe('Termination State', () => {
+    let mockClient: MockGalileoApiClient;
+
+    beforeEach(() => {
+      logger = new GalileoLogger({ mode: 'batch' });
+      mockClient = logger['client'] as unknown as MockGalileoApiClient;
+      mockClient.init = jest.fn().mockResolvedValue(undefined);
+      mockClient.ingestTraces = jest.fn().mockResolvedValue(undefined);
+    });
+
+    it('test terminated getter flips to true after terminate()', async () => {
+      expect(logger.terminated).toBe(false);
+      await logger.terminate();
+      expect(logger.terminated).toBe(true);
+    });
+
+    it('test terminate() is idempotent (flush called only once)', async () => {
+      const flushSpy = jest
+        .spyOn(GalileoLogger.prototype, 'flush')
+        .mockResolvedValue([]);
+      logger = new GalileoLogger({ mode: 'batch' });
+
+      await logger.terminate();
+      await logger.terminate();
+      await logger.terminate();
+
+      expect(flushSpy).toHaveBeenCalledTimes(1);
+      flushSpy.mockRestore();
+    });
+
+    it('test invokes onTerminate callback with itself after flush completes', async () => {
+      const onTerminate = jest.fn();
+      logger = new GalileoLogger({ mode: 'batch', onTerminate });
+
+      await logger.terminate();
+
+      expect(onTerminate).toHaveBeenCalledTimes(1);
+      expect(onTerminate).toHaveBeenCalledWith(logger);
+    });
+
+    it('test onTerminate callback errors are caught and do not propagate', async () => {
+      const onTerminate = jest.fn(() => {
+        throw new Error('callback boom');
+      });
+      logger = new GalileoLogger({ mode: 'batch', onTerminate });
+
+      await expect(logger.terminate()).resolves.toBeUndefined();
+      expect(logger.terminated).toBe(true);
+    });
+
+    it('test startTrace is no-op after terminate', async () => {
+      await logger.terminate();
+      const trace = logger.startTrace({ input: 'x' });
+      expect(trace).toBeInstanceOf(Trace);
+      expect(logger['traces']).toEqual([]);
+    });
+
+    it('test addLlmSpan returns empty span after terminate without mutating parent', async () => {
+      const trace = logger.startTrace({ input: 'x' });
+      await logger.terminate();
+      const span = logger.addLlmSpan({ input: 'in', output: 'out' });
+      expect(span).toBeInstanceOf(LlmSpan);
+      // Guard returned an empty stand-in; the trace must not have gained the span.
+      expect(trace.spans).toHaveLength(0);
+    });
+
+    it('test addWorkflowSpan returns empty span after terminate without mutating parent', async () => {
+      const trace = logger.startTrace({ input: 'x' });
+      await logger.terminate();
+      const span = logger.addWorkflowSpan({ input: 'in' });
+      expect(span).toBeInstanceOf(WorkflowSpan);
+      expect(trace.spans).toHaveLength(0);
+    });
+
+    it('test addAgentSpan returns empty span after terminate', async () => {
+      logger.startTrace({ input: 'x' });
+      await logger.terminate();
+      const span = logger.addAgentSpan({ input: 'in' });
+      expect(span).toBeInstanceOf(AgentSpan);
+    });
+
+    it('test addToolSpan returns empty span after terminate', async () => {
+      logger.startTrace({ input: 'x' });
+      await logger.terminate();
+      const span = logger.addToolSpan({ input: 'in' });
+      expect(span).toBeInstanceOf(ToolSpan);
+    });
+
+    it('test addRetrieverSpan returns empty span after terminate', async () => {
+      logger.startTrace({ input: 'x' });
+      await logger.terminate();
+      const span = logger.addRetrieverSpan({
+        input: 'in',
+        output: [new Document({ content: 'c' })]
+      });
+      expect(span).toBeInstanceOf(RetrieverSpan);
+    });
+
+    it('test addSingleLlmSpanTrace returns empty trace after terminate', async () => {
+      await logger.terminate();
+      const trace = logger.addSingleLlmSpanTrace({
+        input: 'in',
+        output: 'out'
+      });
+      expect(trace).toBeInstanceOf(Trace);
+      expect(logger['traces']).toEqual([]);
+    });
+
+    it('test conclude is no-op after terminate', async () => {
+      logger.startTrace({ input: 'x' });
+      await logger.terminate();
+      expect(() => logger.conclude({ output: 'y' })).not.toThrow();
+    });
+
+    it('test flush is no-op after terminate (no API call)', async () => {
+      await logger.terminate();
+      mockClient.ingestTraces.mockClear();
+
+      const result = await logger.flush();
+      expect(result).toEqual([]);
+      expect(mockClient.ingestTraces).not.toHaveBeenCalled();
+    });
+
+    it('test startSession is no-op after terminate', async () => {
+      await logger.terminate();
+      const id = await logger.startSession({ name: 's' });
+      expect(id).toBe('');
+    });
+
+    it('test setSessionId is no-op after terminate', async () => {
+      await logger.terminate();
+      logger.setSessionId('any');
+      expect(logger.currentSessionId()).toBeUndefined();
+    });
+
+    it('test clearSession is no-op after terminate', async () => {
+      await logger.terminate();
+      expect(() => logger.clearSession()).not.toThrow();
+    });
+
+    it('test guarded method returns instead of throwing after terminate', async () => {
+      await logger.terminate();
+      // Without the guard, addLlmSpan would throw ("no active parent") since the trace
+      // was not created. The guard must short-circuit before that check and return the
+      // typed stand-in — asserting the call does not throw is the behavioral contract.
+      expect(() =>
+        logger.addLlmSpan({ input: 'a', output: 'b' })
+      ).not.toThrow();
+    });
+
+    it('test still flushes pending traces during terminate (batch)', async () => {
+      logger.startTrace({ input: 'x' });
+      logger.addLlmSpan({ input: 'in', output: 'out' });
+
+      await logger.terminate();
+
+      expect(mockClient.ingestTraces).toHaveBeenCalledTimes(1);
+    });
+
+    it('test direct-instantiation logger (no singleton) terminates cleanly', async () => {
+      const standalone = new GalileoLogger({ mode: 'batch' });
+      await expect(standalone.terminate()).resolves.toBeUndefined();
+      expect(standalone.terminated).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
# User description
# [TS SDK] Logger's terminate method brings object back to constructor state, doesn't disable instance
 - [sc-52517](https://app.shortcut.com/galileo/story/52517/ts-sdk-logger-s-terminate-method-brings-object-back-to-constructor-state-doesn-t-disable-instance)

## Description
* Implemented termination process in logger, to avoid using it after termination was called;
* Extended termination to remove reference in singleton;

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
GalileoSingleton_getLogger_("GalileoSingleton.getLogger"):::modified
GalileoLogger_constructor_("GalileoLogger.constructor"):::modified
GalileoSingleton_cleanupLogger_("GalileoSingleton.cleanupLogger"):::added
GalileoLogger_wrapMethodsForTerminated_("GalileoLogger.wrapMethodsForTerminated"):::added
GalileoLogger_applySharedGuards_("GalileoLogger.applySharedGuards"):::added
GalileoLogger_terminate_("GalileoLogger.terminate"):::modified
GalileoSingleton_reset_("GalileoSingleton.reset"):::modified
GalileoSingleton_resetAll_("GalileoSingleton.resetAll"):::modified
GalileoSingleton_getLogger_ -- "Passes mode and onTerminate hook to constructor for deregistration." --> GalileoLogger_constructor_
GalileoSingleton_getLogger_ -- "Uses cleanupLogger to deregister terminated loggers from singleton map." --> GalileoSingleton_cleanupLogger_
GalileoLogger_constructor_ -- "Wraps terminated-aware guards during construction to no-op mutating calls." --> GalileoLogger_wrapMethodsForTerminated_
GalileoLogger_wrapMethodsForTerminated_ -- "Delegates to applySharedGuards, wrapping trace helpers with terminated guard." --> GalileoLogger_applySharedGuards_
GalileoLogger_terminate_ -- "terminate() sets _terminated then fires onTerminate for singleton cleanup." --> GalileoSingleton_cleanupLogger_
GalileoSingleton_reset_ -- "reset() calls terminate(), triggering onTerminate deregistration workflow." --> GalileoLogger_terminate_
GalileoSingleton_reset_ -- "Calls cleanupLogger after terminate to ensure idempotent registry removal." --> GalileoSingleton_cleanupLogger_
GalileoSingleton_resetAll_ -- "resetAll snapshots loggers then terminates to allow hooks deregistration." --> GalileoLogger_terminate_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Implement logger termination hygiene by forcing <code>GalileoLogger</code> to mark <code>terminated</code>, call <code>onTerminate</code>, and have <code>GalileoSingleton</code> remove exited loggers and <code>lastAvailableLogger</code> references via a new cleanup guard. Strengthen guarding by wrapping methods with termination-aware helpers so disabled or terminated loggers emit warnings and stop mutating state, with tests confirming the behavior.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/573?tool=ast&topic=Post-Terminate+Guards>Post-Terminate Guards</a>
        </td><td>Wrap methods with termination-aware guards that preserve original names and log warnings so terminated loggers become no-ops without throwing.<details><summary>Modified files (2)</summary><ul><li>src/utils/galileo-logger.ts</li>
<li>tests/utils/galileo-logger.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(handlers): Improv...</td><td>April 17, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/573?tool=ast&topic=Logger+Termination+Flow>Logger Termination Flow</a>
        </td><td>Ensure <code>GalileoLogger</code> lifecycle ends cleanly by tracking termination, invoking <code>onTerminate</code>, and letting <code>GalileoSingleton</code> drop logger entries and <code>lastAvailableLogger</code> through <code>cleanupLogger</code>, with defensive resets and coverage in singleton tests.<details><summary>Modified files (5)</summary><ul><li>src/singleton.ts</li>
<li>src/types/logging/logger.types.ts</li>
<li>src/utils/galileo-logger.ts</li>
<li>tests/singleton.test.ts</li>
<li>tests/utils/galileo-logger.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>feat(handlers): Improv...</td><td>April 17, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/573?tool=ast>(Baz)</a>.