### PR TITLE
chore(workflow): Improved workflow to properly use trusted publisher.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,10 +25,19 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
-          registry-url: https://registry.npmjs.org/
+
+      - name: Ensure npm >= 11.5.1 (Trusted Publishing support)
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Sanity-check Trusted Publishing prerequisites
+        run: |
+          echo "node:           $(node --version)"
+          echo "npm:            $(npm --version)"
+          echo "id-token avail: ${ACTIONS_ID_TOKEN_REQUEST_TOKEN:+yes}"
+          npm ls @semantic-release/npm || true
 
       - name: Configure Git for SSH signing
         run: |


### PR DESCRIPTION
# User description
- Improvement to release workflow, to support trusted publisher (relates to sc-63580).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the release workflow to install <code>npm@latest</code> so Trusted Publishing works under the Node 24 job. Log <code>node</code>, <code>npm</code>, and token availability before running release tasks to confirm Trusted Publishing prerequisites are present.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>chore(workflow): Updat...</td><td>April 17, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/577?tool=ast>(Baz)</a>.