### PR TITLE
fix(workflow): release workflow OIDC

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -59,9 +59,9 @@ jobs:
         uses: cycjimmy/semantic-release-action@v4
         with:
           ci: false
+          semantic_version: 25
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git
-            @semantic-release/npm@>=13.1.0
         env:
           GITHUB_TOKEN: ${{ secrets.GALILEO_AUTOMATION_GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           git config --global user.email ci@rungalileo.io
           git config --global user.name "galileo-automation"
 
-      - name: Semantic Release (bump version + publish + Github release)
+      - name: Semantic Release (bump version + npm publish + Github release)
         uses: cycjimmy/semantic-release-action@v4
         with:
           ci: false


### PR DESCRIPTION
# User description
- Improvement to release workflow, to support trusted publisher (relates to sc-63580).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update release workflow to support trusted publisher automation by modifying the semantic release action configuration to advertise npm publishing. Align automation credentials by feeding <code>semantic_version</code> 25 into the <code>cycjimmy/semantic-release-action</code> while keeping changelog, git, and GitHub release steps.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Murike</td><td>chore(workflow): Impro...</td><td>April 27, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/579?tool=ast>(Baz)</a>.