### PR TITLE
fix(node): Updating logging for missing root node (langchain).

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@openai/agents": ">=0.4.0",
         "@opentelemetry/api": ">=1.4.0",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+        "@opentelemetry/exporter-trace-otlp-proto": ">=0.41.0",
         "@opentelemetry/resources": ">=1.15.0",
         "@opentelemetry/sdk-trace-base": ">=1.15.0",
         "openai": ">=4.0.0"
@@ -76,6 +77,9 @@
           "optional": true
         },
         "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
           "optional": true
         },
         "@opentelemetry/resources": {

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -104,10 +104,6 @@ export class GalileoCallback
    * Uses try/finally to guarantee node state is always cleared even on error.
    */
   private async _commit(): Promise<void> {
-    let committedRoot: {
-      runId: string;
-      nodeType: LANGCHAIN_NODE_TYPE;
-    } | null = null;
     try {
       if (Object.keys(this._nodes).length === 0) {
         sdkLogger.warn('No nodes to commit');
@@ -127,10 +123,6 @@ export class GalileoCallback
         );
         return;
       }
-
-      // Remember the root we're about to commit so `_endNode` can
-      // recognise late post-commit callbacks for this run_id.
-      committedRoot = { runId: rootNode.runId, nodeType: rootNode.nodeType };
 
       if (this._startNewTrace) {
         let traceMetadata: Record<string, string> | undefined;
@@ -169,13 +161,19 @@ export class GalileoCallback
       if (this._flushOnChainEnd) {
         await this._galileoLogger.flush();
       }
+
+      // Only record the committed root after the logger calls succeed; if any
+      // of the above throws, leave `_lastCommittedRoot` unchanged so a later
+      // end callback for this run_id still surfaces as a warn (the trace was
+      // never finalized).
+      this._lastCommittedRoot = {
+        runId: rootNode.runId,
+        nodeType: rootNode.nodeType
+      };
     } finally {
       // Always clear state, even if an exception occurs
       this._nodes = {};
       this._rootNode = null;
-      if (committedRoot) {
-        this._lastCommittedRoot = committedRoot;
-      }
     }
   }
 

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -66,6 +66,12 @@ export class GalileoCallback
   _flushOnChainEnd: boolean;
   _rootNode: Node | null = null;
   _nodes: Record<string, Node> = {};
+  // Identity of the most recently committed root, retained after `_nodes`
+  // is cleared so `_endNode` can distinguish late post-commit callbacks
+  // (a known LangChain quirk — see `_endNode` below) from genuinely
+  // orphaned end events.
+  _lastCommittedRoot: { runId: string; nodeType: LANGCHAIN_NODE_TYPE } | null =
+    null;
 
   public name = 'GalileoCallback';
 
@@ -98,6 +104,10 @@ export class GalileoCallback
    * Uses try/finally to guarantee node state is always cleared even on error.
    */
   private async _commit(): Promise<void> {
+    let committedRoot: {
+      runId: string;
+      nodeType: LANGCHAIN_NODE_TYPE;
+    } | null = null;
     try {
       if (Object.keys(this._nodes).length === 0) {
         sdkLogger.warn('No nodes to commit');
@@ -117,6 +127,10 @@ export class GalileoCallback
         );
         return;
       }
+
+      // Remember the root we're about to commit so `_endNode` can
+      // recognise late post-commit callbacks for this run_id.
+      committedRoot = { runId: rootNode.runId, nodeType: rootNode.nodeType };
 
       if (this._startNewTrace) {
         let traceMetadata: Record<string, string> | undefined;
@@ -159,6 +173,9 @@ export class GalileoCallback
       // Always clear state, even if an exception occurs
       this._nodes = {};
       this._rootNode = null;
+      if (committedRoot) {
+        this._lastCommittedRoot = committedRoot;
+      }
     }
   }
 
@@ -217,13 +234,39 @@ export class GalileoCallback
    */
   private async _endNode(
     runId: string,
-    params: Record<string, unknown>
+    params: Record<string, unknown>,
+    callbackName: string = '_endNode'
   ): Promise<void> {
     const nodeId = runId;
     const node = this._nodes[nodeId];
 
     if (!node) {
-      sdkLogger.warn(`No node exists for run_id ${nodeId}`);
+      const lastRoot = this._lastCommittedRoot;
+      if (lastRoot && lastRoot.runId === runId) {
+        // LangChain occasionally emits a `handleChainEnd` *after* a
+        // `handleAgentEnd` for the same root run_id. The first end
+        // matched the root and triggered `_commit`, which cleared
+        // `_nodes`; the trace has already been logged. Subsequent late
+        // end callbacks for the same root id are duplicates and safe
+        // to ignore — emit at debug only.
+        sdkLogger.debug(
+          `${callbackName}: ignoring late callback for run_id ${runId} — ` +
+            `the trace rooted at this run was already finalized as a ` +
+            `'${lastRoot.nodeType}' span. This is expected when LangChain ` +
+            `emits handleAgentEnd and handleChainEnd for the same root run_id.`
+        );
+      } else {
+        // Anything else is a genuinely unexpected end without a matching
+        // start: an orphan end (start callback never fired or was filtered
+        // out by `langsmith:hidden`), or state cleared by a concurrent
+        // commit on a callback instance shared across runs.
+        sdkLogger.warn(
+          `${callbackName}: no node exists for run_id ${runId}. ` +
+            `The matching start callback was not received (orphan end), or ` +
+            `the node was cleared by a concurrent commit on this callback ` +
+            `instance.`
+        );
+      }
       return;
     }
 
@@ -250,7 +293,11 @@ export class GalileoCallback
    * Extracts HTTP status from the error's response if available, falls back to 500
    * (unknown/internal error) when no HTTP status is present.
    */
-  private async _handleError(err: Error, runId: string): Promise<void> {
+  private async _handleError(
+    err: Error,
+    runId: string,
+    callbackName: string = '_handleError'
+  ): Promise<void> {
     const errRecord = err as unknown as Record<string, unknown>;
     const response = errRecord.response;
     const status =
@@ -260,10 +307,14 @@ export class GalileoCallback
         ? ((response as Record<string, unknown>).status as number)
         : 500;
 
-    await this._endNode(runId, {
-      output: `Error: ${err.name}: ${err.message}`,
-      statusCode: status
-    });
+    await this._endNode(
+      runId,
+      {
+        output: `Error: ${err.name}: ${err.message}`,
+        statusCode: status
+      },
+      callbackName
+    );
   }
 
   // LangChain callback methods
@@ -314,7 +365,7 @@ export class GalileoCallback
   }
 
   public async handleChainError(err: Error, runId: string): Promise<void> {
-    await this._handleError(err, runId);
+    await this._handleError(err, runId, 'handleChainError');
   }
 
   public async handleChainEnd(
@@ -330,21 +381,29 @@ export class GalileoCallback
   ): Promise<void> {
     // In async scenarios, the input is sent in handleChainEnd, so we need to handle it here
     const input = kwargs?.inputs;
-    await this._endNode(runId, {
-      output: toStringValue(outputs),
-      statusCode: 200,
-      ...(input !== undefined && { input: toStringValue(input) })
-    });
+    await this._endNode(
+      runId,
+      {
+        output: toStringValue(outputs),
+        statusCode: 200,
+        ...(input !== undefined && { input: toStringValue(input) })
+      },
+      'handleChainEnd'
+    );
   }
 
   public async handleAgentEnd(
     finish: AgentFinish,
     runId: string
   ): Promise<void> {
-    await this._endNode(runId, {
-      output: toStringValue(finish),
-      statusCode: 200
-    });
+    await this._endNode(
+      runId,
+      {
+        output: toStringValue(finish),
+        statusCode: 200
+      },
+      'handleAgentEnd'
+    );
   }
 
   public async handleLLMStart(
@@ -376,7 +435,7 @@ export class GalileoCallback
   }
 
   public async handleLLMError(err: Error, runId: string): Promise<void> {
-    await this._handleError(err, runId);
+    await this._handleError(err, runId, 'handleLLMError');
   }
 
   public async handleLLMNewToken(
@@ -522,13 +581,17 @@ export class GalileoCallback
       serializedOutput = String(output.generations);
     }
 
-    await this._endNode(runId, {
-      output: serializedOutput,
-      numInputTokens,
-      numOutputTokens,
-      totalTokens,
-      statusCode: 200
-    });
+    await this._endNode(
+      runId,
+      {
+        output: serializedOutput,
+        numInputTokens,
+        numOutputTokens,
+        totalTokens,
+        statusCode: 200
+      },
+      'handleLLMEnd'
+    );
   }
 
   public async handleToolStart(
@@ -555,7 +618,7 @@ export class GalileoCallback
   }
 
   public async handleToolError(err: Error, runId: string): Promise<void> {
-    await this._handleError(err, runId);
+    await this._handleError(err, runId, 'handleToolError');
   }
 
   public async handleToolEnd(output: unknown, runId: string): Promise<void> {
@@ -566,11 +629,15 @@ export class GalileoCallback
     const toolMessage = findToolMessage(output);
     if (toolMessage !== null) {
       serializedOutput = toStringValue(toolMessage.content);
-      await this._endNode(runId, {
-        output: serializedOutput,
-        toolCallId: toolMessage.tool_call_id,
-        statusCode: 200
-      });
+      await this._endNode(
+        runId,
+        {
+          output: serializedOutput,
+          toolCallId: toolMessage.tool_call_id,
+          statusCode: 200
+        },
+        'handleToolEnd'
+      );
       return;
     }
 
@@ -579,11 +646,15 @@ export class GalileoCallback
       // Check if the first element is itself a ToolMessage
       if (_ToolMessage && output[0] instanceof _ToolMessage) {
         serializedOutput = toStringValue(output[0].content);
-        await this._endNode(runId, {
-          output: serializedOutput,
-          toolCallId: output[0].tool_call_id,
-          statusCode: 200
-        });
+        await this._endNode(
+          runId,
+          {
+            output: serializedOutput,
+            toolCallId: output[0].tool_call_id,
+            statusCode: 200
+          },
+          'handleToolEnd'
+        );
         return;
       }
       serializedOutput = toStringValue(output[0]);
@@ -597,7 +668,11 @@ export class GalileoCallback
       serializedOutput = toStringValue(output);
     }
 
-    await this._endNode(runId, { output: serializedOutput, statusCode: 200 });
+    await this._endNode(
+      runId,
+      { output: serializedOutput, statusCode: 200 },
+      'handleToolEnd'
+    );
   }
 
   public async handleRetrieverStart(
@@ -619,7 +694,7 @@ export class GalileoCallback
   }
 
   public async handleRetrieverError(err: Error, runId: string): Promise<void> {
-    await this._handleError(err, runId);
+    await this._handleError(err, runId, 'handleRetrieverError');
   }
 
   public async handleRetrieverEnd(
@@ -637,6 +712,10 @@ export class GalileoCallback
       serializedResponse = String(documents);
     }
 
-    await this._endNode(runId, { output: serializedResponse, statusCode: 200 });
+    await this._endNode(
+      runId,
+      { output: serializedResponse, statusCode: 200 },
+      'handleRetrieverEnd'
+    );
   }
 }

--- a/src/handlers/langchain/index.ts
+++ b/src/handlers/langchain/index.ts
@@ -211,6 +211,7 @@ export class GalileoCallback
     if (!this._rootNode) {
       sdkLogger.debug(`Setting root node to ${nodeId}`);
       this._rootNode = node;
+      this._lastCommittedRoot = null;
     }
 
     // Add to parent's children if parent exists

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,10 +28,8 @@ import type { RunExperimentParams } from './types/experiment.types';
 import {
   addRowsToDataset,
   createDataset,
-  createDatasetRecord,
   deleteDataset,
   deserializeInputFromString,
-  convertDatasetContentToRecords,
   getRecordsForDataset,
   getDatasetRecordsFromArray,
   getDatasets,
@@ -48,7 +46,6 @@ import {
 } from './utils/datasets';
 import {
   createCustomLlmMetric,
-  createCustomCodeMetric,
   deleteMetric,
   createMetricConfigs,
   populateLocalMetrics,
@@ -63,7 +60,6 @@ import {
   createLlmScorerVersion,
   createCodeScorerVersion,
   deleteScorer,
-  createRunScorerSettings,
   validateCodeScorer
 } from './utils/scorers';
 import { Scorers, ScorerSettings } from './entities/scorers';
@@ -73,10 +69,7 @@ import {
   getJobProgress,
   logScorerJobsStatus,
   getRunScorerJobs,
-  getScorerJobs,
   getScorerJobsStatus,
-  PollJobOptions,
-  JobProgressLogger,
   getJob
 } from './utils/job-progress';
 import {
@@ -98,9 +91,7 @@ import {
   getProjectWithEnvFallbacks,
   deleteProject,
   listProjectUserCollaborators,
-  addProjectUserCollaborators,
   updateProjectUserCollaborator,
-  removeProjectUserCollaborator,
   shareProjectWithUser,
   unshareProjectWithUser
 } from './utils/projects';
@@ -116,9 +107,7 @@ import {
   getExperiments,
   createExperiment,
   getExperiment,
-  runExperiment,
-  updateExperiment,
-  deleteExperiment
+  runExperiment
 } from './utils/experiments';
 import { ExperimentTags } from './entities/experiment-tags';
 import { Experiments } from './entities/experiments';
@@ -183,9 +172,7 @@ export {
   getDataset,
   deleteDataset,
   addRowsToDataset,
-  createDatasetRecord,
   deserializeInputFromString,
-  convertDatasetContentToRecords,
   getRecordsForDataset,
   getDatasetRecordsFromArray,
   getDatasetMetadata,
@@ -209,8 +196,6 @@ export {
   createExperiment,
   getExperiment,
   runExperiment,
-  updateExperiment,
-  deleteExperiment,
   // Experiment entities
   ExperimentTags,
   Experiments,
@@ -222,9 +207,7 @@ export {
   getProjectWithEnvFallbacks,
   deleteProject,
   listProjectUserCollaborators,
-  addProjectUserCollaborators,
   updateProjectUserCollaborator,
-  removeProjectUserCollaborator,
   shareProjectWithUser,
   unshareProjectWithUser,
   // Log streams
@@ -249,7 +232,6 @@ export {
   galileoContext,
   // Metrics
   createCustomLlmMetric,
-  createCustomCodeMetric,
   getMetrics,
   deleteMetric,
   createMetricConfigs,
@@ -265,17 +247,13 @@ export {
   createLlmScorerVersion,
   createCodeScorerVersion,
   deleteScorer,
-  createRunScorerSettings,
   validateCodeScorer,
   // Jobs (legacy)
-  getScorerJobs,
   getScorerJobsStatus,
   // Job Progress (new standardized API)
   getJobProgress,
   logScorerJobsStatus,
   getRunScorerJobs,
-  PollJobOptions,
-  JobProgressLogger,
   getJob,
   // Jobs class
   Jobs,
@@ -315,7 +293,6 @@ export type {
 
 export {
   APIException,
-  ExperimentAPIException,
   DatasetAPIException,
   ProjectAPIException
 } from './utils/errors';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import type { RunExperimentParams } from './types/experiment.types';
 import {
   addRowsToDataset,
   createDataset,
+  createDatasetRecord,
   deleteDataset,
   deserializeInputFromString,
   getRecordsForDataset,
@@ -107,7 +108,9 @@ import {
   getExperiments,
   createExperiment,
   getExperiment,
-  runExperiment
+  runExperiment,
+  updateExperiment,
+  deleteExperiment
 } from './utils/experiments';
 import { ExperimentTags } from './entities/experiment-tags';
 import { Experiments } from './entities/experiments';
@@ -168,6 +171,7 @@ export {
   Datasets,
   getDatasets,
   createDataset,
+  createDatasetRecord,
   getDatasetContent,
   getDataset,
   deleteDataset,
@@ -196,6 +200,8 @@ export {
   createExperiment,
   getExperiment,
   runExperiment,
+  updateExperiment,
+  deleteExperiment,
   // Experiment entities
   ExperimentTags,
   Experiments,

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -169,16 +169,6 @@ export class APIException extends Error {
 }
 
 /**
- * Exception raised when experiment operations fail.
- */
-export class ExperimentAPIException extends APIException {
-  constructor(message: string | unknown) {
-    super(message);
-    this.name = 'ExperimentAPIException';
-  }
-}
-
-/**
  * Exception raised when dataset operations fail.
  */
 export class DatasetAPIException extends APIException {

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -190,6 +190,8 @@ class GalileoLogger implements IGalileoLogger {
    * @param config - Logger configuration
    * @returns Promise that resolves to a fully initialized logger
    * @throws Error if config validation fails or trace/span initialization fails
+   * @deprecated Use `new GalileoLogger(config)` directly. For streaming traceId/spanId initialization, call `initTrace`/`initSpan` afterward. Will be made internal in a future release.
+   * @internal
    */
   static async create(
     config: GalileoLoggerConfigExtended = {}

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -11,6 +11,7 @@ import { LLMResult } from '@langchain/core/outputs';
 import { Serialized } from '@langchain/core/load/serializable';
 import { ChainValues } from '@langchain/core/utils/types';
 import { DocumentInterface, Document } from '@langchain/core/documents';
+import { getSdkLogger } from 'galileo-generated';
 import { StepType } from '../../../src/types/logging/step.types';
 import {
   AgentSpan,
@@ -2271,8 +2272,6 @@ describe('GalileoCallback', () => {
     describe('orphan-end log discrimination (sc-36763)', () => {
       // Spies on the shared `getSdkLogger()` singleton — the same instance
       // captured at module load by the langchain handler.
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const { getSdkLogger } = require('galileo-generated');
       const sdkLogger = getSdkLogger();
       let warnSpy: jest.SpyInstance;
       let debugSpy: jest.SpyInstance;
@@ -2287,7 +2286,7 @@ describe('GalileoCallback', () => {
         debugSpy.mockRestore();
       });
 
-      it('test late handleChainEnd after handleAgentEnd on same root run_id is debug-logged, not warned', async () => {
+      it('should debug-log (not warn) late handleChainEnd after handleAgentEnd on same root run_id', async () => {
         // Reproduces the LangChain quirk from sc-36763: handleAgentEnd and
         // handleChainEnd both fire for the same root run_id; the agent_end
         // commits the trace and clears state, then the late chain_end
@@ -2336,7 +2335,7 @@ describe('GalileoCallback', () => {
         expect(debugMsg).toContain("'agent'");
       });
 
-      it('test handleChainEnd for an unknown run_id (no prior commit) warns with the callback name', async () => {
+      it('should warn with the callback name when handleChainEnd fires for an unknown run_id (no prior commit)', async () => {
         // Genuinely orphan end — no matching start, no recent commit.
         const runId = createId();
 
@@ -2350,7 +2349,7 @@ describe('GalileoCallback', () => {
         expect(warnMsg).toContain('no node exists');
       });
 
-      it('test handleLLMEnd for an unknown run_id warns and identifies the callback', async () => {
+      it('should warn and identify the callback when handleLLMEnd fires for an unknown run_id', async () => {
         const runId = createId();
 
         await callback.handleLLMEnd(
@@ -2366,7 +2365,7 @@ describe('GalileoCallback', () => {
         expect(warnMsg).toContain(runId);
       });
 
-      it('test late handleChainEnd for an unrelated run_id (not the last committed root) still warns', async () => {
+      it('should still warn for late handleChainEnd on an unrelated run_id (not the last committed root)', async () => {
         // After a successful commit, a stray end for a *different* run_id
         // remains an unexpected orphan and must warn — only the just-
         // committed root run_id is whitelisted as the LangChain quirk.

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -2267,5 +2267,135 @@ describe('GalileoCallback', () => {
         expect(span.output).toBe('Error: TypeError: invalid argument');
       });
     });
+
+    describe('orphan-end log discrimination (sc-36763)', () => {
+      // Spies on the shared `getSdkLogger()` singleton — the same instance
+      // captured at module load by the langchain handler.
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const { getSdkLogger } = require('galileo-generated');
+      const sdkLogger = getSdkLogger();
+      let warnSpy: jest.SpyInstance;
+      let debugSpy: jest.SpyInstance;
+
+      beforeEach(() => {
+        warnSpy = jest.spyOn(sdkLogger, 'warn').mockImplementation(() => {});
+        debugSpy = jest.spyOn(sdkLogger, 'debug').mockImplementation(() => {});
+      });
+
+      afterEach(() => {
+        warnSpy.mockRestore();
+        debugSpy.mockRestore();
+      });
+
+      it('test late handleChainEnd after handleAgentEnd on same root run_id is debug-logged, not warned', async () => {
+        // Reproduces the LangChain quirk from sc-36763: handleAgentEnd and
+        // handleChainEnd both fire for the same root run_id; the agent_end
+        // commits the trace and clears state, then the late chain_end
+        // arrives with no node. This MUST NOT surface as a warning.
+        const runId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'agent',
+            lc: 1,
+            type: 'secret',
+            id: ['agent']
+          } as Serialized,
+          { input: 'hello' },
+          runId
+        );
+
+        await callback.handleAgentEnd(
+          {
+            returnValues: { output: 'hi' },
+            log: 'log'
+          } as AgentFinish,
+          runId
+        );
+
+        // First end finalized the trace.
+        expect(callback['_galileoLogger'].traces).toHaveLength(1);
+        expect(callback['_nodes']).toEqual({});
+        expect(callback['_lastCommittedRoot']).toEqual({
+          runId,
+          nodeType: 'agent'
+        });
+
+        warnSpy.mockClear();
+        debugSpy.mockClear();
+
+        // Late duplicate from LangChain.
+        await callback.handleChainEnd({ result: 'hi' }, runId);
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(debugSpy).toHaveBeenCalledTimes(1);
+        const debugMsg = debugSpy.mock.calls[0][0] as string;
+        expect(debugMsg).toContain('handleChainEnd');
+        expect(debugMsg).toContain(runId);
+        expect(debugMsg).toContain('already finalized');
+        expect(debugMsg).toContain("'agent'");
+      });
+
+      it('test handleChainEnd for an unknown run_id (no prior commit) warns with the callback name', async () => {
+        // Genuinely orphan end — no matching start, no recent commit.
+        const runId = createId();
+
+        await callback.handleChainEnd({ result: 'oops' }, runId);
+
+        expect(debugSpy).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const warnMsg = warnSpy.mock.calls[0][0] as string;
+        expect(warnMsg).toContain('handleChainEnd');
+        expect(warnMsg).toContain(runId);
+        expect(warnMsg).toContain('no node exists');
+      });
+
+      it('test handleLLMEnd for an unknown run_id warns and identifies the callback', async () => {
+        const runId = createId();
+
+        await callback.handleLLMEnd(
+          {
+            generations: [[{ text: 'x', generationInfo: {} }]]
+          } as LLMResult,
+          runId
+        );
+
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const warnMsg = warnSpy.mock.calls[0][0] as string;
+        expect(warnMsg).toContain('handleLLMEnd');
+        expect(warnMsg).toContain(runId);
+      });
+
+      it('test late handleChainEnd for an unrelated run_id (not the last committed root) still warns', async () => {
+        // After a successful commit, a stray end for a *different* run_id
+        // remains an unexpected orphan and must warn — only the just-
+        // committed root run_id is whitelisted as the LangChain quirk.
+        const rootId = createId();
+        await callback.handleChainStart(
+          {
+            name: 'agent',
+            lc: 1,
+            type: 'secret',
+            id: ['agent']
+          } as Serialized,
+          { input: 'x' },
+          rootId
+        );
+        await callback.handleAgentEnd(
+          { returnValues: { output: 'y' }, log: 'l' } as AgentFinish,
+          rootId
+        );
+
+        warnSpy.mockClear();
+        debugSpy.mockClear();
+
+        const otherId = createId();
+        await callback.handleChainEnd({ result: 'z' }, otherId);
+
+        expect(debugSpy).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy.mock.calls[0][0]).toContain(otherId);
+      });
+    });
   });
 });

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -2395,6 +2395,58 @@ describe('GalileoCallback', () => {
         expect(warnSpy).toHaveBeenCalledTimes(1);
         expect(warnSpy.mock.calls[0][0]).toContain(otherId);
       });
+
+      it('should leave _lastCommittedRoot unset when _commit throws, so a late end still warns', async () => {
+        // If startTrace/logNodeTree/flush throws, the trace was never
+        // finalized — `_lastCommittedRoot` must NOT be updated, so a later
+        // duplicate end for the same run_id surfaces as a warn (real failure)
+        // rather than a debug ("already finalized") false negative.
+        const startTraceSpy = jest
+          .spyOn(callback['_galileoLogger'], 'startTrace')
+          .mockImplementation(() => {
+            throw new Error('startTrace failed');
+          });
+
+        const runId = createId();
+        await callback.handleChainStart(
+          {
+            name: 'agent',
+            lc: 1,
+            type: 'secret',
+            id: ['agent']
+          } as Serialized,
+          { input: 'hello' },
+          runId
+        );
+
+        await expect(
+          callback.handleAgentEnd(
+            { returnValues: { output: 'hi' }, log: 'log' } as AgentFinish,
+            runId
+          )
+        ).rejects.toThrow('startTrace failed');
+
+        // State is still cleared (finally), but the failed commit is NOT
+        // recorded as the last committed root.
+        expect(callback['_nodes']).toEqual({});
+        expect(callback['_rootNode']).toBeNull();
+        expect(callback['_lastCommittedRoot']).toBeNull();
+
+        warnSpy.mockClear();
+        debugSpy.mockClear();
+        startTraceSpy.mockRestore();
+
+        // A late duplicate end for the same run_id must warn — the prior
+        // commit aborted, so this is a genuine orphan from the caller's view.
+        await callback.handleChainEnd({ result: 'hi' }, runId);
+
+        expect(debugSpy).not.toHaveBeenCalled();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        const warnMsg = warnSpy.mock.calls[0][0] as string;
+        expect(warnMsg).toContain('handleChainEnd');
+        expect(warnMsg).toContain(runId);
+        expect(warnMsg).toContain('no node exists');
+      });
     });
   });
 });

--- a/tests/handlers/langchain/callback.test.ts
+++ b/tests/handlers/langchain/callback.test.ts
@@ -2447,6 +2447,54 @@ describe('GalileoCallback', () => {
         expect(warnMsg).toContain(runId);
         expect(warnMsg).toContain('no node exists');
       });
+
+      it('should reset _lastCommittedRoot when a new trace starts on a reused callback instance', async () => {
+        // After a successful commit, `_lastCommittedRoot` is retained so
+        // late post-commit callbacks for that run_id can be debug-logged.
+        // But once a fresh trace begins on the same callback instance, the
+        // stale value must be cleared — otherwise a genuinely orphaned end
+        // that happens to collide with the previous root's run_id would be
+        // silently downgraded to debug.
+        const firstRunId = createId();
+
+        await callback.handleChainStart(
+          {
+            name: 'agent',
+            lc: 1,
+            type: 'secret',
+            id: ['agent']
+          } as Serialized,
+          { input: 'first' },
+          firstRunId
+        );
+
+        await callback.handleAgentEnd(
+          { returnValues: { output: 'done' }, log: 'log' } as AgentFinish,
+          firstRunId
+        );
+
+        expect(callback['_lastCommittedRoot']).toEqual({
+          runId: firstRunId,
+          nodeType: 'agent'
+        });
+
+        // A new trace begins on the same callback instance.
+        const secondRunId = createId();
+        await callback.handleChainStart(
+          {
+            name: 'agent',
+            lc: 1,
+            type: 'secret',
+            id: ['agent']
+          } as Serialized,
+          { input: 'second' },
+          secondRunId
+        );
+
+        // Stale committed-root identity must be dropped the moment a new
+        // root is established.
+        expect(callback['_lastCommittedRoot']).toBeNull();
+      });
     });
   });
 });


### PR DESCRIPTION
# User description
# [ Bug ] TS/JS SDK showing no node exists however successfully logging to Galileo
 - [sc-36763](https://app.shortcut.com/galileo/story/36763/bug-ts-js-sdk-showing-no-node-exists-however-successfully-logging-to-galileo)

## Description
* Improved logging to distinguish between actual issues in root nodes not being found during langchain processing, and the process with langchain agent trace conclusion (which emits two end events, and shouldn't be treated as an actual issue).

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
GalileoCallback_handleChainEnd_("GalileoCallback.handleChainEnd"):::modified
GalileoCallback_endNode_("GalileoCallback._endNode"):::modified
GalileoCallback_handleAgentEnd_("GalileoCallback.handleAgentEnd"):::modified
GalileoCallback_handleToolEnd_("GalileoCallback.handleToolEnd"):::modified
GalileoCallback_handleRetrieverEnd_("GalileoCallback.handleRetrieverEnd"):::modified
GalileoCallback_handleChainError_("GalileoCallback.handleChainError"):::modified
GalileoCallback_handleError_("GalileoCallback._handleError"):::modified
GalileoCallback_handleToolError_("GalileoCallback.handleToolError"):::modified
GalileoCallback_handleChainEnd_ -- "Passes callbackName; _endNode ignores late duplicate chain ends by runId." --> GalileoCallback_endNode_
GalileoCallback_handleAgentEnd_ -- "Passes callbackName; _endNode labels agent span and ignores late ends." --> GalileoCallback_endNode_
GalileoCallback_handleToolEnd_ -- "Passes callbackName; _endNode finalizes tool span and filters late ends." --> GalileoCallback_endNode_
GalileoCallback_handleRetrieverEnd_ -- "Passes callbackName; _endNode finalizes retriever span with proper labeling." --> GalileoCallback_endNode_
GalileoCallback_handleChainError_ -- "Adds callbackName to _handleError, improving error log context." --> GalileoCallback_handleError_
GalileoCallback_handleToolError_ -- "Adds callbackName to _handleError, improving tool error reporting context." --> GalileoCallback_handleError_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Clarify LangChain logging by teaching <code>GalileoCallback</code> to track the last committed root run and label end/error callbacks so non-issues stay debug-level while genuine orphans warn. Strengthen LangChain callback tests to cover late end callbacks, error handling, and trace reset behavior that anchors <code>_lastCommittedRoot</code>.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/586?tool=ast&topic=SDK+export+cleanup>SDK export cleanup</a>
        </td><td>Clean up the SDK surface by pruning unused dataset/project utilities, removing <code>ExperimentAPIException</code>, and deprecating <code>GalileoLogger.create</code> plus its optional proto exporter dependency so the entry module reflects the active APIs.<details><summary>Modified files (4)</summary><ul><li>package-lock.json</li>
<li>src/index.ts</li>
<li>src/utils/errors.ts</li>
<li>src/utils/galileo-logger.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ricardo.maurique@galil...</td><td>fix(test): Fixed tests...</td><td>May 04, 2026</td></tr>
<tr><td>Focadecombate</td><td>feat: add OpenTelemetr...</td><td>May 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/586?tool=ast&topic=LangChain+logging>LangChain logging</a>
        </td><td>Track the last committed root in <code>GalileoCallback</code>, pass callback names through <code>_endNode</code>/<code>_handleError</code>, and log duplicates as debug while leaving genuine orphan ends as warnings.<details><summary>Modified files (2)</summary><ul><li>src/handlers/langchain/index.ts</li>
<li>tests/handlers/langchain/callback.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ricardo.maurique@galil...</td><td>fix(reset): Resetting ...</td><td>May 05, 2026</td></tr>
<tr><td>Murike</td><td>feat(handlers): Improv...</td><td>April 17, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/586?tool=ast>(Baz)</a>.