### PR TITLE
chore(dependency): Updated galileo-generated dependency.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "axios": "^1.15.1",
         "cli-progress": "^3.12.0",
         "form-data": "^4.0.5",
-        "galileo-generated": "^0.2.11",
+        "galileo-generated": "^0.2.14",
         "jsonwebtoken": "^9.0.2",
         "openapi-fetch": "^0.13.3",
         "openapi-typescript-helpers": "^0.0.15",
@@ -1473,26 +1473,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/@langchain/openai": {
-      "version": "0.3.14",
-      "resolved": "https://registry.npmjs.org/@langchain/openai/-/openai-0.3.14.tgz",
-      "integrity": "sha512-lNWjUo1tbvsss45IF7UQtMu1NJ6oUKvhgPYWXnX9f/d6OmuLu7D99HQ3Y88vLcUo9XjjOy417olYHignMduMjA==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "js-tiktoken": "^1.0.12",
-        "openai": "^4.71.0",
-        "zod": "^3.22.4",
-        "zod-to-json-schema": "^3.22.3"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.2.26 <0.4.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -4649,9 +4629,9 @@
       }
     },
     "node_modules/galileo-generated": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/galileo-generated/-/galileo-generated-0.2.11.tgz",
-      "integrity": "sha512-hamc7/CH62TCm5n7bgDw2DvILwobxwbV6nx/Pdz7ibkyHy9TiFds9SRFbGzrSHj3zQ7foFaEqAWw6+YGoRyF8w==",
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/galileo-generated/-/galileo-generated-0.2.14.tgz",
+      "integrity": "sha512-s+wv+d1pJHqJ80wp+BK2Z7jY2Hme9Olyw4CFQykySQ2jD/oY+hExb+UOCsSpayC+aXksXRR/r7IV/EI7lo1zLQ==",
       "dependencies": {
         "zod": "^3.25.65 || ^4.0.0"
       },
@@ -9300,6 +9280,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "axios": "^1.15.1",
     "cli-progress": "^3.12.0",
     "form-data": "^4.0.5",
-    "galileo-generated": "^0.2.11",
+    "galileo-generated": "^0.2.14",
     "jsonwebtoken": "^9.0.2",
     "openapi-fetch": "^0.13.3",
     "openapi-typescript-helpers": "^0.0.15",


### PR DESCRIPTION
# User description
# Updating galileo-generated lockfile
 - [sc-63580](https://app.shortcut.com/galileo/story/63580/updating-galileo-generated-lockfile)

## Description
* Updated galileo-js to use the newest version of galileo-generated, that fixes a mismatch between package.json a package-lock.json  .

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>galileo-js</code> to depend on the newest <code>galileo-generated</code> release that resolves the package/version mismatch. Regenerate npm lock data so the dependency tree matches the refreshed dependency metadata.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/576?tool=ast&topic=Galileo+Dependency>Galileo Dependency</a>
        </td><td>Update <code>galileo-generated</code> to v0.2.14 in the dependency set for <code>galileo-js</code> so the runtime uses the patched package metadata.<details><summary>Modified files (2)</summary><ul><li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>fix(security): Updated...</td><td>April 21, 2026</td></tr>
<tr><td>quinn-galileo</td><td>chore: release 2.0.0 (...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/576?tool=ast&topic=Lockfile+Refresh>Lockfile Refresh</a>
        </td><td>Refresh <code>package-lock.json</code> entries so the dependency tree and metadata align with the new <code>galileo-generated</code> release and its transitive modules.<details><summary>Modified files (1)</summary><ul><li>package-lock.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>fix(security): Updated...</td><td>April 21, 2026</td></tr>
<tr><td>quinn-galileo</td><td>chore: release 2.0.0 (...</td><td>April 02, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/576?tool=ast>(Baz)</a>.