### PR TITLE
fix(name): Default node name setup removed, falling to node type as new default.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -634,7 +634,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@cfworker/json-schema/-/json-schema-4.0.3.tgz",
       "integrity": "sha512-ZykIcDTVv5UNmKWSTLAs3VukO6NDJkkSKxrgUTDPBkAlORVT3H9n5DbRjRl8xIotklscHdbLIa0b9+y3mQq73g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1455,7 +1455,7 @@
       "version": "0.3.78",
       "resolved": "https://registry.npmjs.org/@langchain/core/-/core-0.3.78.tgz",
       "integrity": "sha512-Nn0x9erQlK3zgtRU1Z8NUjLuyW0gzdclMsvLQ6wwLeDqV91pE+YKl6uQb+L2NUDs4F0N7c2Zncgz46HxrvPzuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cfworker/json-schema": "^4.0.2",
@@ -1866,7 +1866,7 @@
       "version": "2.6.13",
       "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.6.13.tgz",
       "integrity": "sha512-QGpRVpzSaUs30JBSGPjOg4Uveu384erbHBoT1zeONvyCfwQxIkUshLAOqN/k9EjGviPRmWTTe6aH2qySWKTVSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -1927,7 +1927,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -2156,7 +2156,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "event-target-shim": "^5.0.0"
@@ -2202,7 +2202,7 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
       "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "humanize-ms": "^1.2.1"
@@ -2287,7 +2287,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2644,7 +2644,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2895,7 +2895,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2929,7 +2929,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2946,7 +2946,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
@@ -3080,7 +3080,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -3093,7 +3093,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/color-support": {
@@ -3159,7 +3159,7 @@
       "version": "2.14.6",
       "resolved": "https://registry.npmjs.org/console-table-printer/-/console-table-printer-2.14.6.tgz",
       "integrity": "sha512-MCBl5HNVaFuuHW6FGbL/4fB7N/ormCy+tQ+sxTrF6QtSbSNETvPuOVbkJBhzDgYhvjWGrTma4eYJa37ZuoQsPw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "simple-wcswidth": "^1.0.1"
@@ -3295,7 +3295,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
       "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4231,7 +4231,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4241,7 +4241,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
       "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/execa": {
@@ -4551,14 +4551,14 @@
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.2.tgz",
       "integrity": "sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/formdata-node": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.4.1.tgz",
       "integrity": "sha512-0iirZp3uVDjVGt9p49aTaqjk84TrglENEDuqfdlZQ1roC9CWlPk6Avf8EEnZNcAqPonwkG35x4n3ww/1THYAeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "node-domexception": "1.0.0",
@@ -4940,7 +4940,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -5056,7 +5056,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
       "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.0.0"
@@ -6435,7 +6435,7 @@
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/js-tiktoken/-/js-tiktoken-1.0.15.tgz",
       "integrity": "sha512-65ruOWWXDEZHHbAo7EjOcNxOGasQKbL4Fq3jEr2xsCqSsoOo6VVSqzWQb6PRIqypFSDcma4jO90YP0w5X8qVXQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "base64-js": "^1.5.1"
@@ -6596,7 +6596,7 @@
       "version": "0.3.74",
       "resolved": "https://registry.npmjs.org/langsmith/-/langsmith-0.3.74.tgz",
       "integrity": "sha512-ZuW3Qawz8w88XcuCRH91yTp6lsdGuwzRqZ5J0Hf5q/AjMz7DwcSv0MkE6V5W+8hFMI850QZN2Wlxwm3R9lHlZg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/uuid": "^10.0.0",
@@ -6994,7 +6994,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
       "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
@@ -7022,7 +7022,7 @@
       "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
       "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
       "deprecated": "Use your platform's native DOMException instead",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -7042,7 +7042,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-url": "^5.0.0"
@@ -7271,7 +7271,7 @@
       "version": "4.104.0",
       "resolved": "https://registry.npmjs.org/openai/-/openai-4.104.0.tgz",
       "integrity": "sha512-p99EFNsA/yX6UhVO93f5kJsDRLAg+CTA2RBqdHK4RtK8u5IJw32Hyb2dTGKbnnFmnuoBv5r7Z2CURI9sGZpSuA==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/node": "^18.11.18",
@@ -7302,7 +7302,7 @@
       "version": "18.19.130",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
       "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
@@ -7312,7 +7312,7 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/openapi-fetch": {
@@ -7424,7 +7424,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -7466,7 +7466,7 @@
       "version": "6.6.2",
       "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
       "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventemitter3": "^4.0.4",
@@ -7496,7 +7496,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
       "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-finally": "^1.0.0"
@@ -8438,7 +8438,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/simple-wcswidth/-/simple-wcswidth-1.1.2.tgz",
       "integrity": "sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/sisteransi": {
@@ -8706,7 +8706,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -8974,7 +8974,7 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
@@ -9369,7 +9369,7 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -9408,7 +9408,7 @@
       "version": "4.0.0-beta.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
       "integrity": "sha512-QW95TCTaHmsYfHDybGMwO5IJIM93I/6vTRk+daHTWFPhwh+C8Cg7j7XyKrwrj8Ib6vYXe0ocYNrmzY4xAAN6ug==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -9418,7 +9418,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/webworker-shim": {
@@ -9432,7 +9432,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "~0.0.3",
@@ -9781,7 +9781,7 @@
       "version": "3.24.1",
       "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.1.tgz",
       "integrity": "sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"

--- a/src/handlers/openai/index.ts
+++ b/src/handlers/openai/index.ts
@@ -150,8 +150,7 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                 if (!isParentTraceValid) {
                   logger!.startTrace({
                     input: JSON.stringify(normalizedInput),
-                    output: undefined,
-                    name: 'openai-client-generation'
+                    output: undefined
                   });
                 }
 
@@ -168,7 +167,6 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                     processErrorSpan(
                       error,
                       logger,
-                      'openai-completion-generation',
                       requestData as Record<string, unknown>,
                       startTime,
                       normalizedInput
@@ -211,7 +209,6 @@ function generateChatCompletionProxy<T extends OpenAIType>(
                 logger.addLlmSpan({
                   input: normalizedInput,
                   output,
-                  name: 'openai-completion-generation',
                   model: (requestData.model as string) || 'unknown',
                   numInputTokens: usage.inputTokens,
                   numOutputTokens: usage.outputTokens,
@@ -281,8 +278,7 @@ function generateResponseApiProxy<T extends OpenAIType>(
           if (!isParentTraceValid) {
             logger.startTrace({
               input: JSON.stringify(normalizedInput),
-              output: undefined,
-              name: 'openai-responses-generation'
+              output: undefined
             });
           }
 
@@ -298,7 +294,6 @@ function generateResponseApiProxy<T extends OpenAIType>(
               processErrorSpan(
                 error,
                 logger,
-                'openai-responses-generation',
                 requestData as Record<string, unknown>,
                 startTime,
                 normalizedInput
@@ -373,7 +368,6 @@ function generateResponseApiProxy<T extends OpenAIType>(
 function processErrorSpan(
   error: unknown,
   logger: GalileoLogger,
-  name: string,
   requestData: Record<string, unknown>,
   startTime: Date,
   input: LlmSpanAllowedInputType
@@ -392,7 +386,6 @@ function processErrorSpan(
   logger.addLlmSpan({
     input,
     output: { content: `Error: ${errorMessage}` },
-    name,
     model: (requestData.model as string) || 'unknown',
     numInputTokens: 0,
     numOutputTokens: 0,
@@ -728,7 +721,6 @@ class StreamWrapper implements AsyncIterable<any> {
       this.logger.addLlmSpan({
         input: convertInputToMessages(this.requestData.input),
         output: { content: `Error: ${errorMessage}` },
-        name: 'openai-responses-generation',
         model: this.requestData.model || 'unknown',
         numInputTokens: 0,
         numOutputTokens: 0,
@@ -849,7 +841,6 @@ class StreamWrapper implements AsyncIterable<any> {
       this.logger.addLlmSpan({
         input: normalizedInput,
         output: { content: `Error: ${errorMessage}` },
-        name: 'openai-client-generation',
         model: this.requestData.model || 'unknown',
         numInputTokens: 0,
         numOutputTokens: 0,
@@ -907,7 +898,6 @@ class StreamWrapper implements AsyncIterable<any> {
       this.logger.addLlmSpan({
         input: normalizedInput,
         output: finalOutput,
-        name: 'openai-client-generation',
         model: this.requestData.model || 'unknown',
         numInputTokens: usage.inputTokens,
         numOutputTokens: usage.outputTokens,

--- a/src/handlers/openai/output-items.ts
+++ b/src/handlers/openai/output-items.ts
@@ -260,7 +260,6 @@ export function processOutputItems(
     input: normalizedInput as LlmSpanAllowedInputType,
     output: output as LlmSpanAllowedOutputType,
     model: model || 'unknown',
-    name: 'openai-responses-generation',
     tools: tools as JsonObject[] | undefined,
     statusCode,
     numInputTokens: parsedUsage.inputTokens,

--- a/tests/utils/openai.test.ts
+++ b/tests/utils/openai.test.ts
@@ -137,7 +137,7 @@ describe('OpenAI Wrapper', () => {
     expect(startTraceCall.input).toBe(
       '[{"role":"user","content":"Say hello world!"}]'
     );
-    expect(startTraceCall.name).toBe('openai-client-generation');
+    expect(startTraceCall.name).toBeUndefined();
     expect(startTraceCall.output).toBeUndefined();
     // Check createdAt separately since it's added by the mock
     if (startTraceCall.createdAt === undefined) {
@@ -148,7 +148,6 @@ describe('OpenAI Wrapper', () => {
       createdAt: mockDate,
       input: requestData.messages,
       output: [mockResponse.choices[0].message],
-      name: 'openai-completion-generation',
       model: 'gpt-4o',
       numInputTokens: 10,
       numOutputTokens: 5,
@@ -208,7 +207,7 @@ describe('OpenAI Wrapper', () => {
     expect(startTraceCall.input).toBe(
       '[{"role":"user","content":"Say hello world!"}]'
     );
-    expect(startTraceCall.name).toBe('openai-client-generation');
+    expect(startTraceCall.name).toBeUndefined();
     expect(startTraceCall.output).toBeUndefined();
     // Check createdAt separately since it's added by the mock
     if (startTraceCall.createdAt === undefined) {
@@ -222,7 +221,7 @@ describe('OpenAI Wrapper', () => {
       content: 'Hello world!',
       role: 'assistant'
     });
-    expect(addLlmSpanCall.name).toBe('openai-client-generation');
+    expect(addLlmSpanCall.name).toBeUndefined();
     expect(addLlmSpanCall.model).toBe('gpt-4o');
     expect(addLlmSpanCall.numInputTokens).toBe(0);
     expect(addLlmSpanCall.numOutputTokens).toBe(0);
@@ -488,12 +487,12 @@ describe('OpenAI Wrapper', () => {
       expect.objectContaining({
         input: requestData.messages,
         output: { content: 'Error: API Error' },
-        name: 'openai-completion-generation',
         statusCode: 500,
         numInputTokens: 0,
         numOutputTokens: 0
       })
     );
+    expect(mockLogger.addLlmSpan.mock.calls[0][0].name).toBeUndefined();
     expect(mockLogger.conclude).toHaveBeenCalledWith({
       output: 'Error: API Error',
       durationNs: 1_000_000
@@ -573,12 +572,12 @@ describe('OpenAI Wrapper', () => {
     expect(mockLogger.addLlmSpan).toHaveBeenCalledWith(
       expect.objectContaining({
         metadata: expect.any(Object),
-        name: 'openai-completion-generation',
         model: 'gpt-4o'
       })
     );
     const addLlmSpanCall = mockLogger.addLlmSpan.mock.calls[0][0];
     expect(addLlmSpanCall.metadata).toEqual({});
+    expect(addLlmSpanCall.name).toBeUndefined();
   });
 
   describe('Streaming Responses API', () => {
@@ -640,7 +639,7 @@ describe('OpenAI Wrapper', () => {
       // Verify processOutputItems was called (via addLlmSpan)
       expect(mockLogger.addLlmSpan).toHaveBeenCalled();
       const addLlmSpanCall = mockLogger.addLlmSpan.mock.calls[0][0];
-      expect(addLlmSpanCall.name).toBe('openai-responses-generation');
+      expect(addLlmSpanCall.name).toBeUndefined();
     });
 
     test('should accumulate output items from multiple chunks', async () => {
@@ -1075,12 +1074,12 @@ describe('OpenAI Wrapper', () => {
         expect.objectContaining({
           input: requestData.messages, // ← Message[] object (not string)
           output: { content: 'Error: Rate limit exceeded' },
-          name: 'openai-completion-generation',
           statusCode: 500, // Default when error status not extracted
           numInputTokens: 0,
           numOutputTokens: 0
         })
       );
+      expect(mockLogger.addLlmSpan.mock.calls[0][0].name).toBeUndefined();
     });
 
     test('Responses API error logs Message[] input (not string)', async () => {
@@ -1122,11 +1121,11 @@ describe('OpenAI Wrapper', () => {
       const addLlmSpanCall = mockLogger.addLlmSpan.mock.calls[0][0];
       expect(addLlmSpanCall).toMatchObject({
         output: { content: 'Error: Authentication failed' },
-        name: 'openai-responses-generation',
         statusCode: 500, // Default when error status not extracted
         numInputTokens: 0,
         numOutputTokens: 0
       });
+      expect(addLlmSpanCall.name).toBeUndefined();
 
       // Verify input is Message[] (converted from input)
       expect(Array.isArray(addLlmSpanCall.input)).toBe(true);


### PR DESCRIPTION
# The TypeScript SDK logs Open AI traces as openai-client-generation, Python does it as LLM
 - [sc-33572](https://app.shortcut.com/galileo/story/33572/the-typescript-sdk-logs-open-ai-traces-as-openai-client-generation-python-does-it-as-llm)

## Description
* Default node name setup removed, falling to node type as new default.

Evidence comparing equivalent Python and TS traces, after this refactor?
<img width="2545" height="1385" alt="sc-33572" src="https://github.com/user-attachments/assets/5f9b1b73-c7ac-4d55-9101-bc7444f74d49" />
