### PR TITLE
chore(workflow): Extra refactoring to properly support OIDC.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,9 +59,9 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           ci: false
+          semantic_version: 25
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
-            @semantic-release/npm@>=13.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GALILEO_AUTOMATION_GITHUB_TOKEN }}


### PR DESCRIPTION
# User description
- Configured installation of semantic release action v15, to make sure npm v13 is being used, instead of enforcing this separately.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Aligns the release workflow with OIDC by configuring the semantic release action to v15 so npm v13 is supplied through the action itself. Keeps the changelog and git plugins while specifying <code>semantic_version: 25</code> for the action.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>chore(workflow): Impro...</td><td>April 27, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/578?tool=ast>(Baz)</a>.