### PR TITLE
feat: add metricAggregates + getExperimentColumns, deprecate aggregateMetrics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@openai/agents": ">=0.4.0",
         "@opentelemetry/api": ">=1.4.0",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+        "@opentelemetry/exporter-trace-otlp-proto": ">=0.41.0",
         "@opentelemetry/resources": ">=1.15.0",
         "@opentelemetry/sdk-trace-base": ">=1.15.0",
         "openai": ">=4.0.0"
@@ -76,6 +77,9 @@
           "optional": true
         },
         "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
           "optional": true
         },
         "@opentelemetry/resources": {

--- a/src/api-client/base-client.ts
+++ b/src/api-client/base-client.ts
@@ -10,6 +10,16 @@ import { Routes } from '../types/routes.types';
 import { getSdkIdentifier } from '../utils/version';
 import { objectToSnake, toCamel } from 'ts-case-convert';
 import type { ObjectToSnake, ObjectToCamel } from 'ts-case-convert';
+import {
+  GalileoAPIError,
+  isGalileoAPIStandardErrorData
+} from '../types/errors.types';
+
+// Type guards for snake_case and camelCase conversion
+type ValidatedSnakeCase<T extends object, TTarget> =
+  ObjectToSnake<T> extends TTarget ? TTarget : never;
+type ValidatedCamelCase<T extends object, TTarget> =
+  ObjectToCamel<T> extends TTarget ? TTarget : never;
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -24,16 +34,6 @@ function objectToCamelPreservingUuids(obj: unknown): unknown {
   }
   return result;
 }
-import {
-  GalileoAPIError,
-  isGalileoAPIStandardErrorData
-} from '../types/errors.types';
-
-// Type guards for snake_case and camelCase conversion
-type ValidatedSnakeCase<T extends object, TTarget> =
-  ObjectToSnake<T> extends TTarget ? TTarget : never;
-type ValidatedCamelCase<T extends object, TTarget> =
-  ObjectToCamel<T> extends TTarget ? TTarget : never;
 
 export enum RequestMethod {
   GET = 'GET',

--- a/src/api-client/base-client.ts
+++ b/src/api-client/base-client.ts
@@ -8,8 +8,22 @@ import { decode } from 'jsonwebtoken';
 import type { paths } from '../types/api.types';
 import { Routes } from '../types/routes.types';
 import { getSdkIdentifier } from '../utils/version';
-import { objectToCamel, objectToSnake } from 'ts-case-convert';
+import { objectToSnake, toCamel } from 'ts-case-convert';
 import type { ObjectToSnake, ObjectToCamel } from 'ts-case-convert';
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function objectToCamelPreservingUuids(obj: unknown): unknown {
+  if (obj === null || obj === undefined || typeof obj !== 'object') return obj;
+  if (obj instanceof Uint8Array || obj instanceof Date) return obj;
+  if (Array.isArray(obj)) return obj.map(objectToCamelPreservingUuids);
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    result[UUID_RE.test(k) ? k : toCamel(k)] = objectToCamelPreservingUuids(v);
+  }
+  return result;
+}
 import {
   GalileoAPIError,
   isGalileoAPIStandardErrorData
@@ -284,7 +298,7 @@ export class BaseClient {
   public convertToCamelCase<T extends object, TTarget>(
     obj: T
   ): ValidatedCamelCase<T, TTarget> {
-    return objectToCamel<T>(obj) as ValidatedCamelCase<T, TTarget>;
+    return objectToCamelPreservingUuids(obj) as ValidatedCamelCase<T, TTarget>;
   }
 
   protected initializeClient(): void {

--- a/src/entities/experiments.ts
+++ b/src/entities/experiments.ts
@@ -52,28 +52,6 @@ export class Experiments {
   }
 
   /**
-   * ts-case-convert treats UUID hyphens as word separators, mangling keys like
-   * "a14a1c2f-23f0-4aad-8eee-cc09d2a42287" → "a14a1c2f23f04aad8eeeCc09d2a42287".
-   * Detect 32-char hex strings (UUIDs with hyphens stripped) and restore them.
-   */
-  private _restoreUuidKeys(
-    metrics: Record<string, unknown> | null | undefined
-  ): Record<string, unknown> | null | undefined {
-    if (!metrics) return metrics;
-    const HEX32 = /^[0-9a-f]{32}$/i;
-    return Object.fromEntries(
-      Object.entries(metrics).map(([key, val]) => {
-        const lower = key.toLowerCase();
-        if (HEX32.test(lower)) {
-          const uuid = `${lower.slice(0, 8)}-${lower.slice(8, 12)}-${lower.slice(12, 16)}-${lower.slice(16, 20)}-${lower.slice(20)}`;
-          return [uuid, val];
-        }
-        return [key, val];
-      })
-    );
-  }
-
-  /**
    * Enriches an experiment response with `metricAggregates` (alias for
    * `structuredAggregateMetrics`) and a runtime deprecation warning on `aggregateMetrics`.
    */
@@ -82,10 +60,7 @@ export class Experiments {
   ): ExperimentResponseType {
     const enriched = {
       ...response,
-      metricAggregates:
-        (this._restoreUuidKeys(
-          response.structuredAggregateMetrics as Record<string, unknown>
-        ) as ExperimentResponseType['metricAggregates']) ?? undefined
+      metricAggregates: response.structuredAggregateMetrics ?? undefined
     };
     Object.defineProperty(enriched, 'aggregateMetrics', {
       get() {

--- a/src/entities/experiments.ts
+++ b/src/entities/experiments.ts
@@ -89,7 +89,7 @@ export class Experiments {
    * const cols = await experiments.getExperimentColumns({ projectName: 'My Project' });
    * const colMap = Object.fromEntries((cols.columns ?? []).map(c => [c.id, c]));
    * for (const [metricId, agg] of Object.entries(experiment.metricAggregates ?? {})) {
-   *   const col = colMap[`metrics/${metricId}`];   // undefined for system metrics
+   *   const col = colMap[`metrics/${metricId}`];   // null metricKeyAlias for system metrics
    *   const label = col?.label ?? metricId;
    *   console.log(`${label}: avg=${agg.avg}`);
    * }

--- a/src/entities/experiments.ts
+++ b/src/entities/experiments.ts
@@ -3,6 +3,7 @@ import {
   type ExperimentResponseType,
   type ExperimentUpdateRequest,
   type ExperimentDatasetRequest,
+  type ExperimentsAvailableColumnsResponse,
   type RunExperimentWithFunctionOutput,
   type RunExperimentParams,
   type RunExperimentOutput,
@@ -51,6 +52,62 @@ export class Experiments {
   }
 
   /**
+   * Enriches an experiment response with `metricAggregates` (alias for
+   * `structuredAggregateMetrics`) and a runtime deprecation warning on `aggregateMetrics`.
+   */
+  private _enrichExperimentResponse(
+    response: ExperimentResponseType
+  ): ExperimentResponseType {
+    const enriched = {
+      ...response,
+      metricAggregates: response.structuredAggregateMetrics ?? undefined
+    };
+    Object.defineProperty(enriched, 'aggregateMetrics', {
+      get() {
+        sdkLogger.warn(
+          'DEPRECATED: aggregateMetrics is deprecated. Use metricAggregates instead, ' +
+            'which returns full statistical aggregates (avg, min, max, p50, p90, p95, p99) ' +
+            'keyed by scorer UUID for scorer-backed metrics or raw string for system metrics ' +
+            "(e.g. 'cost', 'duration_ns')."
+        );
+        return response.aggregateMetrics;
+      },
+      enumerable: true,
+      configurable: true
+    });
+    return enriched;
+  }
+
+  /**
+   * Returns all available columns for the experiment comparison table.
+   *
+   * Scorer-backed metric columns have IDs of the form `"metrics/{scorer-uuid}"`, which maps
+   * directly to the keys in `experiment.metricAggregates`. Use `column.metricKeyAlias` for
+   * the legacy snake_case metric name and `column.label` for the display label.
+   *
+   * @example
+   * const cols = await experiments.getExperimentColumns({ projectName: 'My Project' });
+   * const colMap = Object.fromEntries((cols.columns ?? []).map(c => [c.id, c]));
+   * for (const [metricId, agg] of Object.entries(experiment.metricAggregates ?? {})) {
+   *   const col = colMap[`metrics/${metricId}`];   // undefined for system metrics
+   *   const label = col?.label ?? metricId;
+   *   console.log(`${label}: avg=${agg.avg}`);
+   * }
+   */
+  async getExperimentColumns(options: {
+    projectId?: string;
+    projectName?: string;
+  }): Promise<ExperimentsAvailableColumnsResponse> {
+    const client = await this.ensureClient();
+    await client.init({
+      projectScoped: true,
+      projectId: options.projectId,
+      projectName: options.projectName
+    });
+    return client.getExperimentsAvailableColumns();
+  }
+
+  /**
    * Gets an experiment by ID or name.
    * @param options - The options for getting an experiment.
    * @param options.projectId - (Optional) The unique identifier of the project.
@@ -79,11 +136,15 @@ export class Experiments {
     });
 
     if (options.id) {
-      return await client.getExperiment(options.id);
+      const result = await client.getExperiment(options.id);
+      return result ? this._enrichExperimentResponse(result) : undefined;
     }
 
     const experiments = await client.getExperiments();
-    return experiments.find((experiment) => experiment.name === options.name);
+    const found = experiments.find(
+      (experiment) => experiment.name === options.name
+    );
+    return found ? this._enrichExperimentResponse(found) : undefined;
   }
 
   /**
@@ -131,7 +192,7 @@ export class Experiments {
       );
     }
 
-    return experiment;
+    return this._enrichExperimentResponse(experiment);
   }
 
   /**
@@ -149,7 +210,11 @@ export class Experiments {
   }): Promise<ExperimentResponseType> {
     const client = await this.ensureClient();
     await client.init({ projectId: options.projectId });
-    return await client.updateExperiment(options.id, options.updateRequest);
+    const result = await client.updateExperiment(
+      options.id,
+      options.updateRequest
+    );
+    return this._enrichExperimentResponse(result);
   }
 
   /**

--- a/src/entities/experiments.ts
+++ b/src/entities/experiments.ts
@@ -14,6 +14,7 @@ import type {
   LocalMetricConfig,
   Metric
 } from '../types/metrics.types';
+import type { MetricAggregates } from '../types/new-api.types';
 import { Metrics } from '../utils/metrics';
 import { ExperimentTags } from './experiment-tags';
 import type {
@@ -35,6 +36,9 @@ import type { Dataset } from '../entities/datasets';
 import { getSdkLogger } from 'galileo-generated';
 
 const sdkLogger = getSdkLogger();
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
  * Entity class for managing experiments.
@@ -58,9 +62,52 @@ export class Experiments {
   private _enrichExperimentResponse(
     response: ExperimentResponseType
   ): ExperimentResponseType {
-    const enriched = {
+    const self = this;
+    const enriched: ExperimentResponseType = {
       ...response,
-      metricAggregates: response.structuredAggregateMetrics ?? undefined
+      metricAggregates: response.structuredAggregateMetrics ?? undefined,
+      /**
+       * Look up aggregate statistics for a metric by any identifier.
+       *
+       * Accepts (in priority order):
+       * 1. Scorer UUID string — direct lookup in metricAggregates
+       * 2. GalileoMetrics value / human-readable label (e.g. "Correctness")
+       * 3. Legacy metric_key_alias (e.g. "correctness") — fallback after label miss
+       *
+       * Returns undefined if metricAggregates is not yet populated or the metric
+       * is not found.
+       */
+      getMetricAggregate: async (
+        metric: GalileoMetrics | string
+      ): Promise<MetricAggregates | undefined> => {
+        const aggregates = enriched.metricAggregates;
+        if (!aggregates) return undefined;
+
+        // UUID → direct lookup, no column resolution needed
+        if (UUID_RE.test(metric)) {
+          return aggregates[metric];
+        }
+
+        // Label or metricKeyAlias → resolve via experiment_columns
+        const cols = await self.getExperimentColumns({
+          projectId: response.projectId
+        });
+        const columns = cols.columns ?? [];
+        type ColItem = (typeof columns)[number];
+        let aliasMatch: ColItem | undefined;
+        for (const col of columns) {
+          if (col.label === metric) {
+            return aggregates[col.id.replace(/^metrics\//, '')];
+          }
+          if (col.metricKeyAlias === metric && !aliasMatch) {
+            aliasMatch = col;
+          }
+        }
+        if (aliasMatch) {
+          return aggregates[aliasMatch.id.replace(/^metrics\//, '')];
+        }
+        return undefined;
+      }
     };
     Object.defineProperty(enriched, 'aggregateMetrics', {
       get() {

--- a/src/entities/experiments.ts
+++ b/src/entities/experiments.ts
@@ -62,7 +62,6 @@ export class Experiments {
   private _enrichExperimentResponse(
     response: ExperimentResponseType
   ): ExperimentResponseType {
-    const self = this;
     const enriched: ExperimentResponseType = {
       ...response,
       metricAggregates: response.structuredAggregateMetrics ?? undefined,
@@ -89,7 +88,7 @@ export class Experiments {
         }
 
         // Label or metricKeyAlias → resolve via experiment_columns
-        const cols = await self.getExperimentColumns({
+        const cols = await this.getExperimentColumns({
           projectId: response.projectId
         });
         const columns = cols.columns ?? [];

--- a/src/entities/experiments.ts
+++ b/src/entities/experiments.ts
@@ -52,6 +52,28 @@ export class Experiments {
   }
 
   /**
+   * ts-case-convert treats UUID hyphens as word separators, mangling keys like
+   * "a14a1c2f-23f0-4aad-8eee-cc09d2a42287" → "a14a1c2f23f04aad8eeeCc09d2a42287".
+   * Detect 32-char hex strings (UUIDs with hyphens stripped) and restore them.
+   */
+  private _restoreUuidKeys(
+    metrics: Record<string, unknown> | null | undefined
+  ): Record<string, unknown> | null | undefined {
+    if (!metrics) return metrics;
+    const HEX32 = /^[0-9a-f]{32}$/i;
+    return Object.fromEntries(
+      Object.entries(metrics).map(([key, val]) => {
+        const lower = key.toLowerCase();
+        if (HEX32.test(lower)) {
+          const uuid = `${lower.slice(0, 8)}-${lower.slice(8, 12)}-${lower.slice(12, 16)}-${lower.slice(16, 20)}-${lower.slice(20)}`;
+          return [uuid, val];
+        }
+        return [key, val];
+      })
+    );
+  }
+
+  /**
    * Enriches an experiment response with `metricAggregates` (alias for
    * `structuredAggregateMetrics`) and a runtime deprecation warning on `aggregateMetrics`.
    */
@@ -60,7 +82,10 @@ export class Experiments {
   ): ExperimentResponseType {
     const enriched = {
       ...response,
-      metricAggregates: response.structuredAggregateMetrics ?? undefined
+      metricAggregates:
+        (this._restoreUuidKeys(
+          response.structuredAggregateMetrics as Record<string, unknown>
+        ) as ExperimentResponseType['metricAggregates']) ?? undefined
     };
     Object.defineProperty(enriched, 'aggregateMetrics', {
       get() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,8 @@ import {
   getExperiment,
   runExperiment,
   updateExperiment,
-  deleteExperiment
+  deleteExperiment,
+  getExperimentColumns
 } from './utils/experiments';
 import { ExperimentTags } from './entities/experiment-tags';
 import { Experiments } from './entities/experiments';
@@ -211,6 +212,7 @@ export {
   runExperiment,
   updateExperiment,
   deleteExperiment,
+  getExperimentColumns,
   // Experiment entities
   ExperimentTags,
   Experiments,

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -851,289 +851,6 @@ export interface paths {
     patch: operations['update_metric_settings_projects__project_id__log_streams__log_stream_id__metric_settings_patch'];
     trace?: never;
   };
-  '/projects/{project_id}/traces': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Log Traces */
-    post: operations['log_traces_projects__project_id__traces_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/traces/{trace_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get Trace */
-    get: operations['get_trace_projects__project_id__traces__trace_id__get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * Update Trace
-     * @description Update a trace with the given ID.
-     */
-    patch: operations['update_trace_projects__project_id__traces__trace_id__patch'];
-    trace?: never;
-  };
-  '/projects/{project_id}/spans/{span_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get Span */
-    get: operations['get_span_projects__project_id__spans__span_id__get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    /**
-     * Update Span
-     * @description Update a span with the given ID.
-     */
-    patch: operations['update_span_projects__project_id__spans__span_id__patch'];
-    trace?: never;
-  };
-  '/projects/{project_id}/metrics-testing/available_columns': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Metrics Testing Available Columns */
-    post: operations['metrics_testing_available_columns_projects__project_id__metrics_testing_available_columns_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/traces/search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Query Traces */
-    post: operations['query_traces_projects__project_id__traces_search_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/traces/partial_search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Query Partial Traces */
-    post: operations['query_partial_traces_projects__project_id__traces_partial_search_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/traces/count': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Count Traces
-     * @description This endpoint may return a slightly inaccurate count due to the way records are filtered before deduplication.
-     */
-    post: operations['count_traces_projects__project_id__traces_count_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/spans': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Log Spans */
-    post: operations['log_spans_projects__project_id__spans_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/spans/search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Query Spans */
-    post: operations['query_spans_projects__project_id__spans_search_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/spans/partial_search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Query Partial Spans */
-    post: operations['query_partial_spans_projects__project_id__spans_partial_search_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/spans/count': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Count Spans */
-    post: operations['count_spans_projects__project_id__spans_count_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/sessions': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Create Session */
-    post: operations['create_session_projects__project_id__sessions_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/sessions/search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Query Sessions */
-    post: operations['query_sessions_projects__project_id__sessions_search_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/sessions/partial_search': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Query Partial Sessions */
-    post: operations['query_partial_sessions_projects__project_id__sessions_partial_search_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/sessions/count': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Count Sessions */
-    post: operations['count_sessions_projects__project_id__sessions_count_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/sessions/{session_id}': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** Get Session */
-    get: operations['get_session_projects__project_id__sessions__session_id__get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/projects/{project_id}/traces/aggregated': {
     parameters: {
       query?: never;
@@ -1151,23 +868,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/projects/{project_id}/export_records': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /** Export Records */
-    post: operations['export_records_projects__project_id__export_records_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/projects/{project_id}/recompute-metrics': {
     parameters: {
       query?: never;
@@ -1179,66 +879,6 @@ export interface paths {
     put?: never;
     /** Recompute Metrics */
     post: operations['recompute_metrics_projects__project_id__recompute_metrics_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/traces/delete': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Delete Traces
-     * @description Delete all trace records that match the provided filters.
-     */
-    post: operations['delete_traces_projects__project_id__traces_delete_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/spans/delete': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Delete Spans
-     * @description Delete all span records that match the provided filters.
-     */
-    post: operations['delete_spans_projects__project_id__spans_delete_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/sessions/delete': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Delete Sessions
-     * @description Delete all session records that match the provided filters.
-     */
-    post: operations['delete_sessions_projects__project_id__sessions_delete_post'];
     delete?: never;
     options?: never;
     head?: never;
@@ -1352,46 +992,6 @@ export interface paths {
      * @description Procures the column information for experiments.
      */
     post: operations['experiments_available_columns_projects__project_id__experiments_available_columns_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/experiments/{experiment_id}/metrics': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Get Experiment Metrics
-     * @description Retrieve metrics for a specific experiment.
-     */
-    post: operations['get_experiment_metrics_projects__project_id__experiments__experiment_id__metrics_post'];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  '/projects/{project_id}/experiments/metrics': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    get?: never;
-    put?: never;
-    /**
-     * Get Experiments Metrics
-     * @description Retrieve metrics for all experiments in a project.
-     */
-    post: operations['get_experiments_metrics_projects__project_id__experiments_metrics_post'];
     delete?: never;
     options?: never;
     head?: never;
@@ -2537,26 +2137,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/integrations': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /**
-     * List Integrations
-     * @description List the created integrations for the requesting user.
-     */
-    get: operations['list_integrations_integrations_get'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/integrations/available': {
     parameters: {
       query?: never;
@@ -2593,7 +2173,7 @@ export interface paths {
     post?: never;
     /**
      * Delete Integration
-     * @description Delete the integration created by this user.
+     * @description Delete an integration. Admins can delete integrations created by other admins in the same org.
      */
     delete: operations['delete_integration_integrations__name__delete'];
     options?: never;
@@ -3066,7 +2646,7 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/llm_integrations': {
+  '/datasets/{dataset_id}/variable_preview': {
     parameters: {
       query?: never;
       header?: never;
@@ -3074,10 +2654,10 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Get Integrations And Model Info
-     * @description Get the list of supported scorer models for the user's llm integrations.
+     * Get Dataset Variable Preview
+     * @description Return a variable preview derived from the sampled dataset input rows.
      */
-    get: operations['get_integrations_and_model_info_llm_integrations_get'];
+    get: operations['get_dataset_variable_preview_datasets__dataset_id__variable_preview_get'];
     put?: never;
     post?: never;
     delete?: never;
@@ -3086,20 +2666,40 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/llm_integrations/projects/{project_id}/runs/{run_id}': {
+  '/projects/{project_id}/experiments/{experiment_id}/metrics': {
     parameters: {
       query?: never;
       header?: never;
       path?: never;
       cookie?: never;
     };
-    /**
-     * Get Integrations And Model Info For Run
-     * @description Get the list of supported scorer models for the run owner's llm integrations.
-     */
-    get: operations['get_integrations_and_model_info_for_run_llm_integrations_projects__project_id__runs__run_id__get'];
+    get?: never;
     put?: never;
-    post?: never;
+    /**
+     * Get Experiment Metrics
+     * @description Retrieve metrics for a specific experiment.
+     */
+    post: operations['get_experiment_metrics_projects__project_id__experiments__experiment_id__metrics_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/experiments/metrics': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Get Experiments Metrics
+     * @description Retrieve metrics for all experiments in a project.
+     */
+    post: operations['get_experiments_metrics_projects__project_id__experiments_metrics_post'];
     delete?: never;
     options?: never;
     head?: never;
@@ -3177,6 +2777,102 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/scorers/llm/validate/dataset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Validate Llm Scorer Dataset */
+    post: operations['validate_llm_scorer_dataset_scorers_llm_validate_dataset_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/scorers/code/validate/dataset': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Validate Code Scorer Dataset
+     * @description Validate a code scorer against dataset rows.
+     */
+    post: operations['validate_code_scorer_dataset_scorers_code_validate_dataset_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/traces': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Log Traces */
+    post: operations['log_traces_projects__project_id__traces_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/traces/{trace_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Trace */
+    get: operations['get_trace_projects__project_id__traces__trace_id__get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * Update Trace
+     * @description Update a trace with the given ID.
+     */
+    patch: operations['update_trace_projects__project_id__traces__trace_id__patch'];
+    trace?: never;
+  };
+  '/projects/{project_id}/spans/{span_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Span */
+    get: operations['get_span_projects__project_id__spans__span_id__get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    /**
+     * Update Span
+     * @description Update a span with the given ID.
+     */
+    patch: operations['update_span_projects__project_id__spans__span_id__patch'];
+    trace?: never;
+  };
   '/projects/{project_id}/traces/available_columns': {
     parameters: {
       query?: never;
@@ -3188,6 +2884,23 @@ export interface paths {
     put?: never;
     /** Traces Available Columns */
     post: operations['traces_available_columns_projects__project_id__traces_available_columns_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/metrics-testing/available_columns': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Metrics Testing Available Columns */
+    post: operations['metrics_testing_available_columns_projects__project_id__metrics_testing_available_columns_post'];
     delete?: never;
     options?: never;
     head?: never;
@@ -3222,6 +2935,128 @@ export interface paths {
     put?: never;
     /** Sessions Available Columns */
     post: operations['sessions_available_columns_projects__project_id__sessions_available_columns_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/traces/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query Traces */
+    post: operations['query_traces_projects__project_id__traces_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/traces/partial_search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query Partial Traces */
+    post: operations['query_partial_traces_projects__project_id__traces_partial_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/traces/count': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Count Traces
+     * @description This endpoint may return a slightly inaccurate count due to the way records are filtered before deduplication.
+     */
+    post: operations['count_traces_projects__project_id__traces_count_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/spans': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Log Spans */
+    post: operations['log_spans_projects__project_id__spans_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/spans/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query Spans */
+    post: operations['query_spans_projects__project_id__spans_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/spans/partial_search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query Partial Spans */
+    post: operations['query_partial_spans_projects__project_id__spans_partial_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/spans/count': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Count Spans */
+    post: operations['count_spans_projects__project_id__spans_count_post'];
     delete?: never;
     options?: never;
     head?: never;
@@ -3277,6 +3112,317 @@ export interface paths {
     put?: never;
     /** Query Custom Metrics */
     post: operations['query_custom_metrics_projects__project_id__metrics_custom_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/sessions': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Create Session */
+    post: operations['create_session_projects__project_id__sessions_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/sessions/search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query Sessions */
+    post: operations['query_sessions_projects__project_id__sessions_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/sessions/partial_search': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Query Partial Sessions */
+    post: operations['query_partial_sessions_projects__project_id__sessions_partial_search_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/sessions/count': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Count Sessions */
+    post: operations['count_sessions_projects__project_id__sessions_count_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/sessions/{session_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Session */
+    get: operations['get_session_projects__project_id__sessions__session_id__get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/export_records': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** Export Records */
+    post: operations['export_records_projects__project_id__export_records_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/traces/delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Delete Traces
+     * @description Delete all trace records that match the provided filters.
+     */
+    post: operations['delete_traces_projects__project_id__traces_delete_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/spans/delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Delete Spans
+     * @description Delete all span records that match the provided filters.
+     */
+    post: operations['delete_spans_projects__project_id__spans_delete_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/projects/{project_id}/sessions/delete': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Delete Sessions
+     * @description Delete all session records that match the provided filters.
+     */
+    post: operations['delete_sessions_projects__project_id__sessions_delete_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/integrations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List Integrations
+     * @description List the created integrations for the requesting user.
+     */
+    get: operations['list_integrations_integrations_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/integrations/select': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Select Integration
+     * @description Select an integration for this user.
+     */
+    post: operations['select_integration_integrations_select_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/integrations/disable': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Disable Integration
+     * @description Disable an integration type for this user.
+     *
+     *     Creates an opt-out record so no shared integration of this type is used.
+     */
+    post: operations['disable_integration_integrations_disable_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/llm_integrations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Integrations And Model Info
+     * @description Get the list of supported scorer models for the user's llm integrations.
+     */
+    get: operations['get_integrations_and_model_info_llm_integrations_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/llm_integrations/projects/{project_id}/runs/{run_id}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Integrations And Model Info For Run
+     * @description Get the list of supported scorer models for the run owner's llm integrations.
+     */
+    get: operations['get_integrations_and_model_info_for_run_llm_integrations_projects__project_id__runs__run_id__get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/code-metric-generations': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Create Code Metric Generation
+     * @description Generate scorer code from a user message (natural language, existing code, or combination).
+     *
+     *     Creates a background job that calls an LLM with the code metric generation system prompt.
+     *     Returns a generation ID for polling.
+     *
+     *     **Response:** 202 Accepted with generation ID.
+     */
+    post: operations['create_code_metric_generation_code_metric_generations_post'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/code-metric-generations/{generation_id}/status': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get Code Metric Generation Status
+     * @description Lightweight endpoint for polling code metric generation status.
+     *
+     *     Returns status, generated code (if complete), or error message (if failed).
+     */
+    get: operations['get_code_metric_generation_status_code_metric_generations__generation_id__status_get'];
+    put?: never;
+    post?: never;
     delete?: never;
     options?: never;
     head?: never;
@@ -3345,6 +3491,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -3358,6 +3505,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -3447,6 +3595,7 @@ export interface components {
         | components['schemas']['LlmSpan']
         | components['schemas']['RetrieverSpan']
         | components['schemas']['ToolSpan']
+        | components['schemas']['ControlSpan']
       )[];
       /**
        * @description Agent type.
@@ -3912,6 +4061,7 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
     };
     /** AggregatedTraceViewResponse */
@@ -3943,14 +4093,14 @@ export interface components {
        */
       has_all_traces: boolean;
     };
-    /** AndNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
-    AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
+    /** AndNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
+    AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
       /** And */
       and: (
-        | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
       )[];
     };
     /** AnnotationAggregate */
@@ -3976,6 +4126,8 @@ export interface components {
       dislike_count: number;
       /** Unrated Count */
       unrated_count: number;
+      /** Tie Count */
+      tie_count?: number | null;
     };
     /**
      * AnnotationQueueAction
@@ -4146,7 +4298,8 @@ export interface components {
       | 'okta'
       | 'azure-ad'
       | 'custom'
-      | 'saml';
+      | 'saml'
+      | 'invite';
     /** AvailableIntegrations */
     AvailableIntegrations: {
       /** Integrations */
@@ -4672,6 +4825,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -4894,6 +5049,34 @@ export interface components {
        */
       file: string;
     };
+    /** Body_validate_code_scorer_dataset_scorers_code_validate_dataset_post */
+    Body_validate_code_scorer_dataset_scorers_code_validate_dataset_post: {
+      /**
+       * File
+       * Format: binary
+       */
+      file: string;
+      /**
+       * Dataset Id
+       * Format: uuid
+       */
+      dataset_id: string;
+      /** Dataset Version Index */
+      dataset_version_index?: number | null;
+      /**
+       * Limit
+       * @default 100
+       */
+      limit?: number;
+      /** Starting Token */
+      starting_token?: number | null;
+      /** Required Scorers */
+      required_scorers?: string | string[] | null;
+      /** Scoreable Node Types */
+      scoreable_node_types?: string | string[] | null;
+      /** Score Type */
+      score_type?: string | null;
+    };
     /** Body_validate_code_scorer_log_record_scorers_code_validate_log_record_post */
     Body_validate_code_scorer_log_record_scorers_code_validate_log_record_post: {
       /**
@@ -4975,6 +5158,10 @@ export interface components {
       };
       /** Average */
       average?: number | null;
+      roll_up_method?:
+        | components['schemas']['RollUpMethodDisplayOptions']
+        | null;
+      data_type?: components['schemas']['OutputTypeEnum'] | null;
     };
     /** BucketedMetrics */
     BucketedMetrics: {
@@ -5215,6 +5402,27 @@ export interface components {
       } | null;
     };
     /**
+     * CodeMetricGenerationStatus
+     * @enum {string}
+     */
+    CodeMetricGenerationStatus: 'generating' | 'completed' | 'failed';
+    /**
+     * CodeMetricGenerationStatusResponse
+     * @description Lightweight polling response.
+     */
+    CodeMetricGenerationStatusResponse: {
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string;
+      status: components['schemas']['CodeMetricGenerationStatus'];
+      /** Generated Code */
+      generated_code?: string | null;
+      /** Error Message */
+      error_message?: string | null;
+    };
+    /**
      * CollaboratorRole
      * @enum {string}
      */
@@ -5335,6 +5543,12 @@ export interface components {
         | null;
       /** Metadata */
       metadata: components['schemas']['ColumnMappingConfig'] | string[] | null;
+      /** Mgt */
+      mgt?: {
+        [key: string]: components['schemas']['ColumnMappingConfig'];
+      } | null;
+    } & {
+      [key: string]: unknown;
     };
     /** ColumnMappingConfig */
     ColumnMappingConfig: {
@@ -5509,6 +5723,179 @@ export interface components {
           )[]
         | null;
     };
+    /**
+     * ControlAction
+     * @enum {string}
+     */
+    ControlAction: 'deny' | 'steer' | 'observe';
+    /**
+     * ControlAppliesTo
+     * @enum {string}
+     */
+    ControlAppliesTo: 'llm_call' | 'tool_call';
+    /**
+     * ControlCheckStage
+     * @enum {string}
+     */
+    ControlCheckStage: 'pre' | 'post';
+    /** ControlResult */
+    ControlResult: {
+      /** @description Decision/action produced by the control. */
+      action: components['schemas']['ControlAction'];
+      /**
+       * Matched
+       * @description Whether the control matched. False covers both non-match and error cases; use error_message to distinguish errors.
+       */
+      matched: boolean;
+      /**
+       * Confidence
+       * @description Confidence score reported by the control evaluation result.
+       */
+      confidence?: number | null;
+      /**
+       * Error Message
+       * @description Error text when control evaluation failed. This should be null for normal matches and non-matches.
+       */
+      error_message?: string | null;
+    };
+    /** ControlSpan */
+    ControlSpan: {
+      /**
+       * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      type: 'control';
+      /**
+       * Input
+       * @description Input to the trace or span.
+       * @default
+       */
+      input?:
+        | string
+        | components['schemas']['galileo_core__schemas__logging__llm__Message'][]
+        | (
+            | components['schemas']['TextContentPart']
+            | components['schemas']['FileContentPart']
+          )[];
+      /**
+       * Redacted Input
+       * @description Redacted input of the trace or span.
+       */
+      redacted_input?:
+        | string
+        | components['schemas']['galileo_core__schemas__logging__llm__Message'][]
+        | (
+            | components['schemas']['TextContentPart']
+            | components['schemas']['FileContentPart']
+          )[]
+        | null;
+      /** @description Output of the trace or span. */
+      output?: components['schemas']['ControlResult'] | null;
+      /** @description Redacted output of the trace or span. */
+      redacted_output?: components['schemas']['ControlResult'] | null;
+      /**
+       * Name
+       * @description Name of the trace, span or session.
+       * @default
+       */
+      name?: string;
+      /**
+       * Created
+       * Format: date-time
+       * @description Timestamp of the trace or span's creation.
+       */
+      created_at?: string;
+      /**
+       * User Metadata
+       * @description Metadata associated with this trace or span.
+       */
+      user_metadata?: {
+        [key: string]: string;
+      };
+      /**
+       * Tags
+       * @description Tags associated with this trace or span.
+       */
+      tags?: string[];
+      /**
+       * Status Code
+       * @description Status code of the trace or span. Used for logging failure or error states.
+       */
+      status_code?: number | null;
+      /** @description Metrics associated with this trace or span. */
+      metrics?: components['schemas']['Metrics'];
+      /**
+       * External Id
+       * @description A user-provided session, trace or span ID.
+       */
+      external_id?: string | null;
+      /**
+       * Dataset Input
+       * @description Input to the dataset associated with this trace
+       */
+      dataset_input?: string | null;
+      /**
+       * Dataset Output
+       * @description Output from the dataset associated with this trace
+       */
+      dataset_output?: string | null;
+      /**
+       * Dataset Metadata
+       * @description Metadata from the dataset associated with this trace
+       */
+      dataset_metadata?: {
+        [key: string]: string;
+      };
+      /**
+       * ID
+       * @description Galileo ID of the session, trace or span
+       */
+      id?: string | null;
+      /**
+       * Session ID
+       * @description Galileo ID of the session containing the trace or span or session
+       */
+      session_id?: string | null;
+      /**
+       * Trace ID
+       * @description Galileo ID of the trace containing the span (or the same value as id for a trace)
+       */
+      trace_id?: string | null;
+      /**
+       * Step Number
+       * @description Topological step number of the span.
+       */
+      step_number?: number | null;
+      /**
+       * Parent ID
+       * @description Galileo ID of the parent of this span
+       */
+      parent_id?: string | null;
+      /**
+       * Control Id
+       * @description Identifier of the control definition that produced this span.
+       */
+      control_id?: number | null;
+      /**
+       * Agent Name
+       * @description Normalized agent name associated with this control execution.
+       */
+      agent_name?: string | null;
+      /** @description Execution stage where the control ran, typically 'pre' or 'post'. */
+      check_stage?: components['schemas']['ControlCheckStage'] | null;
+      /** @description Parent execution type the control applied to, for example 'llm_call' or 'tool_call'. */
+      applies_to?: components['schemas']['ControlAppliesTo'] | null;
+      /**
+       * Evaluator Name
+       * @description Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+       */
+      evaluator_name?: string | null;
+      /**
+       * Selector Path
+       * @description Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+       */
+      selector_path?: string | null;
+    };
     /** CorrectnessScorer */
     CorrectnessScorer: {
       /**
@@ -5543,6 +5930,39 @@ export interface components {
        * @description Number of judges for the scorer.
        */
       num_judges?: number | null;
+    };
+    /**
+     * CreateCodeMetricGenerationRequest
+     * @description Request to generate scorer code from a user message.
+     */
+    CreateCodeMetricGenerationRequest: {
+      /**
+       * User Message
+       * @description Natural language, code, or combination
+       */
+      user_message: string;
+      /**
+       * Node Type
+       * @description Selected scoreable node type (llm, retriever, trace, agent, workflow, tool, session)
+       */
+      node_type?: string | null;
+      /**
+       * Model Name
+       * @description Model alias to use for generation. Defaults to best available.
+       */
+      model_name?: string | null;
+    };
+    /**
+     * CreateCodeMetricGenerationResponse
+     * @description Response with generation ID for polling.
+     */
+    CreateCodeMetricGenerationResponse: {
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string;
+      status: components['schemas']['CodeMetricGenerationStatus'];
     };
     /** CreateCustomLunaScorerVersionRequest */
     CreateCustomLunaScorerVersionRequest: {
@@ -5714,6 +6134,10 @@ export interface components {
         | null;
       /** Is Session */
       is_session?: boolean | null;
+      /** Validation Config */
+      validation_config?: {
+        [key: string]: unknown;
+      } | null;
       /**
        * Upload Data In Separate Task
        * @default true
@@ -5890,6 +6314,10 @@ export interface components {
         | null;
       /** Is Session */
       is_session?: boolean | null;
+      /** Validation Config */
+      validation_config?: {
+        [key: string]: unknown;
+      } | null;
       /**
        * Upload Data In Separate Task
        * @default true
@@ -6004,7 +6432,11 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
-      roll_up_method?: components['schemas']['NumericRollUpMethod'] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
+      roll_up_method?:
+        | components['schemas']['RollUpMethodDisplayOptions']
+        | null;
       /** Metric Color Picker Config */
       metric_color_picker_config?:
         | (
@@ -6372,6 +6804,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -6501,6 +6935,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -6620,6 +7056,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -6738,6 +7176,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -6866,6 +7306,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -6991,6 +7433,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7116,6 +7560,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7241,6 +7687,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7366,6 +7814,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7491,6 +7941,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7621,6 +8073,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7746,6 +8200,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -7875,6 +8331,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -8000,6 +8458,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -8125,6 +8585,8 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       roll_up_strategy?: components['schemas']['RollUpStrategy'] | null;
       /** Roll Up Methods */
       roll_up_methods?:
@@ -8171,7 +8633,9 @@ export interface components {
       | 'star_rating_aggregate'
       | 'thumb_rating_aggregate'
       | 'tags_rating_aggregate'
-      | 'text_rating_aggregate';
+      | 'text_rating_aggregate'
+      | 'annotation_agreement'
+      | 'fully_annotated';
     /**
      * DataTypeOptions
      * @enum {string}
@@ -8336,11 +8800,10 @@ export interface components {
        * @enum {string}
        */
       edit_type: 'copy_record_data';
-      /**
-       * Project Id
-       * Format: uuid4
-       */
-      project_id: string;
+      /** Project Id */
+      project_id?: string | null;
+      /** Queue Id */
+      queue_id?: string | null;
       /**
        * Ids
        * @description List of trace or span IDs to copy data from
@@ -8486,6 +8949,13 @@ export interface components {
       operator?: 'eq' | 'ne' | 'one_of' | 'not_in' | 'contains';
       /** Value */
       value: string | string[];
+    };
+    /** DatasetInputJsonField */
+    DatasetInputJsonField: {
+      /** Key */
+      key: string;
+      /** Values */
+      values: components['schemas']['JsonValue'][];
     };
     /** DatasetLastEditedByUserAtSort */
     DatasetLastEditedByUserAtSort: {
@@ -9013,6 +9483,7 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
     };
     /** ExperimentMetricsResponse */
@@ -9133,6 +9604,13 @@ export interface components {
       aggregate_metrics?: {
         [key: string]: unknown;
       };
+      /**
+       * Structured Aggregate Metrics
+       * @description Structured aggregate metrics keyed by raw metric name with full statistical aggregates. Present only when use_clickhouse_run_aggregates flag is enabled.
+       */
+      structured_aggregate_metrics?: {
+        [key: string]: components['schemas']['MetricAggregates'];
+      } | null;
       /**
        * Aggregate Feedback
        * @deprecated
@@ -9309,6 +9787,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -9322,6 +9801,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -9459,10 +9939,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -9517,6 +10014,7 @@ export interface components {
         | components['schemas']['ExtendedLlmSpanRecord']
         | components['schemas']['ExtendedToolSpanRecordWithChildren']
         | components['schemas']['ExtendedRetrieverSpanRecordWithChildren']
+        | components['schemas']['ExtendedControlSpanRecord']
       )[];
       /**
        * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
@@ -9559,6 +10057,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -9572,6 +10071,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -9709,10 +10209,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -9757,6 +10274,262 @@ export interface components {
        * @default default
        */
       agent_type?: components['schemas']['AgentType'];
+    };
+    /** ExtendedControlSpanRecord */
+    ExtendedControlSpanRecord: {
+      /**
+       * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      type: 'control';
+      /**
+       * Input
+       * @description Input to the trace or span.
+       * @default
+       */
+      input?:
+        | string
+        | components['schemas']['galileo_core__schemas__logging__llm__Message'][]
+        | (
+            | components['schemas']['TextContentPart']
+            | components['schemas']['FileContentPart']
+          )[];
+      /**
+       * Redacted Input
+       * @description Redacted input of the trace or span.
+       */
+      redacted_input?:
+        | string
+        | components['schemas']['galileo_core__schemas__logging__llm__Message'][]
+        | (
+            | components['schemas']['TextContentPart']
+            | components['schemas']['FileContentPart']
+          )[]
+        | null;
+      /** @description Output of the trace or span. */
+      output?: components['schemas']['ControlResult'] | null;
+      /** @description Redacted output of the trace or span. */
+      redacted_output?: components['schemas']['ControlResult'] | null;
+      /**
+       * Name
+       * @description Name of the trace, span or session.
+       * @default
+       */
+      name?: string;
+      /**
+       * Created
+       * Format: date-time
+       * @description Timestamp of the trace or span's creation.
+       */
+      created_at?: string;
+      /**
+       * User Metadata
+       * @description Metadata associated with this trace or span.
+       */
+      user_metadata?: {
+        [key: string]: string;
+      };
+      /**
+       * Tags
+       * @description Tags associated with this trace or span.
+       */
+      tags?: string[];
+      /**
+       * Status Code
+       * @description Status code of the trace or span. Used for logging failure or error states.
+       */
+      status_code?: number | null;
+      /** @description Metrics associated with this trace or span. */
+      metrics?: components['schemas']['Metrics'];
+      /**
+       * External Id
+       * @description A user-provided session, trace or span ID.
+       */
+      external_id?: string | null;
+      /**
+       * Dataset Input
+       * @description Input to the dataset associated with this trace
+       */
+      dataset_input?: string | null;
+      /**
+       * Dataset Output
+       * @description Output from the dataset associated with this trace
+       */
+      dataset_output?: string | null;
+      /**
+       * Dataset Metadata
+       * @description Metadata from the dataset associated with this trace
+       */
+      dataset_metadata?: {
+        [key: string]: string;
+      };
+      /**
+       * ID
+       * Format: uuid4
+       * @description Galileo ID of the session, trace or span
+       */
+      id: string;
+      /**
+       * Session ID
+       * Format: uuid4
+       * @description Galileo ID of the session containing the trace (or the same value as id for a trace)
+       */
+      session_id: string;
+      /**
+       * Trace ID
+       * @description Galileo ID of the trace containing the span (or the same value as id for a trace)
+       */
+      trace_id?: string | null;
+      /**
+       * Project ID
+       * Format: uuid4
+       * @description Galileo ID of the project associated with this trace or span
+       */
+      project_id: string;
+      /**
+       * Run ID
+       * Format: uuid4
+       * @description Galileo ID of the run (log stream or experiment) associated with this trace or span
+       */
+      run_id: string;
+      /**
+       * Last Updated
+       * @description Timestamp of the session or trace or span's last update
+       */
+      updated_at?: string | null;
+      /**
+       * Has Children
+       * @description Whether or not this trace or span has child spans
+       */
+      has_children?: boolean | null;
+      /**
+       * Metrics Batch Id
+       * @description Galileo ID of the metrics batch associated with this trace or span
+       */
+      metrics_batch_id?: string | null;
+      /**
+       * Session Batch Id
+       * @description Galileo ID of the metrics batch associated with this trace or span
+       */
+      session_batch_id?: string | null;
+      /**
+       * Feedback Rating Info
+       * @description Feedback information related to the record
+       */
+      feedback_rating_info?: {
+        [key: string]: components['schemas']['FeedbackRatingInfo'];
+      };
+      /**
+       * Annotations
+       * @description Annotations keyed by template ID and annotator ID
+       */
+      annotations?: {
+        [key: string]: {
+          [key: string]: components['schemas']['AnnotationRatingInfo'];
+        };
+      };
+      /**
+       * File Ids
+       * @description IDs of files associated with this record
+       */
+      file_ids?: string[];
+      /**
+       * File Modalities
+       * @description Modalities of files associated with this record
+       */
+      file_modalities?: components['schemas']['ContentModality'][];
+      /**
+       * Annotation Aggregates
+       * @description Annotation aggregate information keyed by template ID
+       */
+      annotation_aggregates?: {
+        [key: string]: components['schemas']['AnnotationAggregate'];
+      };
+      /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
+       * Annotation Queue Ids
+       * @description IDs of annotation queues this record is in
+       */
+      annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
+      /**
+       * Metric Info
+       * @description Detailed information about the metrics associated with this trace or span
+       */
+      metric_info?: {
+        [key: string]:
+          | components['schemas']['MetricNotComputed']
+          | components['schemas']['MetricPending']
+          | components['schemas']['MetricComputing']
+          | components['schemas']['MetricNotApplicable']
+          | components['schemas']['MetricSuccess']
+          | components['schemas']['MetricError']
+          | components['schemas']['MetricFailed']
+          | components['schemas']['MetricRollUp'];
+      } | null;
+      /**
+       * Files
+       * @description File metadata keyed by file ID for files associated with this record
+       */
+      files?: {
+        [key: string]: components['schemas']['FileMetadata'];
+      } | null;
+      /**
+       * Parent ID
+       * Format: uuid4
+       * @description Galileo ID of the parent of this span
+       */
+      parent_id: string;
+      /**
+       * Is Complete
+       * @description Whether the parent trace is complete or not
+       * @default true
+       */
+      is_complete?: boolean;
+      /**
+       * Step Number
+       * @description Topological step number of the span.
+       */
+      step_number?: number | null;
+      /**
+       * Control Id
+       * @description Identifier of the control definition that produced this span.
+       */
+      control_id?: number | null;
+      /**
+       * Agent Name
+       * @description Normalized agent name associated with this control execution.
+       */
+      agent_name?: string | null;
+      /** @description Execution stage where the control ran, typically 'pre' or 'post'. */
+      check_stage?: components['schemas']['ControlCheckStage'] | null;
+      /** @description Parent execution type the control applied to, for example 'llm_call' or 'tool_call'. */
+      applies_to?: components['schemas']['ControlAppliesTo'] | null;
+      /**
+       * Evaluator Name
+       * @description Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+       */
+      evaluator_name?: string | null;
+      /**
+       * Selector Path
+       * @description Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+       */
+      selector_path?: string | null;
     };
     /** ExtendedLlmSpanRecord */
     ExtendedLlmSpanRecord: {
@@ -9919,10 +10692,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -10167,10 +10957,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -10220,6 +11027,7 @@ export interface components {
         | components['schemas']['ExtendedLlmSpanRecord']
         | components['schemas']['ExtendedToolSpanRecordWithChildren']
         | components['schemas']['ExtendedRetrieverSpanRecordWithChildren']
+        | components['schemas']['ExtendedControlSpanRecord']
       )[];
       /**
        * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
@@ -10383,10 +11191,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -10469,6 +11294,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -10482,6 +11308,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -10618,10 +11445,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -10695,6 +11539,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -10708,6 +11553,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -10844,10 +11690,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -11039,10 +11902,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -11097,6 +11977,7 @@ export interface components {
         | components['schemas']['ExtendedLlmSpanRecord']
         | components['schemas']['ExtendedToolSpanRecordWithChildren']
         | components['schemas']['ExtendedRetrieverSpanRecordWithChildren']
+        | components['schemas']['ExtendedControlSpanRecord']
       )[];
       /**
        * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
@@ -11260,10 +12141,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -11497,10 +12395,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -11541,6 +12456,7 @@ export interface components {
         | components['schemas']['ExtendedLlmSpanRecord']
         | components['schemas']['ExtendedToolSpanRecordWithChildren']
         | components['schemas']['ExtendedRetrieverSpanRecordWithChildren']
+        | components['schemas']['ExtendedControlSpanRecord']
       )[];
       /**
        * Type
@@ -11730,10 +12646,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -11808,6 +12741,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -11821,6 +12755,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -11958,10 +12893,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -12011,6 +12963,7 @@ export interface components {
         | components['schemas']['ExtendedLlmSpanRecord']
         | components['schemas']['ExtendedToolSpanRecordWithChildren']
         | components['schemas']['ExtendedRetrieverSpanRecordWithChildren']
+        | components['schemas']['ExtendedControlSpanRecord']
       )[];
       /**
        * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
@@ -12053,6 +13006,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -12066,6 +13020,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -12203,10 +13158,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -12474,13 +13446,13 @@ export interface components {
      * @enum {string}
      */
     FileStatus: 'complete' | 'failed' | 'pending' | 'not_uploaded';
-    FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____:
-      | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-      | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-      | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-      | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____'];
-    /** FilterLeaf[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
-    FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
+    FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____:
+      | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+      | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+      | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+      | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____'];
+    /** FilterLeaf[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
+    FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
       /** Filter */
       filter:
         | components['schemas']['LogRecordsIDFilter']
@@ -12488,7 +13460,8 @@ export interface components {
         | components['schemas']['LogRecordsNumberFilter']
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
-        | components['schemas']['LogRecordsTextFilter'];
+        | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter'];
     };
     /** FineTunedScorer */
     FineTunedScorer: {
@@ -12595,6 +13568,13 @@ export interface components {
        * @default false
        */
       ground_truth?: boolean;
+      /**
+       * Multimodal Capabilities
+       * @description Multimodal capabilities required by this scorer.
+       */
+      multimodal_capabilities?:
+        | components['schemas']['MultimodalCapability'][]
+        | null;
     };
     /** GeneratedScorerResponse */
     GeneratedScorerResponse: {
@@ -13488,6 +14468,15 @@ export interface components {
        * @default false
        */
       is_selected?: boolean;
+      /**
+       * Is Disabled
+       * @default false
+       */
+      is_disabled?: boolean;
+    };
+    /** IntegrationDisableRequest */
+    IntegrationDisableRequest: {
+      integration_name: components['schemas']['IntegrationName'];
     };
     /** IntegrationModelsResponse */
     IntegrationModelsResponse: {
@@ -13525,13 +14514,21 @@ export interface components {
       | 'azure'
       | 'custom'
       | 'databricks'
-      | 'labelstudio'
       | 'mistral'
       | 'nvidia'
       | 'openai'
       | 'vegas_gateway'
       | 'vertex_ai'
       | 'writer';
+    /** IntegrationSelectRequest */
+    IntegrationSelectRequest: {
+      integration_name: components['schemas']['IntegrationName'];
+      /**
+       * Integration Id
+       * Format: uuid4
+       */
+      integration_id: string;
+    };
     /**
      * InternalToolCall
      * @description A tool call executed internally by the model during reasoning.
@@ -13715,6 +14712,9 @@ export interface components {
       /** Steps Total */
       steps_total?: number | null;
     };
+    JsonPrimitive: string | number | boolean | null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    JsonValue: any; // circular self-reference in generated spec — simplified to any
     /**
      * LLMExportFormat
      * @enum {string}
@@ -14059,6 +15059,8 @@ export interface components {
         | components['schemas']['ScorerNameFilter']
         | components['schemas']['ScorerTypeFilter']
         | components['schemas']['ScorerModelTypeFilter']
+        | components['schemas']['ScorerExcludeSlmScorersFilter']
+        | components['schemas']['ScorerExcludeMultimodalScorersFilter']
         | components['schemas']['ScorerTagsFilter']
         | components['schemas']['ScorerCreatorFilter']
         | components['schemas']['ScorerCreatedAtFilter']
@@ -14462,6 +15464,11 @@ export interface components {
        * @description Type of label color for the column, if this is a multilabel metric column.
        */
       label_color?: ('positive' | 'negative') | null;
+      /**
+       * Metric Key Alias
+       * @description Alternate metric key for this column. When store_metric_ids is ON, this holds the legacy metric_name string. Used for dual-key ClickHouse queries.
+       */
+      metric_key_alias?: string | null;
     };
     /** LogRecordsCustomMetricsQueryRequest */
     LogRecordsCustomMetricsQueryRequest: {
@@ -14482,7 +15489,7 @@ export interface components {
       metrics_testing_id?: string | null;
       /** @description Filter expression tree for complex filtering */
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
       /**
        * Start Time
@@ -14575,9 +15582,10 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
     };
     /** LogRecordsDeleteResponse */
@@ -14593,6 +15601,27 @@ export interface components {
      * @description Request schema for exporting log records (sessions, traces, spans).
      */
     LogRecordsExportRequest: {
+      /**
+       * Column Ids
+       * @description Column IDs to include in the export. Applies only to CSV exports.
+       */
+      column_ids?: string[] | null;
+      /**
+       * @description Export format
+       * @default jsonl
+       */
+      export_format?: components['schemas']['LLMExportFormat'];
+      /**
+       * Redact
+       * @description Redact sensitive data
+       * @default true
+       */
+      redact?: boolean;
+      /**
+       * File Name
+       * @description Optional filename for the exported file
+       */
+      file_name?: string | null;
       /**
        * Log Stream Id
        * @description Log stream id associated with the traces.
@@ -14619,31 +15648,11 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       /** @description Sort clause for the export.  Defaults to native sort (created_at, id descending). */
       sort?: components['schemas']['LogRecordsSortClause'] | null;
-      /**
-       * Column Ids
-       * @description Column IDs to include in export
-       */
-      column_ids?: string[] | null;
-      /**
-       * @description Export format
-       * @default jsonl
-       */
-      export_format?: components['schemas']['LLMExportFormat'];
       root_type: components['schemas']['RootType'];
-      /**
-       * Redact
-       * @description Redact sensitive data
-       * @default true
-       */
-      redact?: boolean;
-      /**
-       * File Name
-       * @description Optional filename for the exported file
-       */
-      file_name?: string | null;
     };
     /**
      * LogRecordsFilterType
@@ -14655,7 +15664,31 @@ export interface components {
       | 'number'
       | 'boolean'
       | 'text'
-      | 'collection';
+      | 'collection'
+      | 'fully_annotated';
+    /**
+     * LogRecordsFullyAnnotatedFilter
+     * @description Queue-scoped filter for records rated across all queue templates.
+     */
+    LogRecordsFullyAnnotatedFilter: {
+      /**
+       * Column Id
+       * @description Queue-scoped filter identifier. This filter only works for annotation-queue searches that provide queue context.
+       * @default fully_annotated
+       * @constant
+       */
+      column_id?: 'fully_annotated';
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      type: 'fully_annotated';
+      /**
+       * User Ids
+       * @description Optional queue member IDs to require for full annotation in a queue-scoped search. If omitted, all tracked queue members visible to the requester are used.
+       */
+      user_ids?: string[] | null;
+    };
     /** LogRecordsIDFilter */
     LogRecordsIDFilter: {
       /**
@@ -14702,6 +15735,7 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       /**
        * Start Time
@@ -14813,9 +15847,10 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
       /** @description Sort for the query.  Defaults to native sort (created_at, id descending). */
       sort?: components['schemas']['LogRecordsSortClause'] | null;
@@ -14864,6 +15899,7 @@ export interface components {
         | components['schemas']['PartialExtendedLlmSpanRecord']
         | components['schemas']['PartialExtendedToolSpanRecord']
         | components['schemas']['PartialExtendedRetrieverSpanRecord']
+        | components['schemas']['PartialExtendedControlSpanRecord']
         | components['schemas']['PartialExtendedSessionRecord']
       )[];
     };
@@ -14906,9 +15942,10 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
     };
     /** LogRecordsQueryCountResponse */
@@ -14956,9 +15993,10 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
       /** @description Sort for the query.  Defaults to native sort (created_at, id descending). */
       sort?: components['schemas']['LogRecordsSortClause'] | null;
@@ -15006,6 +16044,7 @@ export interface components {
         | components['schemas']['ExtendedLlmSpanRecord']
         | components['schemas']['ExtendedToolSpanRecord']
         | components['schemas']['ExtendedRetrieverSpanRecord']
+        | components['schemas']['ExtendedControlSpanRecord']
         | components['schemas']['ExtendedSessionRecord']
       )[];
     };
@@ -15113,6 +16152,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Tags
@@ -15215,6 +16255,7 @@ export interface components {
         | components['schemas']['LlmSpan']
         | components['schemas']['RetrieverSpan']
         | components['schemas']['ToolSpan']
+        | components['schemas']['ControlSpan']
       )[];
       /**
        * Trace Id
@@ -15353,6 +16394,19 @@ export interface components {
       operator?: 'eq' | 'ne' | 'one_of' | 'not_in' | 'contains';
       /** Value */
       value: string | string[];
+    };
+    /**
+     * LogStreamInfo
+     * @description Minimal log stream representation (id and name only).
+     */
+    LogStreamInfo: {
+      /**
+       * Id
+       * Format: uuid4
+       */
+      id: string;
+      /** Name */
+      name: string;
     };
     /** RunNameFilter */
     LogStreamNameFilter: {
@@ -15751,7 +16805,7 @@ export interface components {
      * LunaOutputTypeEnum
      * @enum {string}
      */
-    LunaOutputTypeEnum: 'float' | 'string' | 'string_list';
+    LunaOutputTypeEnum: 'float' | 'string' | 'string_list' | 'bool_list';
     /**
      * MCPApprovalRequestEvent
      * @description MCP approval request - when human approval is needed for an MCP tool call.
@@ -15969,6 +17023,39 @@ export interface components {
       value: string | string[];
     };
     /**
+     * MetricAggregates
+     * @description Structured aggregate values for a single metric, computed from ClickHouse row-level data.
+     */
+    MetricAggregates: {
+      /** Avg */
+      avg?: number | null;
+      /** Sum */
+      sum?: number | null;
+      /** Min */
+      min?: number | null;
+      /** Max */
+      max?: number | null;
+      /** Count */
+      count?: number | null;
+      /** Pct */
+      pct?: number | null;
+      /** P50 */
+      p50?: number | null;
+      /** P90 */
+      p90?: number | null;
+      /** P95 */
+      p95?: number | null;
+      /** P99 */
+      p99?: number | null;
+      /**
+       * Value Distribution
+       * @description Distribution of discrete values as {value: count}. For boolean metrics: {'0': 2, '1': 8}. For categorical metrics: {'low': 5, 'medium': 3, 'high': 2}.
+       */
+      value_distribution?: {
+        [key: string]: number;
+      } | null;
+    };
+    /**
      * MetricAggregation
      * @enum {string}
      */
@@ -15981,7 +17068,9 @@ export interface components {
       | 'P50'
       | 'P90'
       | 'P95'
-      | 'P99';
+      | 'P99'
+      | 'PercentageFalse'
+      | 'PercentageTrue';
     /** MetricAggregationDetail */
     MetricAggregationDetail: {
       /**
@@ -16134,6 +17223,8 @@ export interface components {
        */
       status_type: 'computing';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /**
        * Message
        * @default Metric is computing.
@@ -16193,6 +17284,8 @@ export interface components {
        */
       status_type: 'error';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /**
        * Message
        * @default An error occured.
@@ -16214,6 +17307,8 @@ export interface components {
        */
       status_type: 'failed';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /**
        * Message
        * @default Metric failed to compute.
@@ -16235,6 +17330,8 @@ export interface components {
        */
       status_type: 'not_applicable';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /**
        * Message
        * @default Metric not applicable.
@@ -16256,6 +17353,8 @@ export interface components {
        */
       status_type: 'not_computed';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /**
        * Message
        * @default Metric not computed.
@@ -16270,6 +17369,8 @@ export interface components {
        */
       status_type: 'pending';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
     };
     /** MetricRollUp */
     MetricRollUp: {
@@ -16279,6 +17380,8 @@ export interface components {
        */
       status_type: 'roll_up';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /** Value */
       value:
         | string
@@ -16342,15 +17445,13 @@ export interface components {
        * Roll Up Metrics
        * @description Roll up metrics e.g. sum, average, min, max for numeric, and category_count for categorical metrics.
        */
-      roll_up_metrics?:
-        | {
-            [key: string]: number;
-          }
-        | {
-            [key: string]: {
+      roll_up_metrics?: {
+        [key: string]:
+          | number
+          | {
               [key: string]: number;
             };
-          };
+      };
     };
     /** MetricSettingsRequest */
     MetricSettingsRequest: {
@@ -16383,6 +17484,8 @@ export interface components {
        */
       status_type: 'success';
       scorer_type?: components['schemas']['ScorerType'] | null;
+      /** Metric Key Alias */
+      metric_key_alias?: string | null;
       /** Value */
       value:
         | string
@@ -16737,14 +17840,14 @@ export interface components {
       | 'workflow'
       | 'trace'
       | 'session';
-    /** NotNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
-    NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
+    /** NotNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
+    NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
       /** Not */
       not:
-        | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____'];
+        | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____'];
     };
     /**
      * NumericColorConstraint
@@ -16838,14 +17941,14 @@ export interface components {
       type?: string;
       function: components['schemas']['OpenAIFunction'];
     };
-    /** OrNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
-    OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
+    /** OrNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]] */
+    OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____: {
       /** Or */
       or: (
-        | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
-        | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterLeaf_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['AndNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['OrNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['NotNode_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
       )[];
     };
     /**
@@ -17055,6 +18158,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -17068,6 +18172,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -17201,10 +18306,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -17248,6 +18370,257 @@ export interface components {
        * @default default
        */
       agent_type?: components['schemas']['AgentType'];
+    };
+    /** PartialExtendedControlSpanRecord */
+    PartialExtendedControlSpanRecord: {
+      /**
+       * @description Type of the trace, span or session. (enum property replaced by openapi-typescript)
+       * @enum {string}
+       */
+      type: 'control';
+      /**
+       * Input
+       * @description Input to the trace or span.
+       * @default
+       */
+      input?:
+        | string
+        | components['schemas']['galileo_core__schemas__logging__llm__Message'][]
+        | (
+            | components['schemas']['TextContentPart']
+            | components['schemas']['FileContentPart']
+          )[];
+      /**
+       * Redacted Input
+       * @description Redacted input of the trace or span.
+       */
+      redacted_input?:
+        | string
+        | components['schemas']['galileo_core__schemas__logging__llm__Message'][]
+        | (
+            | components['schemas']['TextContentPart']
+            | components['schemas']['FileContentPart']
+          )[]
+        | null;
+      /** @description Output of the trace or span. */
+      output?: components['schemas']['ControlResult'] | null;
+      /** @description Redacted output of the trace or span. */
+      redacted_output?: components['schemas']['ControlResult'] | null;
+      /**
+       * Name
+       * @description Name of the trace, span or session.
+       * @default
+       */
+      name?: string;
+      /**
+       * Created
+       * Format: date-time
+       * @description Timestamp of the trace or span's creation.
+       */
+      created_at?: string;
+      /**
+       * User Metadata
+       * @description Metadata associated with this trace or span.
+       */
+      user_metadata?: {
+        [key: string]: string;
+      };
+      /**
+       * Tags
+       * @description Tags associated with this trace or span.
+       */
+      tags?: string[];
+      /**
+       * Status Code
+       * @description Status code of the trace or span. Used for logging failure or error states.
+       */
+      status_code?: number | null;
+      /** @description Metrics associated with this trace or span. */
+      metrics?: components['schemas']['Metrics'];
+      /**
+       * External Id
+       * @description A user-provided session, trace or span ID.
+       */
+      external_id?: string | null;
+      /**
+       * Dataset Input
+       * @description Input to the dataset associated with this trace
+       */
+      dataset_input?: string | null;
+      /**
+       * Dataset Output
+       * @description Output from the dataset associated with this trace
+       */
+      dataset_output?: string | null;
+      /**
+       * Dataset Metadata
+       * @description Metadata from the dataset associated with this trace
+       */
+      dataset_metadata?: {
+        [key: string]: string;
+      };
+      /**
+       * ID
+       * @description Galileo ID of the session, trace or span
+       */
+      id?: string | null;
+      /**
+       * Session ID
+       * @description Galileo ID of the session containing the trace (or the same value as id for a trace)
+       */
+      session_id?: string | null;
+      /**
+       * Trace ID
+       * @description Galileo ID of the trace containing the span (or the same value as id for a trace)
+       */
+      trace_id?: string | null;
+      /**
+       * Project ID
+       * @description Galileo ID of the project associated with this trace or span
+       */
+      project_id?: string | null;
+      /**
+       * Run ID
+       * @description Galileo ID of the run (log stream or experiment) associated with this trace or span
+       */
+      run_id?: string | null;
+      /**
+       * Last Updated
+       * @description Timestamp of the session or trace or span's last update
+       */
+      updated_at?: string | null;
+      /**
+       * Has Children
+       * @description Whether or not this trace or span has child spans
+       */
+      has_children?: boolean | null;
+      /**
+       * Metrics Batch Id
+       * @description Galileo ID of the metrics batch associated with this trace or span
+       */
+      metrics_batch_id?: string | null;
+      /**
+       * Session Batch Id
+       * @description Galileo ID of the metrics batch associated with this trace or span
+       */
+      session_batch_id?: string | null;
+      /**
+       * Feedback Rating Info
+       * @description Feedback information related to the record
+       */
+      feedback_rating_info?: {
+        [key: string]: components['schemas']['FeedbackRatingInfo'];
+      };
+      /**
+       * Annotations
+       * @description Annotations keyed by template ID and annotator ID
+       */
+      annotations?: {
+        [key: string]: {
+          [key: string]: components['schemas']['AnnotationRatingInfo'];
+        };
+      };
+      /**
+       * File Ids
+       * @description IDs of files associated with this record
+       */
+      file_ids?: string[];
+      /**
+       * File Modalities
+       * @description Modalities of files associated with this record
+       */
+      file_modalities?: components['schemas']['ContentModality'][];
+      /**
+       * Annotation Aggregates
+       * @description Annotation aggregate information keyed by template ID
+       */
+      annotation_aggregates?: {
+        [key: string]: components['schemas']['AnnotationAggregate'];
+      };
+      /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
+       * Annotation Queue Ids
+       * @description IDs of annotation queues this record is in
+       */
+      annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
+      /**
+       * Metric Info
+       * @description Detailed information about the metrics associated with this trace or span
+       */
+      metric_info?: {
+        [key: string]:
+          | components['schemas']['MetricNotComputed']
+          | components['schemas']['MetricPending']
+          | components['schemas']['MetricComputing']
+          | components['schemas']['MetricNotApplicable']
+          | components['schemas']['MetricSuccess']
+          | components['schemas']['MetricError']
+          | components['schemas']['MetricFailed']
+          | components['schemas']['MetricRollUp'];
+      } | null;
+      /**
+       * Files
+       * @description File metadata keyed by file ID for files associated with this record
+       */
+      files?: {
+        [key: string]: components['schemas']['FileMetadata'];
+      } | null;
+      /**
+       * Parent ID
+       * @description Galileo ID of the parent of this span
+       */
+      parent_id?: string | null;
+      /**
+       * Is Complete
+       * @description Whether the parent trace is complete or not
+       * @default true
+       */
+      is_complete?: boolean;
+      /**
+       * Step Number
+       * @description Topological step number of the span.
+       */
+      step_number?: number | null;
+      /**
+       * Control Id
+       * @description Identifier of the control definition that produced this span.
+       */
+      control_id?: number | null;
+      /**
+       * Agent Name
+       * @description Normalized agent name associated with this control execution.
+       */
+      agent_name?: string | null;
+      /** @description Execution stage where the control ran, typically 'pre' or 'post'. */
+      check_stage?: components['schemas']['ControlCheckStage'] | null;
+      /** @description Parent execution type the control applied to, for example 'llm_call' or 'tool_call'. */
+      applies_to?: components['schemas']['ControlAppliesTo'] | null;
+      /**
+       * Evaluator Name
+       * @description Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+       */
+      evaluator_name?: string | null;
+      /**
+       * Selector Path
+       * @description Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+       */
+      selector_path?: string | null;
     };
     /** PartialExtendedLlmSpanRecord */
     PartialExtendedLlmSpanRecord: {
@@ -17406,10 +18779,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -17649,10 +19039,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -17734,6 +19141,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -17747,6 +19155,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -17880,10 +19289,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -18069,10 +19495,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -18300,10 +19743,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -18376,6 +19836,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -18389,6 +19850,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -18522,10 +19984,27 @@ export interface components {
         [key: string]: components['schemas']['AnnotationAggregate'];
       };
       /**
+       * Annotation Agreement
+       * @description Annotation agreement scores keyed by template ID
+       */
+      annotation_agreement?: {
+        [key: string]: number;
+      };
+      /**
+       * Overall Annotation Agreement
+       * @description Average annotation agreement across all templates in the queue
+       */
+      overall_annotation_agreement?: number | null;
+      /**
        * Annotation Queue Ids
        * @description IDs of annotation queues this record is in
        */
       annotation_queue_ids?: string[];
+      /**
+       * Fully Annotated
+       * @description Whether every field is annotated by every annotator in the queue
+       */
+      fully_annotated?: boolean | null;
       /**
        * Metric Info
        * @description Detailed information about the metrics associated with this trace or span
@@ -18947,6 +20426,11 @@ export interface components {
        * @description List of labels associated with the project.
        */
       labels?: components['schemas']['ProjectLabels'][];
+      /**
+       * Log Streams
+       * @description Log streams for this project. Only populated when include_logstreams=True.
+       */
+      log_streams?: components['schemas']['LogStreamInfo'][] | null;
     };
     /**
      * ProjectLabels
@@ -19759,9 +21243,10 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
       /** @description Sort for the query.  Defaults to native sort (created_at, id descending). */
       sort?: components['schemas']['LogRecordsSortClause'] | null;
@@ -20023,8 +21508,26 @@ export interface components {
         | components['schemas']['LlmSpan']
         | components['schemas']['RetrieverSpan']
         | components['schemas']['ToolSpan']
+        | components['schemas']['ControlSpan']
       )[];
     };
+    /**
+     * RollUpMethodDisplayOptions
+     * @description Display options for roll up methods when showing rolled up metrics in the UI.
+     *
+     *     Separates display intent from computation methods. The computation methods
+     *     (NumericRollUpMethod, CategoricalRollUpMethod) control what aggregations are available.
+     *     This enum controls how the UI displays the selected roll-up value for a scorer.
+     * @enum {string}
+     */
+    RollUpMethodDisplayOptions:
+      | 'average'
+      | 'sum'
+      | 'max'
+      | 'min'
+      | 'category_count'
+      | 'percentage_true'
+      | 'percentage_false';
     /**
      * RollUpStrategy
      * @description Strategies for rolling metrics up the Session/Trace/Span hierarchy.
@@ -20485,8 +21988,9 @@ export interface components {
       multimodal_capabilities?:
         | components['schemas']['MultimodalCapability'][]
         | null;
-      /** Roll Up Method */
-      roll_up_method?: string | null;
+      roll_up_method?:
+        | components['schemas']['RollUpMethodDisplayOptions']
+        | null;
       /**
        * Score Type
        * @description Return type of code scorers (e.g., 'bool', 'int', 'float', 'str').
@@ -20607,6 +22111,31 @@ export interface components {
        */
       value: string;
     };
+    /**
+     * ScorerExcludeMultimodalScorersFilter
+     * @description Internal filter: excludes multimodal scorers (non-empty multimodal_capabilities).
+     *
+     *     Auto-appended by the service layer when the `multimodal` feature flag is disabled.
+     */
+    ScorerExcludeMultimodalScorersFilter: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      name: 'exclude_multimodal_scorers';
+    };
+    /**
+     * ScorerExcludeSlmScorersFilter
+     * @description Internal filter: excludes scorers with model_type == slm while including
+     *     scorers where model_type IS NULL. Auto-appended by the service layer.
+     */
+    ScorerExcludeSlmScorersFilter: {
+      /**
+       * @description discriminator enum property added by openapi-typescript
+       * @enum {string}
+       */
+      name: 'exclude_slm_scorers';
+    };
     /** ScorerIDFilter */
     ScorerIDFilter: {
       /**
@@ -20655,6 +22184,13 @@ export interface components {
        * @enum {string}
        */
       name: 'model_type';
+      /**
+       * Operator
+       * @enum {string}
+       */
+      operator: 'eq' | 'ne' | 'one_of' | 'not_in';
+      /** Value */
+      value: string | string[];
     };
     /** ScorerNameFilter */
     ScorerNameFilter: {
@@ -20725,8 +22261,13 @@ export interface components {
         | null;
       /** Required Scorers */
       required_scorers?: string[] | null;
+      /** Required Metric Ids */
+      required_metric_ids?: string[] | null;
       /** Deprecated */
       deprecated?: boolean | null;
+      roll_up_method?:
+        | components['schemas']['RollUpMethodDisplayOptions']
+        | null;
       roll_up_config?: components['schemas']['BaseMetricRollUpConfigDB'] | null;
       /**
        * Label
@@ -20748,7 +22289,6 @@ export interface components {
       created_at?: string | null;
       /** Updated At */
       updated_at?: string | null;
-      roll_up_method?: components['schemas']['NumericRollUpMethod'] | null;
       /** Metric Color Picker Config */
       metric_color_picker_config?:
         | (
@@ -20758,6 +22298,8 @@ export interface components {
             | components['schemas']['MetricColorPickerMultiLabel']
           )
         | null;
+      /** Metric Name */
+      metric_name?: string | null;
     };
     /** ScorerScoreableNodeTypesFilter */
     ScorerScoreableNodeTypesFilter: {
@@ -20945,6 +22487,11 @@ export interface components {
        * @default false
        */
       context_relevance_luna?: boolean;
+      /**
+       * Chunk Relevance Luna
+       * @default false
+       */
+      chunk_relevance_luna?: boolean;
       /**
        * Completeness Nli
        * @default false
@@ -21438,6 +22985,7 @@ export interface components {
       | 'tool'
       | 'workflow'
       | 'agent'
+      | 'control'
       | 'trace'
       | 'session';
     /** StringData */
@@ -22069,6 +23617,7 @@ export interface components {
         | components['schemas']['LlmSpan']
         | components['schemas']['RetrieverSpan']
         | components['schemas']['ToolSpan']
+        | components['schemas']['ControlSpan']
       )[];
       /**
        * Tool Call Id
@@ -22297,6 +23846,7 @@ export interface components {
         | components['schemas']['LlmSpan']
         | components['schemas']['RetrieverSpan']
         | components['schemas']['ToolSpan']
+        | components['schemas']['ControlSpan']
       )[];
     };
     /** TraceMetadata */
@@ -22406,9 +23956,9 @@ export interface components {
       multimodal_capabilities?:
         | components['schemas']['MultimodalCapability'][]
         | null;
-      /** Required Scorers */
-      required_scorers?: string[] | null;
-      roll_up_method?: components['schemas']['NumericRollUpMethod'] | null;
+      roll_up_method?:
+        | components['schemas']['RollUpMethodDisplayOptions']
+        | null;
       /** Metric Color Picker Config */
       metric_color_picker_config?:
         | (
@@ -22437,7 +23987,14 @@ export interface components {
      * UserAction
      * @enum {string}
      */
-    UserAction: 'update' | 'delete' | 'read_api_keys';
+    UserAction:
+      | 'update'
+      | 'delete'
+      | 'read_api_keys'
+      | 'change_role_to_admin'
+      | 'change_role_to_manager'
+      | 'change_role_to_user'
+      | 'change_role_to_read_only';
     /** UserCollaborator */
     UserCollaborator: {
       /**
@@ -22576,6 +24133,19 @@ export interface components {
       /** Test Scores */
       test_scores: components['schemas']['TestScore'][];
     };
+    /** ValidateCodeScorerDatasetResponse */
+    ValidateCodeScorerDatasetResponse: {
+      /**
+       * Metrics Experiment Id
+       * Format: uuid4
+       */
+      metrics_experiment_id: string;
+      /**
+       * Project Id
+       * Format: uuid4
+       */
+      project_id: string;
+    };
     /** ValidateCodeScorerResponse */
     ValidateCodeScorerResponse: {
       /**
@@ -22583,6 +24153,58 @@ export interface components {
        * Format: uuid4
        */
       task_id: string;
+    };
+    /**
+     * ValidateLLMScorerDatasetRequest
+     * @description Request to validate a new LLM scorer against a dataset.
+     */
+    ValidateLLMScorerDatasetRequest: {
+      /** Query */
+      query: string;
+      /** Response */
+      response: string;
+      chain_poll_template: components['schemas']['ChainPollTemplate'];
+      scorer_configuration: components['schemas']['GeneratedScorerConfiguration'];
+      /** User Prompt */
+      user_prompt: string;
+      /**
+       * Dataset Id
+       * Format: uuid4
+       */
+      dataset_id: string;
+      /** Dataset Version Index */
+      dataset_version_index?: number | null;
+      /**
+       * Limit
+       * @description Maximum number of dataset rows to process.
+       * @default 100
+       */
+      limit?: number;
+      /**
+       * Starting Token
+       * @description Pagination offset into dataset rows.
+       */
+      starting_token?: number | null;
+      /**
+       * Sort
+       * @description Optional sort configuration for dataset rows.
+       */
+      sort?: {
+        [key: string]: unknown;
+      } | null;
+    };
+    /** ValidateLLMScorerDatasetResponse */
+    ValidateLLMScorerDatasetResponse: {
+      /**
+       * Metrics Experiment Id
+       * Format: uuid4
+       */
+      metrics_experiment_id: string;
+      /**
+       * Project Id
+       * Format: uuid4
+       */
+      project_id: string;
     };
     /**
      * ValidateLLMScorerLogRecordRequest
@@ -22625,9 +24247,10 @@ export interface components {
         | components['schemas']['LogRecordsBooleanFilter']
         | components['schemas']['LogRecordsCollectionFilter']
         | components['schemas']['LogRecordsTextFilter']
+        | components['schemas']['LogRecordsFullyAnnotatedFilter']
       )[];
       filter_tree?:
-        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
+        | components['schemas']['FilterExpression_Annotated_Union_LogRecordsIDFilter__LogRecordsDateFilter__LogRecordsNumberFilter__LogRecordsBooleanFilter__LogRecordsCollectionFilter__LogRecordsTextFilter__LogRecordsFullyAnnotatedFilter___FieldInfo_annotation_NoneType__required_True__discriminator__type____']
         | null;
       /** @description Sort for the query.  Defaults to native sort (created_at, id descending). */
       sort?: components['schemas']['LogRecordsSortClause'] | null;
@@ -22658,6 +24281,11 @@ export interface components {
        * Format: uuid4
        */
       metrics_experiment_id: string;
+      /**
+       * Project Id
+       * Format: uuid4
+       */
+      project_id: string;
     };
     /** ValidateRegisteredScorerResult */
     ValidateRegisteredScorerResult: {
@@ -22671,6 +24299,7 @@ export interface components {
      * @description Response model for validating a scorer based on log records.
      *
      *     Returns the uuid of the experiment created with the copied log records to store the metric testing results.
+     *     Also returns the project_id so callers can poll /projects/{project_id}/traces/search.
      */
     ValidateScorerLogRecordResponse: {
       /**
@@ -22678,6 +24307,11 @@ export interface components {
        * Format: uuid4
        */
       metrics_experiment_id: string;
+      /**
+       * Project Id
+       * Format: uuid4
+       */
+      project_id: string;
     };
     /** ValidationError */
     ValidationError: {
@@ -22866,6 +24500,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Redacted Output
@@ -22879,6 +24514,7 @@ export interface components {
             | components['schemas']['TextContentPart']
             | components['schemas']['FileContentPart']
           )[]
+        | components['schemas']['ControlResult']
         | null;
       /**
        * Name
@@ -22968,6 +24604,7 @@ export interface components {
         | components['schemas']['LlmSpan']
         | components['schemas']['RetrieverSpan']
         | components['schemas']['ToolSpan']
+        | components['schemas']['ControlSpan']
       )[];
     };
     /** WriterIntegration */
@@ -23155,6 +24792,7 @@ export interface components {
       | 'chunk_attribution_utilization_luna'
       | 'chunk_attribution_utilization'
       | 'chunk_relevance'
+      | 'chunk_relevance_luna'
       | 'context_precision'
       | 'precision_at_k'
       | 'completeness_luna'
@@ -23166,6 +24804,8 @@ export interface components {
       | 'conversation_quality'
       | 'correctness'
       | 'ground_truth_adherence'
+      | 'visual_fidelity'
+      | 'visual_quality'
       | 'input_pii'
       | 'input_pii_gpt'
       | 'input_sexist'
@@ -23201,7 +24841,8 @@ export interface components {
       | 'tool_selection_quality'
       | 'tool_selection_quality_luna'
       | 'uncertainty'
-      | 'user_intent_change';
+      | 'user_intent_change'
+      | 'interruption_detection';
     /**
      * ModelProperties
      * @description Properties for a model in a custom integration.
@@ -23246,6 +24887,7 @@ export interface components {
       | '_context_adherence_luna'
       | '_context_relevance'
       | '_context_relevance_luna'
+      | '_chunk_relevance_luna'
       | '_chunk_attribution_utilization_gpt'
       | '_factuality'
       | '_groundedness'
@@ -25443,640 +27085,6 @@ export interface operations {
       };
     };
   };
-  log_traces_projects__project_id__traces_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogTracesIngestRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogTracesIngestResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  get_trace_projects__project_id__traces__trace_id__get: {
-    parameters: {
-      query?: {
-        include_presigned_urls?: boolean;
-      };
-      header?: never;
-      path: {
-        trace_id: string;
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ExtendedTraceRecordWithChildren'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  update_trace_projects__project_id__traces__trace_id__patch: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        trace_id: string;
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogTraceUpdateRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogTraceUpdateResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  get_span_projects__project_id__spans__span_id__get: {
-    parameters: {
-      query?: {
-        include_presigned_urls?: boolean;
-      };
-      header?: never;
-      path: {
-        span_id: string;
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json':
-            | components['schemas']['ExtendedAgentSpanRecordWithChildren']
-            | components['schemas']['ExtendedWorkflowSpanRecordWithChildren']
-            | components['schemas']['ExtendedLlmSpanRecord']
-            | components['schemas']['ExtendedToolSpanRecordWithChildren']
-            | components['schemas']['ExtendedRetrieverSpanRecordWithChildren'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  update_span_projects__project_id__spans__span_id__patch: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        span_id: string;
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogSpanUpdateRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogSpanUpdateResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  metrics_testing_available_columns_projects__project_id__metrics_testing_available_columns_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['MetricsTestingAvailableColumnsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsAvailableColumnsResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  query_traces_projects__project_id__traces_search_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsQueryRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsQueryResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  query_partial_traces_projects__project_id__traces_partial_search_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsPartialQueryRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsPartialQueryResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  count_traces_projects__project_id__traces_count_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsQueryCountRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsQueryCountResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  log_spans_projects__project_id__spans_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogSpansIngestRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogSpansIngestResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  query_spans_projects__project_id__spans_search_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsQueryRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsQueryResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  query_partial_spans_projects__project_id__spans_partial_search_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsPartialQueryRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsPartialQueryResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  count_spans_projects__project_id__spans_count_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsQueryCountRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsQueryCountResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  create_session_projects__project_id__sessions_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['SessionCreateRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['SessionCreateResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  query_sessions_projects__project_id__sessions_search_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsQueryRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsQueryResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  query_partial_sessions_projects__project_id__sessions_partial_search_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsPartialQueryRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsPartialQueryResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  count_sessions_projects__project_id__sessions_count_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsQueryCountRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsQueryCountResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  get_session_projects__project_id__sessions__session_id__get: {
-    parameters: {
-      query?: {
-        include_presigned_urls?: boolean;
-      };
-      header?: never;
-      path: {
-        session_id: string;
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ExtendedSessionRecordWithChildren'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
   get_aggregated_trace_view_projects__project_id__traces_aggregated_post: {
     parameters: {
       query?: never;
@@ -26112,41 +27120,6 @@ export interface operations {
       };
     };
   };
-  export_records_projects__project_id__export_records_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsExportRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
   recompute_metrics_projects__project_id__recompute_metrics_post: {
     parameters: {
       query?: never;
@@ -26169,111 +27142,6 @@ export interface operations {
         };
         content: {
           'application/json': unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  delete_traces_projects__project_id__traces_delete_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsDeleteRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsDeleteResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  delete_spans_projects__project_id__spans_delete_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsDeleteRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsDeleteResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  delete_sessions_projects__project_id__sessions_delete_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['LogRecordsDeleteRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['LogRecordsDeleteResponse'];
         };
       };
       /** @description Validation Error */
@@ -26541,77 +27409,6 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['ExperimentsAvailableColumnsResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  get_experiment_metrics_projects__project_id__experiments__experiment_id__metrics_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-        experiment_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['ExperimentMetricsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ExperimentMetricsResponse'];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['HTTPValidationError'];
-        };
-      };
-    };
-  };
-  get_experiments_metrics_projects__project_id__experiments_metrics_post: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        project_id: string;
-      };
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        'application/json': components['schemas']['ExperimentMetricsRequest'];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['ExperimentMetricsResponse'];
         };
       };
       /** @description Validation Error */
@@ -28812,26 +29609,6 @@ export interface operations {
       };
     };
   };
-  list_integrations_integrations_get: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Successful Response */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          'application/json': components['schemas']['IntegrationDB'][];
-        };
-      };
-    };
-  };
   list_available_integrations_integrations_available_get: {
     parameters: {
       query?: never;
@@ -29806,15 +30583,13 @@ export interface operations {
       };
     };
   };
-  get_integrations_and_model_info_llm_integrations_get: {
+  get_dataset_variable_preview_datasets__dataset_id__variable_preview_get: {
     parameters: {
-      query?: {
-        multimodal_capabilities?:
-          | components['schemas']['MultimodalCapability'][]
-          | null;
-      };
+      query?: never;
       header?: never;
-      path?: never;
+      path: {
+        dataset_id: string;
+      };
       cookie?: never;
     };
     requestBody?: never;
@@ -29825,9 +30600,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': {
-            [key: string]: components['schemas']['IntegrationModelsResponse'];
-          };
+          'application/json': components['schemas']['DatasetInputJsonField'][];
         };
       };
       /** @description Validation Error */
@@ -29841,21 +30614,21 @@ export interface operations {
       };
     };
   };
-  get_integrations_and_model_info_for_run_llm_integrations_projects__project_id__runs__run_id__get: {
+  get_experiment_metrics_projects__project_id__experiments__experiment_id__metrics_post: {
     parameters: {
-      query?: {
-        multimodal_capabilities?:
-          | components['schemas']['MultimodalCapability'][]
-          | null;
-      };
+      query?: never;
       header?: never;
       path: {
         project_id: string;
-        run_id: string;
+        experiment_id: string;
       };
       cookie?: never;
     };
-    requestBody?: never;
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ExperimentMetricsRequest'];
+      };
+    };
     responses: {
       /** @description Successful Response */
       200: {
@@ -29863,9 +30636,42 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': {
-            [key: string]: components['schemas']['IntegrationModelsResponse'];
-          };
+          'application/json': components['schemas']['ExperimentMetricsResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_experiments_metrics_projects__project_id__experiments_metrics_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ExperimentMetricsRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ExperimentMetricsResponse'];
         };
       };
       /** @description Validation Error */
@@ -30013,6 +30819,253 @@ export interface operations {
       };
     };
   };
+  validate_llm_scorer_dataset_scorers_llm_validate_dataset_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ValidateLLMScorerDatasetRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ValidateLLMScorerDatasetResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  validate_code_scorer_dataset_scorers_code_validate_dataset_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'multipart/form-data': components['schemas']['Body_validate_code_scorer_dataset_scorers_code_validate_dataset_post'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ValidateCodeScorerDatasetResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  log_traces_projects__project_id__traces_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogTracesIngestRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogTracesIngestResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_trace_projects__project_id__traces__trace_id__get: {
+    parameters: {
+      query?: {
+        include_presigned_urls?: boolean;
+      };
+      header?: never;
+      path: {
+        trace_id: string;
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ExtendedTraceRecordWithChildren'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  update_trace_projects__project_id__traces__trace_id__patch: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        trace_id: string;
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogTraceUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogTraceUpdateResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_span_projects__project_id__spans__span_id__get: {
+    parameters: {
+      query?: {
+        include_presigned_urls?: boolean;
+      };
+      header?: never;
+      path: {
+        span_id: string;
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json':
+            | components['schemas']['ExtendedAgentSpanRecordWithChildren']
+            | components['schemas']['ExtendedWorkflowSpanRecordWithChildren']
+            | components['schemas']['ExtendedLlmSpanRecord']
+            | components['schemas']['ExtendedToolSpanRecordWithChildren']
+            | components['schemas']['ExtendedRetrieverSpanRecordWithChildren']
+            | components['schemas']['ExtendedControlSpanRecord'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  update_span_projects__project_id__spans__span_id__patch: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        span_id: string;
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogSpanUpdateRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogSpanUpdateResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
   traces_available_columns_projects__project_id__traces_available_columns_post: {
     parameters: {
       query?: never;
@@ -30025,6 +31078,41 @@ export interface operations {
     requestBody: {
       content: {
         'application/json': components['schemas']['LogRecordsAvailableColumnsRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsAvailableColumnsResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  metrics_testing_available_columns_projects__project_id__metrics_testing_available_columns_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MetricsTestingAvailableColumnsRequest'];
       };
     };
     responses: {
@@ -30105,6 +31193,251 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['LogRecordsAvailableColumnsResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  query_traces_projects__project_id__traces_search_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsQueryResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  query_partial_traces_projects__project_id__traces_partial_search_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsPartialQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsPartialQueryResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  count_traces_projects__project_id__traces_count_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsQueryCountRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsQueryCountResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  log_spans_projects__project_id__spans_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogSpansIngestRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogSpansIngestResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  query_spans_projects__project_id__spans_search_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsQueryResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  query_partial_spans_projects__project_id__spans_partial_search_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsPartialQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsPartialQueryResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  count_spans_projects__project_id__spans_count_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsQueryCountRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsQueryCountResponse'];
         };
       };
       /** @description Validation Error */
@@ -30210,6 +31543,543 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['LogRecordsMetricsResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  create_session_projects__project_id__sessions_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SessionCreateRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['SessionCreateResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  query_sessions_projects__project_id__sessions_search_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsQueryResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  query_partial_sessions_projects__project_id__sessions_partial_search_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsPartialQueryRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsPartialQueryResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  count_sessions_projects__project_id__sessions_count_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsQueryCountRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsQueryCountResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_session_projects__project_id__sessions__session_id__get: {
+    parameters: {
+      query?: {
+        include_presigned_urls?: boolean;
+      };
+      header?: never;
+      path: {
+        session_id: string;
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ExtendedSessionRecordWithChildren'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  export_records_projects__project_id__export_records_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsExportRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  delete_traces_projects__project_id__traces_delete_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsDeleteRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsDeleteResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  delete_spans_projects__project_id__spans_delete_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsDeleteRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsDeleteResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  delete_sessions_projects__project_id__sessions_delete_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        project_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['LogRecordsDeleteRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['LogRecordsDeleteResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  list_integrations_integrations_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['IntegrationDB'][];
+        };
+      };
+    };
+  };
+  select_integration_integrations_select_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['IntegrationSelectRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['IntegrationDB'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  disable_integration_integrations_disable_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['IntegrationDisableRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': unknown;
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_integrations_and_model_info_llm_integrations_get: {
+    parameters: {
+      query?: {
+        multimodal_capabilities?:
+          | components['schemas']['MultimodalCapability'][]
+          | null;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            [key: string]: components['schemas']['IntegrationModelsResponse'];
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_integrations_and_model_info_for_run_llm_integrations_projects__project_id__runs__run_id__get: {
+    parameters: {
+      query?: {
+        multimodal_capabilities?:
+          | components['schemas']['MultimodalCapability'][]
+          | null;
+      };
+      header?: never;
+      path: {
+        project_id: string;
+        run_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': {
+            [key: string]: components['schemas']['IntegrationModelsResponse'];
+          };
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  create_code_metric_generation_code_metric_generations_post: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['CreateCodeMetricGenerationRequest'];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      202: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CreateCodeMetricGenerationResponse'];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_code_metric_generation_status_code_metric_generations__generation_id__status_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        generation_id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CodeMetricGenerationStatusResponse'];
         };
       };
       /** @description Validation Error */

--- a/src/types/logging/step.types.ts
+++ b/src/types/logging/step.types.ts
@@ -52,7 +52,8 @@ export const StepType = {
   llm: 'llm',
   retriever: 'retriever',
   tool: 'tool',
-  agent: 'agent'
+  agent: 'agent',
+  control: 'control'
 } as const satisfies Record<StepType, StepType>;
 
 export interface MetricsOptions {

--- a/src/types/new-api.types.ts
+++ b/src/types/new-api.types.ts
@@ -7940,6 +7940,18 @@ export type ExperimentResponse = {
     [key: string]: MetricAggregates;
   } | null;
   /**
+   * Look up aggregate statistics for a metric by any identifier.
+   * Populated by the SDK via `_enrichExperimentResponse`.
+   *
+   * Accepts (in priority order):
+   * 1. Scorer UUID string — direct lookup in `metricAggregates`
+   * 2. GalileoMetrics value / human-readable label (e.g. "Correctness")
+   * 3. Legacy metric_key_alias (e.g. "correctness") — fallback after label miss
+   */
+  getMetricAggregate?: (
+    metric: string
+  ) => Promise<MetricAggregates | undefined>;
+  /**
    * Aggregate Feedback
    *
    * Aggregate feedback information related to the experiment (traces only)

--- a/src/types/new-api.types.ts
+++ b/src/types/new-api.types.ts
@@ -93,6 +93,7 @@ export type AgentSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -111,6 +112,7 @@ export type AgentSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -225,6 +227,9 @@ export type AgentSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
   /**
    * Agent type.
@@ -548,6 +553,9 @@ export type AggregatedTraceViewRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
 };
 
@@ -589,18 +597,18 @@ export type AggregatedTraceViewResponse = {
 };
 
 /**
- * AndNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * AndNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * And
      */
     and: Array<
-      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
     >;
   };
 
@@ -649,6 +657,10 @@ export type AnnotationLikeDislikeAggregate = {
    * Unrated Count
    */
   unratedCount: number;
+  /**
+   * Tie Count
+   */
+  tieCount?: number | null;
 };
 
 /**
@@ -915,7 +927,8 @@ export const AuthMethod = {
   OKTA: 'okta',
   AZURE_AD: 'azure-ad',
   CUSTOM: 'custom',
-  SAML: 'saml'
+  SAML: 'saml',
+  INVITE: 'invite'
 } as const;
 
 /**
@@ -1621,6 +1634,10 @@ export type BaseScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -1913,6 +1930,44 @@ export type BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost
   };
 
 /**
+ * Body_validate_code_scorer_dataset_scorers_code_validate_dataset_post
+ */
+export type BodyValidateCodeScorerDatasetScorersCodeValidateDatasetPost = {
+  /**
+   * File
+   */
+  file: Blob | File;
+  /**
+   * Dataset Id
+   */
+  datasetId: string;
+  /**
+   * Dataset Version Index
+   */
+  datasetVersionIndex?: number | null;
+  /**
+   * Limit
+   */
+  limit?: number;
+  /**
+   * Starting Token
+   */
+  startingToken?: number | null;
+  /**
+   * Required Scorers
+   */
+  requiredScorers?: string | Array<string> | null;
+  /**
+   * Scoreable Node Types
+   */
+  scoreableNodeTypes?: string | Array<string> | null;
+  /**
+   * Score Type
+   */
+  scoreType?: string | null;
+};
+
+/**
  * Body_validate_code_scorer_log_record_scorers_code_validate_log_record_post
  */
 export type BodyValidateCodeScorerLogRecordScorersCodeValidateLogRecordPost = {
@@ -2027,6 +2082,8 @@ export type BucketedMetric = {
    * Average
    */
   average?: number | null;
+  rollUpMethod?: RollUpMethodDisplayOptions | null;
+  dataType?: OutputTypeEnum | null;
 };
 
 /**
@@ -2306,6 +2363,42 @@ export type ChunkAttributionUtilizationTemplate = {
 };
 
 /**
+ * CodeMetricGenerationStatus
+ */
+export const CodeMetricGenerationStatus = {
+  GENERATING: 'generating',
+  COMPLETED: 'completed',
+  FAILED: 'failed'
+} as const;
+
+/**
+ * CodeMetricGenerationStatus
+ */
+export type CodeMetricGenerationStatus =
+  (typeof CodeMetricGenerationStatus)[keyof typeof CodeMetricGenerationStatus];
+
+/**
+ * CodeMetricGenerationStatusResponse
+ *
+ * Lightweight polling response.
+ */
+export type CodeMetricGenerationStatusResponse = {
+  /**
+   * Id
+   */
+  id: string;
+  status: CodeMetricGenerationStatus;
+  /**
+   * Generated Code
+   */
+  generatedCode?: string | null;
+  /**
+   * Error Message
+   */
+  errorMessage?: string | null;
+};
+
+/**
  * CollaboratorRole
  */
 export const CollaboratorRole = {
@@ -2457,6 +2550,15 @@ export type ColumnInfo = {
    * Default roll-up aggregation method for this metric (e.g., 'sum', 'average').
    */
   rollUpMethod?: string | null;
+  /**
+   * Metric Key Alias
+   *
+   * Alternate metric key for this column. When scorer UUIDs are used as column IDs
+   * (e.g. "metrics/{uuid}"), this holds the legacy snake_case metric name
+   * (e.g. "correctness") for display and dual-key query fallback.
+   * Patched manually — will be in generated types once SC-64064 merges to production.
+   */
+  metricKeyAlias?: string | null;
 };
 
 /**
@@ -2479,6 +2581,31 @@ export type ColumnMapping = {
    * Metadata
    */
   metadata: ColumnMappingConfig | Array<string> | null;
+  /**
+   * Mgt
+   */
+  mgt?: {
+    [key: string]: ColumnMappingConfig;
+  } | null;
+  [key: string]:
+    | unknown
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | {
+        [key: string]: ColumnMappingConfig;
+      }
+    | null
+    | undefined;
 };
 
 /**
@@ -2673,6 +2800,250 @@ export type ContextRelevanceScorer = {
 };
 
 /**
+ * ControlAction
+ */
+export const ControlAction = {
+  DENY: 'deny',
+  STEER: 'steer',
+  OBSERVE: 'observe'
+} as const;
+
+/**
+ * ControlAction
+ */
+export type ControlAction = (typeof ControlAction)[keyof typeof ControlAction];
+
+/**
+ * ControlAppliesTo
+ */
+export const ControlAppliesTo = {
+  LLM_CALL: 'llm_call',
+  TOOL_CALL: 'tool_call'
+} as const;
+
+/**
+ * ControlAppliesTo
+ */
+export type ControlAppliesTo =
+  (typeof ControlAppliesTo)[keyof typeof ControlAppliesTo];
+
+/**
+ * ControlCheckStage
+ */
+export const ControlCheckStage = { PRE: 'pre', POST: 'post' } as const;
+
+/**
+ * ControlCheckStage
+ */
+export type ControlCheckStage =
+  (typeof ControlCheckStage)[keyof typeof ControlCheckStage];
+
+/**
+ * ControlResult
+ */
+export type ControlResult = {
+  /**
+   * Decision/action produced by the control.
+   */
+  action: ControlAction;
+  /**
+   * Matched
+   *
+   * Whether the control matched. False covers both non-match and error cases; use error_message to distinguish errors.
+   */
+  matched: boolean;
+  /**
+   * Confidence
+   *
+   * Confidence score reported by the control evaluation result.
+   */
+  confidence?: number | null;
+  /**
+   * Error Message
+   *
+   * Error text when control evaluation failed. This should be null for normal matches and non-matches.
+   */
+  errorMessage?: string | null;
+};
+
+/**
+ * ControlSpan
+ */
+export type ControlSpan = {
+  /**
+   * Type
+   *
+   * Type of the trace, span or session.
+   */
+  type?: 'control';
+  /**
+   * Input
+   *
+   * Input to the trace or span.
+   */
+  input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >;
+  /**
+   * Redacted Input
+   *
+   * Redacted input of the trace or span.
+   */
+  redactedInput?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >
+    | null;
+  /**
+   * Output of the trace or span.
+   */
+  output?: ControlResult | null;
+  /**
+   * Redacted output of the trace or span.
+   */
+  redactedOutput?: ControlResult | null;
+  /**
+   * Name
+   *
+   * Name of the trace, span or session.
+   */
+  name?: string;
+  /**
+   * Created
+   *
+   * Timestamp of the trace or span's creation.
+   */
+  createdAt?: string;
+  /**
+   * User Metadata
+   *
+   * Metadata associated with this trace or span.
+   */
+  userMetadata?: {
+    [key: string]: string;
+  };
+  /**
+   * Tags
+   *
+   * Tags associated with this trace or span.
+   */
+  tags?: Array<string>;
+  /**
+   * Status Code
+   *
+   * Status code of the trace or span. Used for logging failure or error states.
+   */
+  statusCode?: number | null;
+  /**
+   * Metrics associated with this trace or span.
+   */
+  metrics?: Metrics;
+  /**
+   * External Id
+   *
+   * A user-provided session, trace or span ID.
+   */
+  externalId?: string | null;
+  /**
+   * Dataset Input
+   *
+   * Input to the dataset associated with this trace
+   */
+  datasetInput?: string | null;
+  /**
+   * Dataset Output
+   *
+   * Output from the dataset associated with this trace
+   */
+  datasetOutput?: string | null;
+  /**
+   * Dataset Metadata
+   *
+   * Metadata from the dataset associated with this trace
+   */
+  datasetMetadata?: {
+    [key: string]: string;
+  };
+  /**
+   * ID
+   *
+   * Galileo ID of the session, trace or span
+   */
+  id?: string | null;
+  /**
+   * Session ID
+   *
+   * Galileo ID of the session containing the trace or span or session
+   */
+  sessionId?: string | null;
+  /**
+   * Trace ID
+   *
+   * Galileo ID of the trace containing the span (or the same value as id for a trace)
+   */
+  traceId?: string | null;
+  /**
+   * Step Number
+   *
+   * Topological step number of the span.
+   */
+  stepNumber?: number | null;
+  /**
+   * Parent ID
+   *
+   * Galileo ID of the parent of this span
+   */
+  parentId?: string | null;
+  /**
+   * Control Id
+   *
+   * Identifier of the control definition that produced this span.
+   */
+  controlId?: number | null;
+  /**
+   * Agent Name
+   *
+   * Normalized agent name associated with this control execution.
+   */
+  agentName?: string | null;
+  /**
+   * Execution stage where the control ran, typically 'pre' or 'post'.
+   */
+  checkStage?: ControlCheckStage | null;
+  /**
+   * Parent execution type the control applied to, for example 'llm_call' or 'tool_call'.
+   */
+  appliesTo?: ControlAppliesTo | null;
+  /**
+   * Evaluator Name
+   *
+   * Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+   */
+  evaluatorName?: string | null;
+  /**
+   * Selector Path
+   *
+   * Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+   */
+  selectorPath?: string | null;
+};
+
+/**
  * CorrectnessScorer
  */
 export type CorrectnessScorer = {
@@ -2712,6 +3083,45 @@ export type CorrectnessScorer = {
    * Number of judges for the scorer.
    */
   numJudges?: number | null;
+};
+
+/**
+ * CreateCodeMetricGenerationRequest
+ *
+ * Request to generate scorer code from a user message.
+ */
+export type CreateCodeMetricGenerationRequest = {
+  /**
+   * User Message
+   *
+   * Natural language, code, or combination
+   */
+  userMessage: string;
+  /**
+   * Node Type
+   *
+   * Selected scoreable node type (llm, retriever, trace, agent, workflow, tool, session)
+   */
+  nodeType?: string | null;
+  /**
+   * Model Name
+   *
+   * Model alias to use for generation. Defaults to best available.
+   */
+  modelName?: string | null;
+};
+
+/**
+ * CreateCodeMetricGenerationResponse
+ *
+ * Response with generation ID for polling.
+ */
+export type CreateCodeMetricGenerationResponse = {
+  /**
+   * Id
+   */
+  id: string;
+  status: CodeMetricGenerationStatus;
 };
 
 /**
@@ -2999,6 +3409,12 @@ export type CreateJobRequest = {
    */
   isSession?: boolean | null;
   /**
+   * Validation Config
+   */
+  validationConfig?: {
+    [key: string]: unknown;
+  } | null;
+  /**
    * Upload Data In Separate Task
    */
   uploadDataInSeparateTask?: boolean;
@@ -3277,6 +3693,12 @@ export type CreateJobResponse = {
    */
   isSession?: boolean | null;
   /**
+   * Validation Config
+   */
+  validationConfig?: {
+    [key: string]: unknown;
+  } | null;
+  /**
    * Upload Data In Separate Task
    */
   uploadDataInSeparateTask?: boolean;
@@ -3442,7 +3864,11 @@ export type CreateScorerRequest = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
-  rollUpMethod?: NumericRollUpMethod | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
+  rollUpMethod?: RollUpMethodDisplayOptions | null;
   /**
    * Metric Color Picker Config
    */
@@ -3902,6 +4328,10 @@ export type CustomizedAgenticSessionSuccessGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4058,6 +4488,10 @@ export type CustomizedAgenticWorkflowSuccessGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4214,6 +4648,10 @@ export type CustomizedChunkAttributionUtilizationGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4370,6 +4808,10 @@ export type CustomizedCompletenessGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4526,6 +4968,10 @@ export type CustomizedFactualityGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4686,6 +5132,10 @@ export type CustomizedGroundTruthAdherenceGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4842,6 +5292,10 @@ export type CustomizedGroundednessGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4998,6 +5452,10 @@ export type CustomizedInputSexistGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5154,6 +5612,10 @@ export type CustomizedInputToxicityGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5310,6 +5772,10 @@ export type CustomizedInstructionAdherenceGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5470,6 +5936,10 @@ export type CustomizedPromptInjectionGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5626,6 +6096,10 @@ export type CustomizedSexistGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5782,6 +6256,10 @@ export type CustomizedToolErrorRateGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5938,6 +6416,10 @@ export type CustomizedToolSelectionQualityGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -6094,6 +6576,10 @@ export type CustomizedToxicityGptScorer = {
    * Required Scorers
    */
   requiredScorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
   rollUpStrategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -6150,7 +6636,9 @@ export const DataType = {
   STAR_RATING_AGGREGATE: 'star_rating_aggregate',
   THUMB_RATING_AGGREGATE: 'thumb_rating_aggregate',
   TAGS_RATING_AGGREGATE: 'tags_rating_aggregate',
-  TEXT_RATING_AGGREGATE: 'text_rating_aggregate'
+  TEXT_RATING_AGGREGATE: 'text_rating_aggregate',
+  ANNOTATION_AGREEMENT: 'annotation_agreement',
+  FULLY_ANNOTATED: 'fully_annotated'
 } as const;
 
 /**
@@ -6396,7 +6884,11 @@ export type DatasetCopyRecordData = {
   /**
    * Project Id
    */
-  projectId: string;
+  projectId?: string | null;
+  /**
+   * Queue Id
+   */
+  queueId?: string | null;
   /**
    * Ids
    *
@@ -6575,6 +7067,20 @@ export type DatasetIdFilter = {
    * Value
    */
   value: string | Array<string | string>;
+};
+
+/**
+ * DatasetInputJsonField
+ */
+export type DatasetInputJsonField = {
+  /**
+   * Key
+   */
+  key: string;
+  /**
+   * Values
+   */
+  values: Array<JsonValue>;
 };
 
 /**
@@ -7250,6 +7756,9 @@ export type ExperimentMetricsRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
 };
 
@@ -7404,10 +7913,32 @@ export type ExperimentResponse = {
   dataset?: ExperimentDataset | null;
   /**
    * Aggregate Metrics
+   * @deprecated Use `metricAggregates` instead, which returns full statistical aggregates
+   * (avg, min, max, p50, p90, p95, p99) keyed by scorer UUID for scorer-backed metrics,
+   * or raw string for system metrics (e.g. 'cost', 'duration_ns').
    */
   aggregateMetrics?: {
     [key: string]: unknown;
   };
+  /**
+   * Structured Aggregate Metrics
+   *
+   * Structured aggregate metrics keyed by raw metric name with full statistical aggregates. Present only when use_clickhouse_run_aggregates flag is enabled.
+   */
+  structuredAggregateMetrics?: {
+    [key: string]: MetricAggregates;
+  } | null;
+  /**
+   * Metric Aggregates
+   *
+   * Structured aggregate metrics keyed by scorer UUID for scorer-backed metrics, or raw
+   * string for system metrics (e.g. 'cost', 'duration_ns'). Alias for
+   * `structuredAggregateMetrics` — use this field instead of the deprecated `aggregateMetrics`.
+   * Populated by the SDK from `structuredAggregateMetrics`.
+   */
+  metricAggregates?: {
+    [key: string]: MetricAggregates;
+  } | null;
   /**
    * Aggregate Feedback
    *
@@ -7639,6 +8170,7 @@ export type ExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -7657,6 +8189,7 @@ export type ExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -7813,11 +8346,31 @@ export type ExtendedAgentSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -7905,6 +8458,9 @@ export type ExtendedAgentSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -7962,6 +8518,7 @@ export type ExtendedAgentSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -7980,6 +8537,7 @@ export type ExtendedAgentSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -8136,11 +8694,31 @@ export type ExtendedAgentSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -8203,6 +8781,329 @@ export type ExtendedAgentSpanRecordWithChildren = {
    * Agent type.
    */
   agentType?: AgentType;
+};
+
+/**
+ * ExtendedControlSpanRecord
+ */
+export type ExtendedControlSpanRecord = {
+  /**
+   * Type
+   *
+   * Type of the trace, span or session.
+   */
+  type?: 'control';
+  /**
+   * Input
+   *
+   * Input to the trace or span.
+   */
+  input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >;
+  /**
+   * Redacted Input
+   *
+   * Redacted input of the trace or span.
+   */
+  redactedInput?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >
+    | null;
+  /**
+   * Output of the trace or span.
+   */
+  output?: ControlResult | null;
+  /**
+   * Redacted output of the trace or span.
+   */
+  redactedOutput?: ControlResult | null;
+  /**
+   * Name
+   *
+   * Name of the trace, span or session.
+   */
+  name?: string;
+  /**
+   * Created
+   *
+   * Timestamp of the trace or span's creation.
+   */
+  createdAt?: string;
+  /**
+   * User Metadata
+   *
+   * Metadata associated with this trace or span.
+   */
+  userMetadata?: {
+    [key: string]: string;
+  };
+  /**
+   * Tags
+   *
+   * Tags associated with this trace or span.
+   */
+  tags?: Array<string>;
+  /**
+   * Status Code
+   *
+   * Status code of the trace or span. Used for logging failure or error states.
+   */
+  statusCode?: number | null;
+  /**
+   * Metrics associated with this trace or span.
+   */
+  metrics?: Metrics;
+  /**
+   * External Id
+   *
+   * A user-provided session, trace or span ID.
+   */
+  externalId?: string | null;
+  /**
+   * Dataset Input
+   *
+   * Input to the dataset associated with this trace
+   */
+  datasetInput?: string | null;
+  /**
+   * Dataset Output
+   *
+   * Output from the dataset associated with this trace
+   */
+  datasetOutput?: string | null;
+  /**
+   * Dataset Metadata
+   *
+   * Metadata from the dataset associated with this trace
+   */
+  datasetMetadata?: {
+    [key: string]: string;
+  };
+  /**
+   * ID
+   *
+   * Galileo ID of the session, trace or span
+   */
+  id: string;
+  /**
+   * Session ID
+   *
+   * Galileo ID of the session containing the trace (or the same value as id for a trace)
+   */
+  sessionId: string;
+  /**
+   * Trace ID
+   *
+   * Galileo ID of the trace containing the span (or the same value as id for a trace)
+   */
+  traceId?: string | null;
+  /**
+   * Project ID
+   *
+   * Galileo ID of the project associated with this trace or span
+   */
+  projectId: string;
+  /**
+   * Run ID
+   *
+   * Galileo ID of the run (log stream or experiment) associated with this trace or span
+   */
+  runId: string;
+  /**
+   * Last Updated
+   *
+   * Timestamp of the session or trace or span's last update
+   */
+  updatedAt?: string | null;
+  /**
+   * Has Children
+   *
+   * Whether or not this trace or span has child spans
+   */
+  hasChildren?: boolean | null;
+  /**
+   * Metrics Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  metricsBatchId?: string | null;
+  /**
+   * Session Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  sessionBatchId?: string | null;
+  /**
+   * Feedback Rating Info
+   *
+   * Feedback information related to the record
+   */
+  feedbackRatingInfo?: {
+    [key: string]: FeedbackRatingInfo;
+  };
+  /**
+   * Annotations
+   *
+   * Annotations keyed by template ID and annotator ID
+   */
+  annotations?: {
+    [key: string]: {
+      [key: string]: AnnotationRatingInfo;
+    };
+  };
+  /**
+   * File Ids
+   *
+   * IDs of files associated with this record
+   */
+  fileIds?: Array<string>;
+  /**
+   * File Modalities
+   *
+   * Modalities of files associated with this record
+   */
+  fileModalities?: Array<ContentModality>;
+  /**
+   * Annotation Aggregates
+   *
+   * Annotation aggregate information keyed by template ID
+   */
+  annotationAggregates?: {
+    [key: string]: AnnotationAggregate;
+  };
+  /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
+   * Annotation Queue Ids
+   *
+   * IDs of annotation queues this record is in
+   */
+  annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
+  /**
+   * Metric Info
+   *
+   * Detailed information about the metrics associated with this trace or span
+   */
+  metricInfo?: {
+    [key: string]:
+      | ({
+          statusType: 'not_computed';
+        } & MetricNotComputed)
+      | ({
+          statusType: 'pending';
+        } & MetricPending)
+      | ({
+          statusType: 'computing';
+        } & MetricComputing)
+      | ({
+          statusType: 'not_applicable';
+        } & MetricNotApplicable)
+      | ({
+          statusType: 'success';
+        } & MetricSuccess)
+      | ({
+          statusType: 'error';
+        } & MetricError)
+      | ({
+          statusType: 'failed';
+        } & MetricFailed)
+      | ({
+          statusType: 'roll_up';
+        } & MetricRollUp);
+  } | null;
+  /**
+   * Files
+   *
+   * File metadata keyed by file ID for files associated with this record
+   */
+  files?: {
+    [key: string]: FileMetadata;
+  } | null;
+  /**
+   * Parent ID
+   *
+   * Galileo ID of the parent of this span
+   */
+  parentId: string;
+  /**
+   * Is Complete
+   *
+   * Whether the parent trace is complete or not
+   */
+  isComplete?: boolean;
+  /**
+   * Step Number
+   *
+   * Topological step number of the span.
+   */
+  stepNumber?: number | null;
+  /**
+   * Control Id
+   *
+   * Identifier of the control definition that produced this span.
+   */
+  controlId?: number | null;
+  /**
+   * Agent Name
+   *
+   * Normalized agent name associated with this control execution.
+   */
+  agentName?: string | null;
+  /**
+   * Execution stage where the control ran, typically 'pre' or 'post'.
+   */
+  checkStage?: ControlCheckStage | null;
+  /**
+   * Parent execution type the control applied to, for example 'llm_call' or 'tool_call'.
+   */
+  appliesTo?: ControlAppliesTo | null;
+  /**
+   * Evaluator Name
+   *
+   * Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+   */
+  evaluatorName?: string | null;
+  /**
+   * Selector Path
+   *
+   * Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+   */
+  selectorPath?: string | null;
 };
 
 /**
@@ -8390,11 +9291,31 @@ export type ExtendedLlmSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -8701,11 +9622,31 @@ export type ExtendedRetrieverSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -8789,6 +9730,9 @@ export type ExtendedRetrieverSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -8975,11 +9919,31 @@ export type ExtendedRetrieverSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9098,6 +10062,7 @@ export type ExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -9116,6 +10081,7 @@ export type ExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -9272,11 +10238,31 @@ export type ExtendedSessionRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9389,6 +10375,7 @@ export type ExtendedSessionRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -9407,6 +10394,7 @@ export type ExtendedSessionRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -9563,11 +10551,31 @@ export type ExtendedSessionRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9807,11 +10815,31 @@ export type ExtendedToolSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9901,6 +10929,9 @@ export type ExtendedToolSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -10087,11 +11118,31 @@ export type ExtendedToolSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -10386,11 +11437,31 @@ export type ExtendedTraceRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -10466,6 +11537,9 @@ export type ExtendedTraceRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -10691,11 +11765,31 @@ export type ExtendedTraceRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -10808,6 +11902,7 @@ export type ExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -10826,6 +11921,7 @@ export type ExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -10982,11 +12078,31 @@ export type ExtendedWorkflowSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -11070,6 +12186,9 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -11127,6 +12246,7 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -11145,6 +12265,7 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -11301,11 +12422,31 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -11617,17 +12758,17 @@ export const FileStatus = {
  */
 export type FileStatus = (typeof FileStatus)[keyof typeof FileStatus];
 
-export type FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
 
-    | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-    | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-    | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-    | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
+    | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+    | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+    | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+    | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
 
 /**
- * FilterLeaf[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * FilterLeaf[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * Filter
@@ -11650,7 +12791,10 @@ export type FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRec
         } & LogRecordsCollectionFilter)
       | ({
           type: 'text';
-        } & LogRecordsTextFilter);
+        } & LogRecordsTextFilter)
+      | ({
+          type: 'fully_annotated';
+        } & LogRecordsFullyAnnotatedFilter);
   };
 
 /**
@@ -11798,6 +12942,12 @@ export type GeneratedScorerConfiguration = {
    * Whether ground truth is enabled for this scorer.
    */
   groundTruth?: boolean;
+  /**
+   * Multimodal Capabilities
+   *
+   * Multimodal capabilities required by this scorer.
+   */
+  multimodalCapabilities?: Array<MultimodalCapability> | null;
 };
 
 /**
@@ -12667,6 +13817,17 @@ export type IntegrationDb = {
    * Is Selected
    */
   isSelected?: boolean;
+  /**
+   * Is Disabled
+   */
+  isDisabled?: boolean;
+};
+
+/**
+ * IntegrationDisableRequest
+ */
+export type IntegrationDisableRequest = {
+  integrationName: IntegrationName;
 };
 
 /**
@@ -12715,7 +13876,6 @@ export const IntegrationName = {
   AZURE: 'azure',
   CUSTOM: 'custom',
   DATABRICKS: 'databricks',
-  LABELSTUDIO: 'labelstudio',
   MISTRAL: 'mistral',
   NVIDIA: 'nvidia',
   OPENAI: 'openai',
@@ -12729,6 +13889,17 @@ export const IntegrationName = {
  */
 export type IntegrationName =
   (typeof IntegrationName)[keyof typeof IntegrationName];
+
+/**
+ * IntegrationSelectRequest
+ */
+export type IntegrationSelectRequest = {
+  integrationName: IntegrationName;
+  /**
+   * Integration Id
+   */
+  integrationId: string;
+};
 
 /**
  * InternalToolCall
@@ -12956,6 +14127,15 @@ export type JobProgress = {
    */
   stepsTotal?: number | null;
 };
+
+export type JsonPrimitive = string | number | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | Array<JsonValue>
+  | {
+      [key: string]: JsonValue;
+    };
 
 /**
  * LLMExportFormat
@@ -13428,6 +14608,12 @@ export type ListScorersRequest = {
     | ({
         name: 'model_type';
       } & ScorerModelTypeFilter)
+    | ({
+        name: 'exclude_slm_scorers';
+      } & ScorerExcludeSlmScorersFilter)
+    | ({
+        name: 'exclude_multimodal_scorers';
+      } & ScorerExcludeMultimodalScorersFilter)
     | ({
         name: 'tags';
       } & ScorerTagsFilter)
@@ -13964,6 +15150,12 @@ export type LogRecordsColumnInfo = {
    * Type of label color for the column, if this is a multilabel metric column.
    */
   labelColor?: 'positive' | 'negative' | null;
+  /**
+   * Metric Key Alias
+   *
+   * Alternate metric key for this column. When store_metric_ids is ON, this holds the legacy metric_name string. Used for dual-key ClickHouse queries.
+   */
+  metricKeyAlias?: string | null;
 };
 
 /**
@@ -13991,7 +15183,7 @@ export type LogRecordsCustomMetricsQueryRequest = {
   /**
    * Filter expression tree for complex filtering
    */
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Start Time
    *
@@ -14092,8 +15284,11 @@ export type LogRecordsDeleteRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
 };
 
 /**
@@ -14114,6 +15309,28 @@ export type LogRecordsDeleteResponse = {
  * Request schema for exporting log records (sessions, traces, spans).
  */
 export type LogRecordsExportRequest = {
+  /**
+   * Column Ids
+   *
+   * Column IDs to include in the export. Applies only to CSV exports.
+   */
+  columnIds?: Array<string> | null;
+  /**
+   * Export format
+   */
+  exportFormat?: LlmExportFormat;
+  /**
+   * Redact
+   *
+   * Redact sensitive data
+   */
+  redact?: boolean;
+  /**
+   * File Name
+   *
+   * Optional filename for the exported file
+   */
+  fileName?: string | null;
   /**
    * Log Stream Id
    *
@@ -14156,34 +15373,15 @@ export type LogRecordsExportRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
   /**
    * Sort clause for the export.  Defaults to native sort (created_at, id descending).
    */
   sort?: LogRecordsSortClause | null;
-  /**
-   * Column Ids
-   *
-   * Column IDs to include in export
-   */
-  columnIds?: Array<string> | null;
-  /**
-   * Export format
-   */
-  exportFormat?: LlmExportFormat;
   rootType: RootType;
-  /**
-   * Redact
-   *
-   * Redact sensitive data
-   */
-  redact?: boolean;
-  /**
-   * File Name
-   *
-   * Optional filename for the exported file
-   */
-  fileName?: string | null;
 };
 
 /**
@@ -14195,7 +15393,8 @@ export const LogRecordsFilterType = {
   NUMBER: 'number',
   BOOLEAN: 'boolean',
   TEXT: 'text',
-  COLLECTION: 'collection'
+  COLLECTION: 'collection',
+  FULLY_ANNOTATED: 'fully_annotated'
 } as const;
 
 /**
@@ -14203,6 +15402,30 @@ export const LogRecordsFilterType = {
  */
 export type LogRecordsFilterType =
   (typeof LogRecordsFilterType)[keyof typeof LogRecordsFilterType];
+
+/**
+ * LogRecordsFullyAnnotatedFilter
+ *
+ * Queue-scoped filter for records rated across all queue templates.
+ */
+export type LogRecordsFullyAnnotatedFilter = {
+  /**
+   * Column Id
+   *
+   * Queue-scoped filter identifier. This filter only works for annotation-queue searches that provide queue context.
+   */
+  columnId?: 'fully_annotated';
+  /**
+   * Type
+   */
+  type?: 'fully_annotated';
+  /**
+   * User Ids
+   *
+   * Optional queue member IDs to require for full annotation in a queue-scoped search. If omitted, all tracked queue members visible to the requester are used.
+   */
+  userIds?: Array<string> | null;
+};
 
 /**
  * LogRecordsIDFilter
@@ -14272,6 +15495,9 @@ export type LogRecordsMetricsQueryRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
   /**
    * Start Time
@@ -14418,8 +15644,11 @@ export type LogRecordsPartialQueryRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -14486,6 +15715,9 @@ export type LogRecordsPartialQueryResponse = {
         type: 'retriever';
       } & PartialExtendedRetrieverSpanRecord)
     | ({
+        type: 'control';
+      } & PartialExtendedControlSpanRecord)
+    | ({
         type: 'session';
       } & PartialExtendedSessionRecord)
   >;
@@ -14535,8 +15767,11 @@ export type LogRecordsQueryCountRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
 };
 
 /**
@@ -14607,8 +15842,11 @@ export type LogRecordsQueryRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -14673,6 +15911,9 @@ export type LogRecordsQueryResponse = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecord)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
     | ({
         type: 'session';
       } & ExtendedSessionRecord)
@@ -14802,6 +16043,7 @@ export type LogSpanUpdateRequest = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Tags
@@ -14933,6 +16175,9 @@ export type LogSpansIngestRequest = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
   /**
    * Trace Id
@@ -15088,6 +16333,22 @@ export type LogStreamIdFilter = {
    * Value
    */
   value: string | Array<string | string>;
+};
+
+/**
+ * LogStreamInfo
+ *
+ * Minimal log stream representation (id and name only).
+ */
+export type LogStreamInfo = {
+  /**
+   * Id
+   */
+  id: string;
+  /**
+   * Name
+   */
+  name: string;
 };
 
 /**
@@ -15567,7 +16828,8 @@ export type LunaInputTypeEnum =
 export const LunaOutputTypeEnum = {
   FLOAT: 'float',
   STRING: 'string',
-  STRING_LIST: 'string_list'
+  STRING_LIST: 'string_list',
+  BOOL_LIST: 'bool_list'
 } as const;
 
 /**
@@ -15833,6 +17095,62 @@ export type MetadataFilter = {
 };
 
 /**
+ * MetricAggregates
+ *
+ * Structured aggregate values for a single metric, computed from ClickHouse row-level data.
+ */
+export type MetricAggregates = {
+  /**
+   * Avg
+   */
+  avg?: number | null;
+  /**
+   * Sum
+   */
+  sum?: number | null;
+  /**
+   * Min
+   */
+  min?: number | null;
+  /**
+   * Max
+   */
+  max?: number | null;
+  /**
+   * Count
+   */
+  count?: number | null;
+  /**
+   * Pct
+   */
+  pct?: number | null;
+  /**
+   * P50
+   */
+  p50?: number | null;
+  /**
+   * P90
+   */
+  p90?: number | null;
+  /**
+   * P95
+   */
+  p95?: number | null;
+  /**
+   * P99
+   */
+  p99?: number | null;
+  /**
+   * Value Distribution
+   *
+   * Distribution of discrete values as {value: count}. For boolean metrics: {'0': 2, '1': 8}. For categorical metrics: {'low': 5, 'medium': 3, 'high': 2}.
+   */
+  valueDistribution?: {
+    [key: string]: number;
+  } | null;
+};
+
+/**
  * MetricAggregation
  */
 export const MetricAggregation = {
@@ -15844,7 +17162,9 @@ export const MetricAggregation = {
   P50: 'P50',
   P90: 'P90',
   P95: 'P95',
-  P99: 'P99'
+  P99: 'P99',
+  PERCENTAGE_FALSE: 'PercentageFalse',
+  PERCENTAGE_TRUE: 'PercentageTrue'
 } as const;
 
 /**
@@ -16059,6 +17379,10 @@ export type MetricComputing = {
   statusType?: 'computing';
   scorerType?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
+  /**
    * Message
    */
   message?: string;
@@ -16152,6 +17476,10 @@ export type MetricError = {
   statusType?: 'error';
   scorerType?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
+  /**
    * Message
    */
   message?: string | null;
@@ -16176,6 +17504,10 @@ export type MetricFailed = {
    */
   statusType?: 'failed';
   scorerType?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
   /**
    * Message
    */
@@ -16202,6 +17534,10 @@ export type MetricNotApplicable = {
   statusType?: 'not_applicable';
   scorerType?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
+  /**
    * Message
    */
   message?: string;
@@ -16227,6 +17563,10 @@ export type MetricNotComputed = {
   statusType?: 'not_computed';
   scorerType?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
+  /**
    * Message
    */
   message?: string;
@@ -16241,6 +17581,10 @@ export type MetricPending = {
    */
   statusType?: 'pending';
   scorerType?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
 };
 
 /**
@@ -16252,6 +17596,10 @@ export type MetricRollUp = {
    */
   statusType?: 'roll_up';
   scorerType?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
   /**
    * Value
    */
@@ -16348,15 +17696,13 @@ export type MetricRollUp = {
    *
    * Roll up metrics e.g. sum, average, min, max for numeric, and category_count for categorical metrics.
    */
-  rollUpMetrics?:
-    | {
-        [key: string]: number;
-      }
-    | {
-        [key: string]: {
+  rollUpMetrics?: {
+    [key: string]:
+      | number
+      | {
           [key: string]: number;
         };
-      };
+  };
 };
 
 /**
@@ -16402,6 +17748,10 @@ export type MetricSuccess = {
    */
   statusType?: 'success';
   scorerType?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metricKeyAlias?: string | null;
   /**
    * Value
    */
@@ -16873,18 +18223,18 @@ export const NodeType = {
 export type NodeType = (typeof NodeType)[keyof typeof NodeType];
 
 /**
- * NotNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * NotNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * Not
      */
     not:
-      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
+      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
   };
 
 /**
@@ -17029,18 +18379,18 @@ export type OpenAiToolChoice = {
 };
 
 /**
- * OrNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * OrNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * Or
      */
     or: Array<
-      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
     >;
   };
 
@@ -17330,6 +18680,7 @@ export type PartialExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -17348,6 +18699,7 @@ export type PartialExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -17504,11 +18856,31 @@ export type PartialExtendedAgentSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -17571,6 +18943,329 @@ export type PartialExtendedAgentSpanRecord = {
    * Agent type.
    */
   agentType?: AgentType;
+};
+
+/**
+ * PartialExtendedControlSpanRecord
+ */
+export type PartialExtendedControlSpanRecord = {
+  /**
+   * Type
+   *
+   * Type of the trace, span or session.
+   */
+  type?: 'control';
+  /**
+   * Input
+   *
+   * Input to the trace or span.
+   */
+  input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >;
+  /**
+   * Redacted Input
+   *
+   * Redacted input of the trace or span.
+   */
+  redactedInput?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >
+    | null;
+  /**
+   * Output of the trace or span.
+   */
+  output?: ControlResult | null;
+  /**
+   * Redacted output of the trace or span.
+   */
+  redactedOutput?: ControlResult | null;
+  /**
+   * Name
+   *
+   * Name of the trace, span or session.
+   */
+  name?: string;
+  /**
+   * Created
+   *
+   * Timestamp of the trace or span's creation.
+   */
+  createdAt?: string;
+  /**
+   * User Metadata
+   *
+   * Metadata associated with this trace or span.
+   */
+  userMetadata?: {
+    [key: string]: string;
+  };
+  /**
+   * Tags
+   *
+   * Tags associated with this trace or span.
+   */
+  tags?: Array<string>;
+  /**
+   * Status Code
+   *
+   * Status code of the trace or span. Used for logging failure or error states.
+   */
+  statusCode?: number | null;
+  /**
+   * Metrics associated with this trace or span.
+   */
+  metrics?: Metrics;
+  /**
+   * External Id
+   *
+   * A user-provided session, trace or span ID.
+   */
+  externalId?: string | null;
+  /**
+   * Dataset Input
+   *
+   * Input to the dataset associated with this trace
+   */
+  datasetInput?: string | null;
+  /**
+   * Dataset Output
+   *
+   * Output from the dataset associated with this trace
+   */
+  datasetOutput?: string | null;
+  /**
+   * Dataset Metadata
+   *
+   * Metadata from the dataset associated with this trace
+   */
+  datasetMetadata?: {
+    [key: string]: string;
+  };
+  /**
+   * ID
+   *
+   * Galileo ID of the session, trace or span
+   */
+  id?: string | null;
+  /**
+   * Session ID
+   *
+   * Galileo ID of the session containing the trace (or the same value as id for a trace)
+   */
+  sessionId?: string | null;
+  /**
+   * Trace ID
+   *
+   * Galileo ID of the trace containing the span (or the same value as id for a trace)
+   */
+  traceId?: string | null;
+  /**
+   * Project ID
+   *
+   * Galileo ID of the project associated with this trace or span
+   */
+  projectId?: string | null;
+  /**
+   * Run ID
+   *
+   * Galileo ID of the run (log stream or experiment) associated with this trace or span
+   */
+  runId?: string | null;
+  /**
+   * Last Updated
+   *
+   * Timestamp of the session or trace or span's last update
+   */
+  updatedAt?: string | null;
+  /**
+   * Has Children
+   *
+   * Whether or not this trace or span has child spans
+   */
+  hasChildren?: boolean | null;
+  /**
+   * Metrics Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  metricsBatchId?: string | null;
+  /**
+   * Session Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  sessionBatchId?: string | null;
+  /**
+   * Feedback Rating Info
+   *
+   * Feedback information related to the record
+   */
+  feedbackRatingInfo?: {
+    [key: string]: FeedbackRatingInfo;
+  };
+  /**
+   * Annotations
+   *
+   * Annotations keyed by template ID and annotator ID
+   */
+  annotations?: {
+    [key: string]: {
+      [key: string]: AnnotationRatingInfo;
+    };
+  };
+  /**
+   * File Ids
+   *
+   * IDs of files associated with this record
+   */
+  fileIds?: Array<string>;
+  /**
+   * File Modalities
+   *
+   * Modalities of files associated with this record
+   */
+  fileModalities?: Array<ContentModality>;
+  /**
+   * Annotation Aggregates
+   *
+   * Annotation aggregate information keyed by template ID
+   */
+  annotationAggregates?: {
+    [key: string]: AnnotationAggregate;
+  };
+  /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
+   * Annotation Queue Ids
+   *
+   * IDs of annotation queues this record is in
+   */
+  annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
+  /**
+   * Metric Info
+   *
+   * Detailed information about the metrics associated with this trace or span
+   */
+  metricInfo?: {
+    [key: string]:
+      | ({
+          statusType: 'not_computed';
+        } & MetricNotComputed)
+      | ({
+          statusType: 'pending';
+        } & MetricPending)
+      | ({
+          statusType: 'computing';
+        } & MetricComputing)
+      | ({
+          statusType: 'not_applicable';
+        } & MetricNotApplicable)
+      | ({
+          statusType: 'success';
+        } & MetricSuccess)
+      | ({
+          statusType: 'error';
+        } & MetricError)
+      | ({
+          statusType: 'failed';
+        } & MetricFailed)
+      | ({
+          statusType: 'roll_up';
+        } & MetricRollUp);
+  } | null;
+  /**
+   * Files
+   *
+   * File metadata keyed by file ID for files associated with this record
+   */
+  files?: {
+    [key: string]: FileMetadata;
+  } | null;
+  /**
+   * Parent ID
+   *
+   * Galileo ID of the parent of this span
+   */
+  parentId?: string | null;
+  /**
+   * Is Complete
+   *
+   * Whether the parent trace is complete or not
+   */
+  isComplete?: boolean;
+  /**
+   * Step Number
+   *
+   * Topological step number of the span.
+   */
+  stepNumber?: number | null;
+  /**
+   * Control Id
+   *
+   * Identifier of the control definition that produced this span.
+   */
+  controlId?: number | null;
+  /**
+   * Agent Name
+   *
+   * Normalized agent name associated with this control execution.
+   */
+  agentName?: string | null;
+  /**
+   * Execution stage where the control ran, typically 'pre' or 'post'.
+   */
+  checkStage?: ControlCheckStage | null;
+  /**
+   * Parent execution type the control applied to, for example 'llm_call' or 'tool_call'.
+   */
+  appliesTo?: ControlAppliesTo | null;
+  /**
+   * Evaluator Name
+   *
+   * Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+   */
+  evaluatorName?: string | null;
+  /**
+   * Selector Path
+   *
+   * Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+   */
+  selectorPath?: string | null;
 };
 
 /**
@@ -17758,11 +19453,31 @@ export type PartialExtendedLlmSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18069,11 +19784,31 @@ export type PartialExtendedRetrieverSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18192,6 +19927,7 @@ export type PartialExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -18210,6 +19946,7 @@ export type PartialExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -18366,11 +20103,31 @@ export type PartialExtendedSessionRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18606,11 +20363,31 @@ export type PartialExtendedToolSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18905,11 +20682,31 @@ export type PartialExtendedTraceRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -19018,6 +20815,7 @@ export type PartialExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -19036,6 +20834,7 @@ export type PartialExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -19192,11 +20991,31 @@ export type PartialExtendedWorkflowSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotationAgreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overallAnnotationAgreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotationQueueIds?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fullyAnnotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -19720,6 +21539,12 @@ export type ProjectItem = {
    * List of labels associated with the project.
    */
   labels?: Array<ProjectLabels>;
+  /**
+   * Log Streams
+   *
+   * Log streams for this project. Only populated when include_logstreams=True.
+   */
+  logStreams?: Array<LogStreamInfo> | null;
 };
 
 /**
@@ -20648,8 +22473,11 @@ export type RecomputeLogRecordsMetricsRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -20994,8 +22822,42 @@ export type RetrieverSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
 };
+
+/**
+ * RollUpMethodDisplayOptions
+ *
+ * Display options for roll up methods when showing rolled up metrics in the UI.
+ *
+ * Separates display intent from computation methods. The computation methods
+ * (NumericRollUpMethod, CategoricalRollUpMethod) control what aggregations are available.
+ * This enum controls how the UI displays the selected roll-up value for a scorer.
+ */
+export const RollUpMethodDisplayOptions = {
+  AVERAGE: 'average',
+  SUM: 'sum',
+  MAX: 'max',
+  MIN: 'min',
+  CATEGORY_COUNT: 'category_count',
+  PERCENTAGE_TRUE: 'percentage_true',
+  PERCENTAGE_FALSE: 'percentage_false'
+} as const;
+
+/**
+ * RollUpMethodDisplayOptions
+ *
+ * Display options for roll up methods when showing rolled up metrics in the UI.
+ *
+ * Separates display intent from computation methods. The computation methods
+ * (NumericRollUpMethod, CategoricalRollUpMethod) control what aggregations are available.
+ * This enum controls how the UI displays the selected roll-up value for a scorer.
+ */
+export type RollUpMethodDisplayOptions =
+  (typeof RollUpMethodDisplayOptions)[keyof typeof RollUpMethodDisplayOptions];
 
 /**
  * RollUpStrategy
@@ -21678,10 +23540,7 @@ export type ScorerConfig = {
    * Multimodal capabilities which this scorer can utilize in its evaluation.
    */
   multimodalCapabilities?: Array<MultimodalCapability> | null;
-  /**
-   * Roll Up Method
-   */
-  rollUpMethod?: string | null;
+  rollUpMethod?: RollUpMethodDisplayOptions | null;
   /**
    * Score Type
    *
@@ -21821,6 +23680,33 @@ export type ScorerEnabledInRunSort = {
 };
 
 /**
+ * ScorerExcludeMultimodalScorersFilter
+ *
+ * Internal filter: excludes multimodal scorers (non-empty multimodal_capabilities).
+ *
+ * Auto-appended by the service layer when the `multimodal` feature flag is disabled.
+ */
+export type ScorerExcludeMultimodalScorersFilter = {
+  /**
+   * Name
+   */
+  name?: 'exclude_multimodal_scorers';
+};
+
+/**
+ * ScorerExcludeSlmScorersFilter
+ *
+ * Internal filter: excludes scorers with model_type == slm while including
+ * scorers where model_type IS NULL. Auto-appended by the service layer.
+ */
+export type ScorerExcludeSlmScorersFilter = {
+  /**
+   * Name
+   */
+  name?: 'exclude_slm_scorers';
+};
+
+/**
  * ScorerIDFilter
  */
 export type ScorerIdFilter = {
@@ -21872,6 +23758,14 @@ export type ScorerModelTypeFilter = {
    * Name
    */
   name?: 'model_type';
+  /**
+   * Operator
+   */
+  operator: 'eq' | 'ne' | 'one_of' | 'not_in';
+  /**
+   * Value
+   */
+  value: string | Array<string>;
 };
 
 /**
@@ -21958,9 +23852,14 @@ export type ScorerResponse = {
    */
   requiredScorers?: Array<string> | null;
   /**
+   * Required Metric Ids
+   */
+  requiredMetricIds?: Array<string> | null;
+  /**
    * Deprecated
    */
   deprecated?: boolean | null;
+  rollUpMethod?: RollUpMethodDisplayOptions | null;
   rollUpConfig?: BaseMetricRollUpConfigDb | null;
   /**
    * Label
@@ -21992,7 +23891,6 @@ export type ScorerResponse = {
    * Updated At
    */
   updatedAt?: string | null;
-  rollUpMethod?: NumericRollUpMethod | null;
   /**
    * Metric Color Picker Config
    */
@@ -22010,6 +23908,10 @@ export type ScorerResponse = {
         type: 'multi_label';
       } & MetricColorPickerMultiLabel)
     | null;
+  /**
+   * Metric Name
+   */
+  metricName?: string | null;
 };
 
 /**
@@ -22202,6 +24104,10 @@ export type ScorersConfiguration = {
    * Context Relevance Luna
    */
   contextRelevanceLuna?: boolean;
+  /**
+   * Chunk Relevance Luna
+   */
+  chunkRelevanceLuna?: boolean;
   /**
    * Completeness Nli
    */
@@ -22728,6 +24634,7 @@ export const StepType = {
   TOOL: 'tool',
   WORKFLOW: 'workflow',
   AGENT: 'agent',
+  CONTROL: 'control',
   TRACE: 'trace',
   SESSION: 'session'
 } as const;
@@ -23453,6 +25360,9 @@ export type ToolSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
   /**
    * Tool Call Id
@@ -23691,6 +25601,9 @@ export type Trace = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
 };
 
@@ -23862,11 +25775,7 @@ export type UpdateScorerRequest = {
    * Multimodal Capabilities
    */
   multimodalCapabilities?: Array<MultimodalCapability> | null;
-  /**
-   * Required Scorers
-   */
-  requiredScorers?: Array<string> | null;
-  rollUpMethod?: NumericRollUpMethod | null;
+  rollUpMethod?: RollUpMethodDisplayOptions | null;
   /**
    * Metric Color Picker Config
    */
@@ -23910,7 +25819,11 @@ export type UpsertDatasetContentRequest = {
 export const UserAction = {
   UPDATE: 'update',
   DELETE: 'delete',
-  READ_API_KEYS: 'read_api_keys'
+  READ_API_KEYS: 'read_api_keys',
+  CHANGE_ROLE_TO_ADMIN: 'change_role_to_admin',
+  CHANGE_ROLE_TO_MANAGER: 'change_role_to_manager',
+  CHANGE_ROLE_TO_USER: 'change_role_to_user',
+  CHANGE_ROLE_TO_READ_ONLY: 'change_role_to_read_only'
 } as const;
 
 /**
@@ -24088,6 +26001,20 @@ export type ValidResult = {
 };
 
 /**
+ * ValidateCodeScorerDatasetResponse
+ */
+export type ValidateCodeScorerDatasetResponse = {
+  /**
+   * Metrics Experiment Id
+   */
+  metricsExperimentId: string;
+  /**
+   * Project Id
+   */
+  projectId: string;
+};
+
+/**
  * ValidateCodeScorerResponse
  */
 export type ValidateCodeScorerResponse = {
@@ -24095,6 +26022,70 @@ export type ValidateCodeScorerResponse = {
    * Task Id
    */
   taskId: string;
+};
+
+/**
+ * ValidateLLMScorerDatasetRequest
+ *
+ * Request to validate a new LLM scorer against a dataset.
+ */
+export type ValidateLlmScorerDatasetRequest = {
+  /**
+   * Query
+   */
+  query: string;
+  /**
+   * Response
+   */
+  response: string;
+  chainPollTemplate: ChainPollTemplate;
+  scorerConfiguration: GeneratedScorerConfiguration;
+  /**
+   * User Prompt
+   */
+  userPrompt: string;
+  /**
+   * Dataset Id
+   */
+  datasetId: string;
+  /**
+   * Dataset Version Index
+   */
+  datasetVersionIndex?: number | null;
+  /**
+   * Limit
+   *
+   * Maximum number of dataset rows to process.
+   */
+  limit?: number;
+  /**
+   * Starting Token
+   *
+   * Pagination offset into dataset rows.
+   */
+  startingToken?: number | null;
+  /**
+   * Sort
+   *
+   * Optional sort configuration for dataset rows.
+   */
+  sort?: {
+    [key: string]: unknown;
+  } | null;
+};
+
+/**
+ * ValidateLLMScorerDatasetResponse
+ */
+export type ValidateLlmScorerDatasetResponse = {
+  /**
+   * Metrics Experiment Id
+   */
+  metricsExperimentId: string;
+  /**
+   * Project Id
+   */
+  projectId: string;
 };
 
 /**
@@ -24156,8 +26147,11 @@ export type ValidateLlmScorerLogRecordRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filterTree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -24196,6 +26190,10 @@ export type ValidateLlmScorerLogRecordResponse = {
    * Metrics Experiment Id
    */
   metricsExperimentId: string;
+  /**
+   * Project Id
+   */
+  projectId: string;
 };
 
 /**
@@ -24214,12 +26212,17 @@ export type ValidateRegisteredScorerResult = {
  * Response model for validating a scorer based on log records.
  *
  * Returns the uuid of the experiment created with the copied log records to store the metric testing results.
+ * Also returns the project_id so callers can poll /projects/{project_id}/traces/search.
  */
 export type ValidateScorerLogRecordResponse = {
   /**
    * Metrics Experiment Id
    */
   metricsExperimentId: string;
+  /**
+   * Project Id
+   */
+  projectId: string;
 };
 
 /**
@@ -24484,6 +26487,7 @@ export type WorkflowSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -24502,6 +26506,7 @@ export type WorkflowSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -24616,6 +26621,9 @@ export type WorkflowSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
 };
 
@@ -24890,6 +26898,7 @@ export const GalileoCoreSchemasSharedScorersScorerNameScorerName = {
   CHUNK_ATTRIBUTION_UTILIZATION_LUNA: 'chunk_attribution_utilization_luna',
   CHUNK_ATTRIBUTION_UTILIZATION: 'chunk_attribution_utilization',
   CHUNK_RELEVANCE: 'chunk_relevance',
+  CHUNK_RELEVANCE_LUNA: 'chunk_relevance_luna',
   CONTEXT_PRECISION: 'context_precision',
   PRECISION_AT_K: 'precision_at_k',
   COMPLETENESS_LUNA: 'completeness_luna',
@@ -24901,6 +26910,8 @@ export const GalileoCoreSchemasSharedScorersScorerNameScorerName = {
   CONVERSATION_QUALITY: 'conversation_quality',
   CORRECTNESS: 'correctness',
   GROUND_TRUTH_ADHERENCE: 'ground_truth_adherence',
+  VISUAL_FIDELITY: 'visual_fidelity',
+  VISUAL_QUALITY: 'visual_quality',
   INPUT_PII: 'input_pii',
   INPUT_PII_GPT: 'input_pii_gpt',
   INPUT_SEXIST: 'input_sexist',
@@ -24932,7 +26943,8 @@ export const GalileoCoreSchemasSharedScorersScorerNameScorerName = {
   TOOL_SELECTION_QUALITY: 'tool_selection_quality',
   TOOL_SELECTION_QUALITY_LUNA: 'tool_selection_quality_luna',
   UNCERTAINTY: 'uncertainty',
-  USER_INTENT_CHANGE: 'user_intent_change'
+  USER_INTENT_CHANGE: 'user_intent_change',
+  INTERRUPTION_DETECTION: 'interruption_detection'
 } as const;
 
 /**
@@ -24990,6 +27002,7 @@ export const PromptgalileoSchemasScorerNameScorerName = {
   _CONTEXT_ADHERENCE_LUNA: '_context_adherence_luna',
   _CONTEXT_RELEVANCE: '_context_relevance',
   _CONTEXT_RELEVANCE_LUNA: '_context_relevance_luna',
+  _CHUNK_RELEVANCE_LUNA: '_chunk_relevance_luna',
   _CHUNK_ATTRIBUTION_UTILIZATION_GPT: '_chunk_attribution_utilization_gpt',
   _FACTUALITY: '_factuality',
   _GROUNDEDNESS: '_groundedness',
@@ -27319,642 +29332,6 @@ export type UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSett
 export type UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSettingsPatchResponse =
   UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSettingsPatchResponses[keyof UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSettingsPatchResponses];
 
-export type LogTracesProjectsProjectIdTracesPostData = {
-  body: LogTracesIngestRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces';
-};
-
-export type LogTracesProjectsProjectIdTracesPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type LogTracesProjectsProjectIdTracesPostError =
-  LogTracesProjectsProjectIdTracesPostErrors[keyof LogTracesProjectsProjectIdTracesPostErrors];
-
-export type LogTracesProjectsProjectIdTracesPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogTracesIngestResponse;
-};
-
-export type LogTracesProjectsProjectIdTracesPostResponse =
-  LogTracesProjectsProjectIdTracesPostResponses[keyof LogTracesProjectsProjectIdTracesPostResponses];
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetData = {
-  body?: never;
-  path: {
-    /**
-     * Trace Id
-     */
-    traceId: string;
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: {
-    /**
-     * Include Presigned Urls
-     */
-    includePresignedUrls?: boolean;
-  };
-  url: '/projects/{project_id}/traces/{trace_id}';
-};
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetError =
-  GetTraceProjectsProjectIdTracesTraceIdGetErrors[keyof GetTraceProjectsProjectIdTracesTraceIdGetErrors];
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: ExtendedTraceRecordWithChildren;
-};
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetResponse =
-  GetTraceProjectsProjectIdTracesTraceIdGetResponses[keyof GetTraceProjectsProjectIdTracesTraceIdGetResponses];
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchData = {
-  body: LogTraceUpdateRequest;
-  path: {
-    /**
-     * Trace Id
-     */
-    traceId: string;
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/{trace_id}';
-};
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchError =
-  UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors];
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogTraceUpdateResponse;
-};
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponse =
-  UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses];
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetData = {
-  body?: never;
-  path: {
-    /**
-     * Span Id
-     */
-    spanId: string;
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: {
-    /**
-     * Include Presigned Urls
-     */
-    includePresignedUrls?: boolean;
-  };
-  url: '/projects/{project_id}/spans/{span_id}';
-};
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetError =
-  GetSpanProjectsProjectIdSpansSpanIdGetErrors[keyof GetSpanProjectsProjectIdSpansSpanIdGetErrors];
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetResponses = {
-  /**
-   * Response Get Span Projects  Project Id  Spans  Span Id  Get
-   *
-   * Successful Response
-   */
-  200:
-    | ({
-        type: 'agent';
-      } & ExtendedAgentSpanRecordWithChildren)
-    | ({
-        type: 'workflow';
-      } & ExtendedWorkflowSpanRecordWithChildren)
-    | ({
-        type: 'llm';
-      } & ExtendedLlmSpanRecord)
-    | ({
-        type: 'tool';
-      } & ExtendedToolSpanRecordWithChildren)
-    | ({
-        type: 'retriever';
-      } & ExtendedRetrieverSpanRecordWithChildren);
-};
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetResponse =
-  GetSpanProjectsProjectIdSpansSpanIdGetResponses[keyof GetSpanProjectsProjectIdSpansSpanIdGetResponses];
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchData = {
-  body: LogSpanUpdateRequest;
-  path: {
-    /**
-     * Span Id
-     */
-    spanId: string;
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/{span_id}';
-};
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchError =
-  UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors];
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogSpanUpdateResponse;
-};
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponse =
-  UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses];
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostData =
-  {
-    body: MetricsTestingAvailableColumnsRequest;
-    path: {
-      /**
-       * Project Id
-       */
-      projectId: string;
-    };
-    query?: never;
-    url: '/projects/{project_id}/metrics-testing/available_columns';
-  };
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostError =
-  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors];
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsAvailableColumnsResponse;
-  };
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponse =
-  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses];
-
-export type QueryTracesProjectsProjectIdTracesSearchPostData = {
-  body: LogRecordsQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/search';
-};
-
-export type QueryTracesProjectsProjectIdTracesSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QueryTracesProjectsProjectIdTracesSearchPostError =
-  QueryTracesProjectsProjectIdTracesSearchPostErrors[keyof QueryTracesProjectsProjectIdTracesSearchPostErrors];
-
-export type QueryTracesProjectsProjectIdTracesSearchPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryResponse;
-};
-
-export type QueryTracesProjectsProjectIdTracesSearchPostResponse =
-  QueryTracesProjectsProjectIdTracesSearchPostResponses[keyof QueryTracesProjectsProjectIdTracesSearchPostResponses];
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostData = {
-  body: LogRecordsPartialQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/partial_search';
-};
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostError =
-  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors];
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsPartialQueryResponse;
-  };
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponse =
-  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses];
-
-export type CountTracesProjectsProjectIdTracesCountPostData = {
-  body: LogRecordsQueryCountRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/count';
-};
-
-export type CountTracesProjectsProjectIdTracesCountPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CountTracesProjectsProjectIdTracesCountPostError =
-  CountTracesProjectsProjectIdTracesCountPostErrors[keyof CountTracesProjectsProjectIdTracesCountPostErrors];
-
-export type CountTracesProjectsProjectIdTracesCountPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryCountResponse;
-};
-
-export type CountTracesProjectsProjectIdTracesCountPostResponse =
-  CountTracesProjectsProjectIdTracesCountPostResponses[keyof CountTracesProjectsProjectIdTracesCountPostResponses];
-
-export type LogSpansProjectsProjectIdSpansPostData = {
-  body: LogSpansIngestRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans';
-};
-
-export type LogSpansProjectsProjectIdSpansPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type LogSpansProjectsProjectIdSpansPostError =
-  LogSpansProjectsProjectIdSpansPostErrors[keyof LogSpansProjectsProjectIdSpansPostErrors];
-
-export type LogSpansProjectsProjectIdSpansPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogSpansIngestResponse;
-};
-
-export type LogSpansProjectsProjectIdSpansPostResponse =
-  LogSpansProjectsProjectIdSpansPostResponses[keyof LogSpansProjectsProjectIdSpansPostResponses];
-
-export type QuerySpansProjectsProjectIdSpansSearchPostData = {
-  body: LogRecordsQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/search';
-};
-
-export type QuerySpansProjectsProjectIdSpansSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QuerySpansProjectsProjectIdSpansSearchPostError =
-  QuerySpansProjectsProjectIdSpansSearchPostErrors[keyof QuerySpansProjectsProjectIdSpansSearchPostErrors];
-
-export type QuerySpansProjectsProjectIdSpansSearchPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryResponse;
-};
-
-export type QuerySpansProjectsProjectIdSpansSearchPostResponse =
-  QuerySpansProjectsProjectIdSpansSearchPostResponses[keyof QuerySpansProjectsProjectIdSpansSearchPostResponses];
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostData = {
-  body: LogRecordsPartialQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/partial_search';
-};
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostError =
-  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors];
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsPartialQueryResponse;
-  };
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponse =
-  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses];
-
-export type CountSpansProjectsProjectIdSpansCountPostData = {
-  body: LogRecordsQueryCountRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/count';
-};
-
-export type CountSpansProjectsProjectIdSpansCountPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CountSpansProjectsProjectIdSpansCountPostError =
-  CountSpansProjectsProjectIdSpansCountPostErrors[keyof CountSpansProjectsProjectIdSpansCountPostErrors];
-
-export type CountSpansProjectsProjectIdSpansCountPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryCountResponse;
-};
-
-export type CountSpansProjectsProjectIdSpansCountPostResponse =
-  CountSpansProjectsProjectIdSpansCountPostResponses[keyof CountSpansProjectsProjectIdSpansCountPostResponses];
-
-export type CreateSessionProjectsProjectIdSessionsPostData = {
-  body: SessionCreateRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions';
-};
-
-export type CreateSessionProjectsProjectIdSessionsPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CreateSessionProjectsProjectIdSessionsPostError =
-  CreateSessionProjectsProjectIdSessionsPostErrors[keyof CreateSessionProjectsProjectIdSessionsPostErrors];
-
-export type CreateSessionProjectsProjectIdSessionsPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: SessionCreateResponse;
-};
-
-export type CreateSessionProjectsProjectIdSessionsPostResponse =
-  CreateSessionProjectsProjectIdSessionsPostResponses[keyof CreateSessionProjectsProjectIdSessionsPostResponses];
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostData = {
-  body: LogRecordsQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions/search';
-};
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostError =
-  QuerySessionsProjectsProjectIdSessionsSearchPostErrors[keyof QuerySessionsProjectsProjectIdSessionsSearchPostErrors];
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryResponse;
-};
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostResponse =
-  QuerySessionsProjectsProjectIdSessionsSearchPostResponses[keyof QuerySessionsProjectsProjectIdSessionsSearchPostResponses];
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostData =
-  {
-    body: LogRecordsPartialQueryRequest;
-    path: {
-      /**
-       * Project Id
-       */
-      projectId: string;
-    };
-    query?: never;
-    url: '/projects/{project_id}/sessions/partial_search';
-  };
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostError =
-  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors];
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsPartialQueryResponse;
-  };
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponse =
-  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses];
-
-export type CountSessionsProjectsProjectIdSessionsCountPostData = {
-  body: LogRecordsQueryCountRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions/count';
-};
-
-export type CountSessionsProjectsProjectIdSessionsCountPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CountSessionsProjectsProjectIdSessionsCountPostError =
-  CountSessionsProjectsProjectIdSessionsCountPostErrors[keyof CountSessionsProjectsProjectIdSessionsCountPostErrors];
-
-export type CountSessionsProjectsProjectIdSessionsCountPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryCountResponse;
-};
-
-export type CountSessionsProjectsProjectIdSessionsCountPostResponse =
-  CountSessionsProjectsProjectIdSessionsCountPostResponses[keyof CountSessionsProjectsProjectIdSessionsCountPostResponses];
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetData = {
-  body?: never;
-  path: {
-    /**
-     * Session Id
-     */
-    sessionId: string;
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: {
-    /**
-     * Include Presigned Urls
-     */
-    includePresignedUrls?: boolean;
-  };
-  url: '/projects/{project_id}/sessions/{session_id}';
-};
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetError =
-  GetSessionProjectsProjectIdSessionsSessionIdGetErrors[keyof GetSessionProjectsProjectIdSessionsSessionIdGetErrors];
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: ExtendedSessionRecordWithChildren;
-};
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetResponse =
-  GetSessionProjectsProjectIdSessionsSessionIdGetResponses[keyof GetSessionProjectsProjectIdSessionsSessionIdGetResponses];
-
 export type GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostData = {
   body: AggregatedTraceViewRequest;
   path: {
@@ -27989,35 +29366,6 @@ export type GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponses
 export type GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponse =
   GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponses[keyof GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponses];
 
-export type ExportRecordsProjectsProjectIdExportRecordsPostData = {
-  body: LogRecordsExportRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/export_records';
-};
-
-export type ExportRecordsProjectsProjectIdExportRecordsPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type ExportRecordsProjectsProjectIdExportRecordsPostError =
-  ExportRecordsProjectsProjectIdExportRecordsPostErrors[keyof ExportRecordsProjectsProjectIdExportRecordsPostErrors];
-
-export type ExportRecordsProjectsProjectIdExportRecordsPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: unknown;
-};
-
 export type RecomputeMetricsProjectsProjectIdRecomputeMetricsPostData = {
   body: RecomputeLogRecordsMetricsRequest;
   path: {
@@ -28046,102 +29394,6 @@ export type RecomputeMetricsProjectsProjectIdRecomputeMetricsPostResponses = {
    */
   200: unknown;
 };
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostData = {
-  body: LogRecordsDeleteRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/delete';
-};
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostError =
-  DeleteTracesProjectsProjectIdTracesDeletePostErrors[keyof DeleteTracesProjectsProjectIdTracesDeletePostErrors];
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsDeleteResponse;
-};
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostResponse =
-  DeleteTracesProjectsProjectIdTracesDeletePostResponses[keyof DeleteTracesProjectsProjectIdTracesDeletePostResponses];
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostData = {
-  body: LogRecordsDeleteRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/delete';
-};
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostError =
-  DeleteSpansProjectsProjectIdSpansDeletePostErrors[keyof DeleteSpansProjectsProjectIdSpansDeletePostErrors];
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsDeleteResponse;
-};
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostResponse =
-  DeleteSpansProjectsProjectIdSpansDeletePostResponses[keyof DeleteSpansProjectsProjectIdSpansDeletePostResponses];
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostData = {
-  body: LogRecordsDeleteRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions/delete';
-};
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostError =
-  DeleteSessionsProjectsProjectIdSessionsDeletePostErrors[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostErrors];
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsDeleteResponse;
-};
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponse =
-  DeleteSessionsProjectsProjectIdSessionsDeletePostResponses[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostResponses];
 
 export type ListExperimentsProjectsProjectIdExperimentsGetData = {
   body?: never;
@@ -28442,79 +29694,6 @@ export type ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColu
 
 export type ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColumnsPostResponse =
   ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColumnsPostResponses[keyof ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColumnsPostResponses];
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostData =
-  {
-    body: ExperimentMetricsRequest;
-    path: {
-      /**
-       * Project Id
-       */
-      projectId: string;
-      /**
-       * Experiment Id
-       */
-      experimentId: string;
-    };
-    query?: never;
-    url: '/projects/{project_id}/experiments/{experiment_id}/metrics';
-  };
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostError =
-  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors];
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: ExperimentMetricsResponse;
-  };
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponse =
-  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses];
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostData = {
-  body: ExperimentMetricsRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    projectId: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/experiments/metrics';
-};
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostError =
-  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors];
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: ExperimentMetricsResponse;
-  };
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponse =
-  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses];
 
 export type GetMetricSettingsProjectsProjectIdExperimentsExperimentIdMetricSettingsGetData =
   {
@@ -30891,25 +32070,6 @@ export type UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTa
 export type UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTagIdPutResponse =
   UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTagIdPutResponses[keyof UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTagIdPutResponses];
 
-export type ListIntegrationsIntegrationsGetData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/integrations';
-};
-
-export type ListIntegrationsIntegrationsGetResponses = {
-  /**
-   * Response List Integrations Integrations Get
-   *
-   * Successful Response
-   */
-  200: Array<IntegrationDb>;
-};
-
-export type ListIntegrationsIntegrationsGetResponse =
-  ListIntegrationsIntegrationsGetResponses[keyof ListIntegrationsIntegrationsGetResponses];
-
 export type ListAvailableIntegrationsIntegrationsAvailableGetData = {
   body?: never;
   path?: never;
@@ -31883,65 +33043,19 @@ export type GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGet
 export type GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGetResponse =
   GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGetResponses[keyof GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGetResponses];
 
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetData = {
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetData = {
   body?: never;
-  path?: never;
-  query?: {
+  path: {
     /**
-     * Multimodal Capabilities
+     * Dataset Id
      */
-    multimodalCapabilities?: Array<MultimodalCapability> | null;
+    datasetId: string;
   };
-  url: '/llm_integrations';
+  query?: never;
+  url: '/datasets/{dataset_id}/variable_preview';
 };
 
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetError =
-  GetIntegrationsAndModelInfoLlmIntegrationsGetErrors[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetErrors];
-
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponses = {
-  /**
-   * Response Get Integrations And Model Info Llm Integrations Get
-   *
-   * Successful Response
-   */
-  200: {
-    [key in LlmIntegration]?: IntegrationModelsResponse;
-  };
-};
-
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponse =
-  GetIntegrationsAndModelInfoLlmIntegrationsGetResponses[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetResponses];
-
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetData =
-  {
-    body?: never;
-    path: {
-      /**
-       * Project Id
-       */
-      projectId: string;
-      /**
-       * Run Id
-       */
-      runId: string;
-    };
-    query?: {
-      /**
-       * Multimodal Capabilities
-       */
-      multimodalCapabilities?: Array<MultimodalCapability> | null;
-    };
-    url: '/llm_integrations/projects/{project_id}/runs/{run_id}';
-  };
-
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors =
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetErrors =
   {
     /**
      * Validation Error
@@ -31949,23 +33063,94 @@ export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRun
     422: HttpValidationError;
   };
 
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetError =
-  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors];
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetError =
+  GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetErrors[keyof GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetErrors];
 
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses =
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponses =
   {
     /**
-     * Response Get Integrations And Model Info For Run Llm Integrations Projects  Project Id  Runs  Run Id  Get
+     * Response Get Dataset Variable Preview Datasets  Dataset Id  Variable Preview Get
      *
      * Successful Response
      */
-    200: {
-      [key in LlmIntegration]?: IntegrationModelsResponse;
-    };
+    200: Array<DatasetInputJsonField>;
   };
 
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponse =
-  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses];
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponse =
+  GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponses[keyof GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponses];
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostData =
+  {
+    body: ExperimentMetricsRequest;
+    path: {
+      /**
+       * Project Id
+       */
+      projectId: string;
+      /**
+       * Experiment Id
+       */
+      experimentId: string;
+    };
+    query?: never;
+    url: '/projects/{project_id}/experiments/{experiment_id}/metrics';
+  };
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostError =
+  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors];
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ExperimentMetricsResponse;
+  };
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponse =
+  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses];
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostData = {
+  body: ExperimentMetricsRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/experiments/metrics';
+};
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostError =
+  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors];
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ExperimentMetricsResponse;
+  };
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponse =
+  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses];
 
 export type CreateScorersPostData = {
   body: CreateScorerRequest;
@@ -32083,6 +33268,266 @@ export type ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponses =
 export type ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponse =
   ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponses[keyof ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponses];
 
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostData = {
+  body: ValidateLlmScorerDatasetRequest;
+  path?: never;
+  query?: never;
+  url: '/scorers/llm/validate/dataset';
+};
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostError =
+  ValidateLlmScorerDatasetScorersLlmValidateDatasetPostErrors[keyof ValidateLlmScorerDatasetScorersLlmValidateDatasetPostErrors];
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: ValidateLlmScorerDatasetResponse;
+};
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponse =
+  ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponses[keyof ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponses];
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostData = {
+  body: BodyValidateCodeScorerDatasetScorersCodeValidateDatasetPost;
+  path?: never;
+  query?: never;
+  url: '/scorers/code/validate/dataset';
+};
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostError =
+  ValidateCodeScorerDatasetScorersCodeValidateDatasetPostErrors[keyof ValidateCodeScorerDatasetScorersCodeValidateDatasetPostErrors];
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: ValidateCodeScorerDatasetResponse;
+};
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponse =
+  ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponses[keyof ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponses];
+
+export type LogTracesProjectsProjectIdTracesPostData = {
+  body: LogTracesIngestRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces';
+};
+
+export type LogTracesProjectsProjectIdTracesPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type LogTracesProjectsProjectIdTracesPostError =
+  LogTracesProjectsProjectIdTracesPostErrors[keyof LogTracesProjectsProjectIdTracesPostErrors];
+
+export type LogTracesProjectsProjectIdTracesPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogTracesIngestResponse;
+};
+
+export type LogTracesProjectsProjectIdTracesPostResponse =
+  LogTracesProjectsProjectIdTracesPostResponses[keyof LogTracesProjectsProjectIdTracesPostResponses];
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetData = {
+  body?: never;
+  path: {
+    /**
+     * Trace Id
+     */
+    traceId: string;
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: {
+    /**
+     * Include Presigned Urls
+     */
+    includePresignedUrls?: boolean;
+  };
+  url: '/projects/{project_id}/traces/{trace_id}';
+};
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetError =
+  GetTraceProjectsProjectIdTracesTraceIdGetErrors[keyof GetTraceProjectsProjectIdTracesTraceIdGetErrors];
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: ExtendedTraceRecordWithChildren;
+};
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetResponse =
+  GetTraceProjectsProjectIdTracesTraceIdGetResponses[keyof GetTraceProjectsProjectIdTracesTraceIdGetResponses];
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchData = {
+  body: LogTraceUpdateRequest;
+  path: {
+    /**
+     * Trace Id
+     */
+    traceId: string;
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/{trace_id}';
+};
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchError =
+  UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors];
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogTraceUpdateResponse;
+};
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponse =
+  UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses];
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetData = {
+  body?: never;
+  path: {
+    /**
+     * Span Id
+     */
+    spanId: string;
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: {
+    /**
+     * Include Presigned Urls
+     */
+    includePresignedUrls?: boolean;
+  };
+  url: '/projects/{project_id}/spans/{span_id}';
+};
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetError =
+  GetSpanProjectsProjectIdSpansSpanIdGetErrors[keyof GetSpanProjectsProjectIdSpansSpanIdGetErrors];
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetResponses = {
+  /**
+   * Response Get Span Projects  Project Id  Spans  Span Id  Get
+   *
+   * Successful Response
+   */
+  200:
+    | ({
+        type: 'agent';
+      } & ExtendedAgentSpanRecordWithChildren)
+    | ({
+        type: 'workflow';
+      } & ExtendedWorkflowSpanRecordWithChildren)
+    | ({
+        type: 'llm';
+      } & ExtendedLlmSpanRecord)
+    | ({
+        type: 'tool';
+      } & ExtendedToolSpanRecordWithChildren)
+    | ({
+        type: 'retriever';
+      } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord);
+};
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetResponse =
+  GetSpanProjectsProjectIdSpansSpanIdGetResponses[keyof GetSpanProjectsProjectIdSpansSpanIdGetResponses];
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchData = {
+  body: LogSpanUpdateRequest;
+  path: {
+    /**
+     * Span Id
+     */
+    spanId: string;
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/{span_id}';
+};
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchError =
+  UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors];
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogSpanUpdateResponse;
+};
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponse =
+  UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses];
+
 export type TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostData =
   {
     body: LogRecordsAvailableColumnsRequest;
@@ -32117,6 +33562,41 @@ export type TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostRes
 
 export type TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostResponse =
   TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostResponses[keyof TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostResponses];
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostData =
+  {
+    body: MetricsTestingAvailableColumnsRequest;
+    path: {
+      /**
+       * Project Id
+       */
+      projectId: string;
+    };
+    query?: never;
+    url: '/projects/{project_id}/metrics-testing/available_columns';
+  };
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostError =
+  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors];
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsAvailableColumnsResponse;
+  };
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponse =
+  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses];
 
 export type SpansAvailableColumnsProjectsProjectIdSpansAvailableColumnsPostData =
   {
@@ -32187,6 +33667,232 @@ export type SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPos
 
 export type SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPostResponse =
   SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPostResponses[keyof SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPostResponses];
+
+export type QueryTracesProjectsProjectIdTracesSearchPostData = {
+  body: LogRecordsQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/search';
+};
+
+export type QueryTracesProjectsProjectIdTracesSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryTracesProjectsProjectIdTracesSearchPostError =
+  QueryTracesProjectsProjectIdTracesSearchPostErrors[keyof QueryTracesProjectsProjectIdTracesSearchPostErrors];
+
+export type QueryTracesProjectsProjectIdTracesSearchPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryResponse;
+};
+
+export type QueryTracesProjectsProjectIdTracesSearchPostResponse =
+  QueryTracesProjectsProjectIdTracesSearchPostResponses[keyof QueryTracesProjectsProjectIdTracesSearchPostResponses];
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostData = {
+  body: LogRecordsPartialQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/partial_search';
+};
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostError =
+  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors];
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsPartialQueryResponse;
+  };
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponse =
+  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses];
+
+export type CountTracesProjectsProjectIdTracesCountPostData = {
+  body: LogRecordsQueryCountRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/count';
+};
+
+export type CountTracesProjectsProjectIdTracesCountPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CountTracesProjectsProjectIdTracesCountPostError =
+  CountTracesProjectsProjectIdTracesCountPostErrors[keyof CountTracesProjectsProjectIdTracesCountPostErrors];
+
+export type CountTracesProjectsProjectIdTracesCountPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryCountResponse;
+};
+
+export type CountTracesProjectsProjectIdTracesCountPostResponse =
+  CountTracesProjectsProjectIdTracesCountPostResponses[keyof CountTracesProjectsProjectIdTracesCountPostResponses];
+
+export type LogSpansProjectsProjectIdSpansPostData = {
+  body: LogSpansIngestRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans';
+};
+
+export type LogSpansProjectsProjectIdSpansPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type LogSpansProjectsProjectIdSpansPostError =
+  LogSpansProjectsProjectIdSpansPostErrors[keyof LogSpansProjectsProjectIdSpansPostErrors];
+
+export type LogSpansProjectsProjectIdSpansPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogSpansIngestResponse;
+};
+
+export type LogSpansProjectsProjectIdSpansPostResponse =
+  LogSpansProjectsProjectIdSpansPostResponses[keyof LogSpansProjectsProjectIdSpansPostResponses];
+
+export type QuerySpansProjectsProjectIdSpansSearchPostData = {
+  body: LogRecordsQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/search';
+};
+
+export type QuerySpansProjectsProjectIdSpansSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QuerySpansProjectsProjectIdSpansSearchPostError =
+  QuerySpansProjectsProjectIdSpansSearchPostErrors[keyof QuerySpansProjectsProjectIdSpansSearchPostErrors];
+
+export type QuerySpansProjectsProjectIdSpansSearchPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryResponse;
+};
+
+export type QuerySpansProjectsProjectIdSpansSearchPostResponse =
+  QuerySpansProjectsProjectIdSpansSearchPostResponses[keyof QuerySpansProjectsProjectIdSpansSearchPostResponses];
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostData = {
+  body: LogRecordsPartialQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/partial_search';
+};
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostError =
+  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors];
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsPartialQueryResponse;
+  };
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponse =
+  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses];
+
+export type CountSpansProjectsProjectIdSpansCountPostData = {
+  body: LogRecordsQueryCountRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/count';
+};
+
+export type CountSpansProjectsProjectIdSpansCountPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CountSpansProjectsProjectIdSpansCountPostError =
+  CountSpansProjectsProjectIdSpansCountPostErrors[keyof CountSpansProjectsProjectIdSpansCountPostErrors];
+
+export type CountSpansProjectsProjectIdSpansCountPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryCountResponse;
+};
+
+export type CountSpansProjectsProjectIdSpansCountPostResponse =
+  CountSpansProjectsProjectIdSpansCountPostResponses[keyof CountSpansProjectsProjectIdSpansCountPostResponses];
 
 export type QueryMetricsProjectsProjectIdMetricsSearchPostData = {
   body: LogRecordsMetricsQueryRequest;
@@ -32284,3 +33990,516 @@ export type QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponses 
 
 export type QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponse =
   QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponses[keyof QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponses];
+
+export type CreateSessionProjectsProjectIdSessionsPostData = {
+  body: SessionCreateRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions';
+};
+
+export type CreateSessionProjectsProjectIdSessionsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateSessionProjectsProjectIdSessionsPostError =
+  CreateSessionProjectsProjectIdSessionsPostErrors[keyof CreateSessionProjectsProjectIdSessionsPostErrors];
+
+export type CreateSessionProjectsProjectIdSessionsPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: SessionCreateResponse;
+};
+
+export type CreateSessionProjectsProjectIdSessionsPostResponse =
+  CreateSessionProjectsProjectIdSessionsPostResponses[keyof CreateSessionProjectsProjectIdSessionsPostResponses];
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostData = {
+  body: LogRecordsQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions/search';
+};
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostError =
+  QuerySessionsProjectsProjectIdSessionsSearchPostErrors[keyof QuerySessionsProjectsProjectIdSessionsSearchPostErrors];
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryResponse;
+};
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostResponse =
+  QuerySessionsProjectsProjectIdSessionsSearchPostResponses[keyof QuerySessionsProjectsProjectIdSessionsSearchPostResponses];
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostData =
+  {
+    body: LogRecordsPartialQueryRequest;
+    path: {
+      /**
+       * Project Id
+       */
+      projectId: string;
+    };
+    query?: never;
+    url: '/projects/{project_id}/sessions/partial_search';
+  };
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostError =
+  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors];
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsPartialQueryResponse;
+  };
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponse =
+  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses];
+
+export type CountSessionsProjectsProjectIdSessionsCountPostData = {
+  body: LogRecordsQueryCountRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions/count';
+};
+
+export type CountSessionsProjectsProjectIdSessionsCountPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CountSessionsProjectsProjectIdSessionsCountPostError =
+  CountSessionsProjectsProjectIdSessionsCountPostErrors[keyof CountSessionsProjectsProjectIdSessionsCountPostErrors];
+
+export type CountSessionsProjectsProjectIdSessionsCountPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryCountResponse;
+};
+
+export type CountSessionsProjectsProjectIdSessionsCountPostResponse =
+  CountSessionsProjectsProjectIdSessionsCountPostResponses[keyof CountSessionsProjectsProjectIdSessionsCountPostResponses];
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetData = {
+  body?: never;
+  path: {
+    /**
+     * Session Id
+     */
+    sessionId: string;
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: {
+    /**
+     * Include Presigned Urls
+     */
+    includePresignedUrls?: boolean;
+  };
+  url: '/projects/{project_id}/sessions/{session_id}';
+};
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetError =
+  GetSessionProjectsProjectIdSessionsSessionIdGetErrors[keyof GetSessionProjectsProjectIdSessionsSessionIdGetErrors];
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: ExtendedSessionRecordWithChildren;
+};
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetResponse =
+  GetSessionProjectsProjectIdSessionsSessionIdGetResponses[keyof GetSessionProjectsProjectIdSessionsSessionIdGetResponses];
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostData = {
+  body: LogRecordsExportRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/export_records';
+};
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostError =
+  ExportRecordsProjectsProjectIdExportRecordsPostErrors[keyof ExportRecordsProjectsProjectIdExportRecordsPostErrors];
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: unknown;
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostData = {
+  body: LogRecordsDeleteRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/delete';
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostError =
+  DeleteTracesProjectsProjectIdTracesDeletePostErrors[keyof DeleteTracesProjectsProjectIdTracesDeletePostErrors];
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsDeleteResponse;
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostResponse =
+  DeleteTracesProjectsProjectIdTracesDeletePostResponses[keyof DeleteTracesProjectsProjectIdTracesDeletePostResponses];
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostData = {
+  body: LogRecordsDeleteRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/delete';
+};
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostError =
+  DeleteSpansProjectsProjectIdSpansDeletePostErrors[keyof DeleteSpansProjectsProjectIdSpansDeletePostErrors];
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsDeleteResponse;
+};
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostResponse =
+  DeleteSpansProjectsProjectIdSpansDeletePostResponses[keyof DeleteSpansProjectsProjectIdSpansDeletePostResponses];
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostData = {
+  body: LogRecordsDeleteRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    projectId: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions/delete';
+};
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostError =
+  DeleteSessionsProjectsProjectIdSessionsDeletePostErrors[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostErrors];
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsDeleteResponse;
+};
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponse =
+  DeleteSessionsProjectsProjectIdSessionsDeletePostResponses[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostResponses];
+
+export type ListIntegrationsIntegrationsGetData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/integrations';
+};
+
+export type ListIntegrationsIntegrationsGetResponses = {
+  /**
+   * Response List Integrations Integrations Get
+   *
+   * Successful Response
+   */
+  200: Array<IntegrationDb>;
+};
+
+export type ListIntegrationsIntegrationsGetResponse =
+  ListIntegrationsIntegrationsGetResponses[keyof ListIntegrationsIntegrationsGetResponses];
+
+export type SelectIntegrationIntegrationsSelectPostData = {
+  body: IntegrationSelectRequest;
+  path?: never;
+  query?: never;
+  url: '/integrations/select';
+};
+
+export type SelectIntegrationIntegrationsSelectPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type SelectIntegrationIntegrationsSelectPostError =
+  SelectIntegrationIntegrationsSelectPostErrors[keyof SelectIntegrationIntegrationsSelectPostErrors];
+
+export type SelectIntegrationIntegrationsSelectPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: IntegrationDb;
+};
+
+export type SelectIntegrationIntegrationsSelectPostResponse =
+  SelectIntegrationIntegrationsSelectPostResponses[keyof SelectIntegrationIntegrationsSelectPostResponses];
+
+export type DisableIntegrationIntegrationsDisablePostData = {
+  body: IntegrationDisableRequest;
+  path?: never;
+  query?: never;
+  url: '/integrations/disable';
+};
+
+export type DisableIntegrationIntegrationsDisablePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DisableIntegrationIntegrationsDisablePostError =
+  DisableIntegrationIntegrationsDisablePostErrors[keyof DisableIntegrationIntegrationsDisablePostErrors];
+
+export type DisableIntegrationIntegrationsDisablePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: unknown;
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Multimodal Capabilities
+     */
+    multimodalCapabilities?: Array<MultimodalCapability> | null;
+  };
+  url: '/llm_integrations';
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetError =
+  GetIntegrationsAndModelInfoLlmIntegrationsGetErrors[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetErrors];
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponses = {
+  /**
+   * Response Get Integrations And Model Info Llm Integrations Get
+   *
+   * Successful Response
+   */
+  200: {
+    [key in LlmIntegration]?: IntegrationModelsResponse;
+  };
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponse =
+  GetIntegrationsAndModelInfoLlmIntegrationsGetResponses[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetResponses];
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetData =
+  {
+    body?: never;
+    path: {
+      /**
+       * Project Id
+       */
+      projectId: string;
+      /**
+       * Run Id
+       */
+      runId: string;
+    };
+    query?: {
+      /**
+       * Multimodal Capabilities
+       */
+      multimodalCapabilities?: Array<MultimodalCapability> | null;
+    };
+    url: '/llm_integrations/projects/{project_id}/runs/{run_id}';
+  };
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetError =
+  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors];
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses =
+  {
+    /**
+     * Response Get Integrations And Model Info For Run Llm Integrations Projects  Project Id  Runs  Run Id  Get
+     *
+     * Successful Response
+     */
+    200: {
+      [key in LlmIntegration]?: IntegrationModelsResponse;
+    };
+  };
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponse =
+  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses];
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostData = {
+  body: CreateCodeMetricGenerationRequest;
+  path?: never;
+  query?: never;
+  url: '/code-metric-generations';
+};
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostError =
+  CreateCodeMetricGenerationCodeMetricGenerationsPostErrors[keyof CreateCodeMetricGenerationCodeMetricGenerationsPostErrors];
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostResponses = {
+  /**
+   * Successful Response
+   */
+  202: CreateCodeMetricGenerationResponse;
+};
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostResponse =
+  CreateCodeMetricGenerationCodeMetricGenerationsPostResponses[keyof CreateCodeMetricGenerationCodeMetricGenerationsPostResponses];
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetData =
+  {
+    body?: never;
+    path: {
+      /**
+       * Generation Id
+       */
+      generationId: string;
+    };
+    query?: never;
+    url: '/code-metric-generations/{generation_id}/status';
+  };
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetError =
+  GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetErrors[keyof GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetErrors];
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: CodeMetricGenerationStatusResponse;
+  };
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponse =
+  GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponses[keyof GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponses];

--- a/src/types/openapi.types.ts
+++ b/src/types/openapi.types.ts
@@ -93,6 +93,7 @@ export type AgentSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -111,6 +112,7 @@ export type AgentSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -225,6 +227,9 @@ export type AgentSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
   /**
    * Agent type.
@@ -548,6 +553,9 @@ export type AggregatedTraceViewRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
 };
 
@@ -589,18 +597,18 @@ export type AggregatedTraceViewResponse = {
 };
 
 /**
- * AndNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * AndNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * And
      */
     and: Array<
-      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
     >;
   };
 
@@ -649,6 +657,10 @@ export type AnnotationLikeDislikeAggregate = {
    * Unrated Count
    */
   unrated_count: number;
+  /**
+   * Tie Count
+   */
+  tie_count?: number | null;
 };
 
 /**
@@ -915,7 +927,8 @@ export const AuthMethod = {
   OKTA: 'okta',
   AZURE_AD: 'azure-ad',
   CUSTOM: 'custom',
-  SAML: 'saml'
+  SAML: 'saml',
+  INVITE: 'invite'
 } as const;
 
 /**
@@ -1621,6 +1634,10 @@ export type BaseScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -1913,6 +1930,44 @@ export type BodyUploadPromptEvaluationDatasetProjectsProjectIdPromptDatasetsPost
   };
 
 /**
+ * Body_validate_code_scorer_dataset_scorers_code_validate_dataset_post
+ */
+export type BodyValidateCodeScorerDatasetScorersCodeValidateDatasetPost = {
+  /**
+   * File
+   */
+  file: Blob | File;
+  /**
+   * Dataset Id
+   */
+  dataset_id: string;
+  /**
+   * Dataset Version Index
+   */
+  dataset_version_index?: number | null;
+  /**
+   * Limit
+   */
+  limit?: number;
+  /**
+   * Starting Token
+   */
+  starting_token?: number | null;
+  /**
+   * Required Scorers
+   */
+  required_scorers?: string | Array<string> | null;
+  /**
+   * Scoreable Node Types
+   */
+  scoreable_node_types?: string | Array<string> | null;
+  /**
+   * Score Type
+   */
+  score_type?: string | null;
+};
+
+/**
  * Body_validate_code_scorer_log_record_scorers_code_validate_log_record_post
  */
 export type BodyValidateCodeScorerLogRecordScorersCodeValidateLogRecordPost = {
@@ -2027,6 +2082,8 @@ export type BucketedMetric = {
    * Average
    */
   average?: number | null;
+  roll_up_method?: RollUpMethodDisplayOptions | null;
+  data_type?: OutputTypeEnum | null;
 };
 
 /**
@@ -2306,6 +2363,42 @@ export type ChunkAttributionUtilizationTemplate = {
 };
 
 /**
+ * CodeMetricGenerationStatus
+ */
+export const CodeMetricGenerationStatus = {
+  GENERATING: 'generating',
+  COMPLETED: 'completed',
+  FAILED: 'failed'
+} as const;
+
+/**
+ * CodeMetricGenerationStatus
+ */
+export type CodeMetricGenerationStatus =
+  (typeof CodeMetricGenerationStatus)[keyof typeof CodeMetricGenerationStatus];
+
+/**
+ * CodeMetricGenerationStatusResponse
+ *
+ * Lightweight polling response.
+ */
+export type CodeMetricGenerationStatusResponse = {
+  /**
+   * Id
+   */
+  id: string;
+  status: CodeMetricGenerationStatus;
+  /**
+   * Generated Code
+   */
+  generated_code?: string | null;
+  /**
+   * Error Message
+   */
+  error_message?: string | null;
+};
+
+/**
  * CollaboratorRole
  */
 export const CollaboratorRole = {
@@ -2457,6 +2550,15 @@ export type ColumnInfo = {
    * Default roll-up aggregation method for this metric (e.g., 'sum', 'average').
    */
   roll_up_method?: string | null;
+  /**
+   * Metric Key Alias
+   *
+   * Alternate metric key for this column. When scorer UUIDs are used as column IDs
+   * (e.g. "metrics/{uuid}"), this holds the legacy snake_case metric name
+   * (e.g. "correctness") for display and dual-key query fallback.
+   * Patched manually — will be in generated types once SC-64064 merges to production.
+   */
+  metric_key_alias?: string | null;
 };
 
 /**
@@ -2479,6 +2581,31 @@ export type ColumnMapping = {
    * Metadata
    */
   metadata: ColumnMappingConfig | Array<string> | null;
+  /**
+   * Mgt
+   */
+  mgt?: {
+    [key: string]: ColumnMappingConfig;
+  } | null;
+  [key: string]:
+    | unknown
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | ColumnMappingConfig
+    | Array<string>
+    | null
+    | {
+        [key: string]: ColumnMappingConfig;
+      }
+    | null
+    | undefined;
 };
 
 /**
@@ -2673,6 +2800,250 @@ export type ContextRelevanceScorer = {
 };
 
 /**
+ * ControlAction
+ */
+export const ControlAction = {
+  DENY: 'deny',
+  STEER: 'steer',
+  OBSERVE: 'observe'
+} as const;
+
+/**
+ * ControlAction
+ */
+export type ControlAction = (typeof ControlAction)[keyof typeof ControlAction];
+
+/**
+ * ControlAppliesTo
+ */
+export const ControlAppliesTo = {
+  LLM_CALL: 'llm_call',
+  TOOL_CALL: 'tool_call'
+} as const;
+
+/**
+ * ControlAppliesTo
+ */
+export type ControlAppliesTo =
+  (typeof ControlAppliesTo)[keyof typeof ControlAppliesTo];
+
+/**
+ * ControlCheckStage
+ */
+export const ControlCheckStage = { PRE: 'pre', POST: 'post' } as const;
+
+/**
+ * ControlCheckStage
+ */
+export type ControlCheckStage =
+  (typeof ControlCheckStage)[keyof typeof ControlCheckStage];
+
+/**
+ * ControlResult
+ */
+export type ControlResult = {
+  /**
+   * Decision/action produced by the control.
+   */
+  action: ControlAction;
+  /**
+   * Matched
+   *
+   * Whether the control matched. False covers both non-match and error cases; use error_message to distinguish errors.
+   */
+  matched: boolean;
+  /**
+   * Confidence
+   *
+   * Confidence score reported by the control evaluation result.
+   */
+  confidence?: number | null;
+  /**
+   * Error Message
+   *
+   * Error text when control evaluation failed. This should be null for normal matches and non-matches.
+   */
+  error_message?: string | null;
+};
+
+/**
+ * ControlSpan
+ */
+export type ControlSpan = {
+  /**
+   * Type
+   *
+   * Type of the trace, span or session.
+   */
+  type?: 'control';
+  /**
+   * Input
+   *
+   * Input to the trace or span.
+   */
+  input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >;
+  /**
+   * Redacted Input
+   *
+   * Redacted input of the trace or span.
+   */
+  redacted_input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >
+    | null;
+  /**
+   * Output of the trace or span.
+   */
+  output?: ControlResult | null;
+  /**
+   * Redacted output of the trace or span.
+   */
+  redacted_output?: ControlResult | null;
+  /**
+   * Name
+   *
+   * Name of the trace, span or session.
+   */
+  name?: string;
+  /**
+   * Created
+   *
+   * Timestamp of the trace or span's creation.
+   */
+  created_at?: string;
+  /**
+   * User Metadata
+   *
+   * Metadata associated with this trace or span.
+   */
+  user_metadata?: {
+    [key: string]: string;
+  };
+  /**
+   * Tags
+   *
+   * Tags associated with this trace or span.
+   */
+  tags?: Array<string>;
+  /**
+   * Status Code
+   *
+   * Status code of the trace or span. Used for logging failure or error states.
+   */
+  status_code?: number | null;
+  /**
+   * Metrics associated with this trace or span.
+   */
+  metrics?: Metrics;
+  /**
+   * External Id
+   *
+   * A user-provided session, trace or span ID.
+   */
+  external_id?: string | null;
+  /**
+   * Dataset Input
+   *
+   * Input to the dataset associated with this trace
+   */
+  dataset_input?: string | null;
+  /**
+   * Dataset Output
+   *
+   * Output from the dataset associated with this trace
+   */
+  dataset_output?: string | null;
+  /**
+   * Dataset Metadata
+   *
+   * Metadata from the dataset associated with this trace
+   */
+  dataset_metadata?: {
+    [key: string]: string;
+  };
+  /**
+   * ID
+   *
+   * Galileo ID of the session, trace or span
+   */
+  id?: string | null;
+  /**
+   * Session ID
+   *
+   * Galileo ID of the session containing the trace or span or session
+   */
+  session_id?: string | null;
+  /**
+   * Trace ID
+   *
+   * Galileo ID of the trace containing the span (or the same value as id for a trace)
+   */
+  trace_id?: string | null;
+  /**
+   * Step Number
+   *
+   * Topological step number of the span.
+   */
+  step_number?: number | null;
+  /**
+   * Parent ID
+   *
+   * Galileo ID of the parent of this span
+   */
+  parent_id?: string | null;
+  /**
+   * Control Id
+   *
+   * Identifier of the control definition that produced this span.
+   */
+  control_id?: number | null;
+  /**
+   * Agent Name
+   *
+   * Normalized agent name associated with this control execution.
+   */
+  agent_name?: string | null;
+  /**
+   * Execution stage where the control ran, typically 'pre' or 'post'.
+   */
+  check_stage?: ControlCheckStage | null;
+  /**
+   * Parent execution type the control applied to, for example 'llm_call' or 'tool_call'.
+   */
+  applies_to?: ControlAppliesTo | null;
+  /**
+   * Evaluator Name
+   *
+   * Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+   */
+  evaluator_name?: string | null;
+  /**
+   * Selector Path
+   *
+   * Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+   */
+  selector_path?: string | null;
+};
+
+/**
  * CorrectnessScorer
  */
 export type CorrectnessScorer = {
@@ -2712,6 +3083,45 @@ export type CorrectnessScorer = {
    * Number of judges for the scorer.
    */
   num_judges?: number | null;
+};
+
+/**
+ * CreateCodeMetricGenerationRequest
+ *
+ * Request to generate scorer code from a user message.
+ */
+export type CreateCodeMetricGenerationRequest = {
+  /**
+   * User Message
+   *
+   * Natural language, code, or combination
+   */
+  user_message: string;
+  /**
+   * Node Type
+   *
+   * Selected scoreable node type (llm, retriever, trace, agent, workflow, tool, session)
+   */
+  node_type?: string | null;
+  /**
+   * Model Name
+   *
+   * Model alias to use for generation. Defaults to best available.
+   */
+  model_name?: string | null;
+};
+
+/**
+ * CreateCodeMetricGenerationResponse
+ *
+ * Response with generation ID for polling.
+ */
+export type CreateCodeMetricGenerationResponse = {
+  /**
+   * Id
+   */
+  id: string;
+  status: CodeMetricGenerationStatus;
 };
 
 /**
@@ -2999,6 +3409,12 @@ export type CreateJobRequest = {
    */
   is_session?: boolean | null;
   /**
+   * Validation Config
+   */
+  validation_config?: {
+    [key: string]: unknown;
+  } | null;
+  /**
    * Upload Data In Separate Task
    */
   upload_data_in_separate_task?: boolean;
@@ -3277,6 +3693,12 @@ export type CreateJobResponse = {
    */
   is_session?: boolean | null;
   /**
+   * Validation Config
+   */
+  validation_config?: {
+    [key: string]: unknown;
+  } | null;
+  /**
    * Upload Data In Separate Task
    */
   upload_data_in_separate_task?: boolean;
@@ -3442,7 +3864,11 @@ export type CreateScorerRequest = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
-  roll_up_method?: NumericRollUpMethod | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
+  roll_up_method?: RollUpMethodDisplayOptions | null;
   /**
    * Metric Color Picker Config
    */
@@ -3902,6 +4328,10 @@ export type CustomizedAgenticSessionSuccessGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4058,6 +4488,10 @@ export type CustomizedAgenticWorkflowSuccessGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4214,6 +4648,10 @@ export type CustomizedChunkAttributionUtilizationGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4370,6 +4808,10 @@ export type CustomizedCompletenessGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4526,6 +4968,10 @@ export type CustomizedFactualityGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4686,6 +5132,10 @@ export type CustomizedGroundTruthAdherenceGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4842,6 +5292,10 @@ export type CustomizedGroundednessGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -4998,6 +5452,10 @@ export type CustomizedInputSexistGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5154,6 +5612,10 @@ export type CustomizedInputToxicityGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5310,6 +5772,10 @@ export type CustomizedInstructionAdherenceGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5470,6 +5936,10 @@ export type CustomizedPromptInjectionGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5626,6 +6096,10 @@ export type CustomizedSexistGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5782,6 +6256,10 @@ export type CustomizedToolErrorRateGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -5938,6 +6416,10 @@ export type CustomizedToolSelectionQualityGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -6094,6 +6576,10 @@ export type CustomizedToxicityGptScorer = {
    * Required Scorers
    */
   required_scorers?: Array<string> | null;
+  /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
   roll_up_strategy?: RollUpStrategy | null;
   /**
    * Roll Up Methods
@@ -6150,7 +6636,9 @@ export const DataType = {
   STAR_RATING_AGGREGATE: 'star_rating_aggregate',
   THUMB_RATING_AGGREGATE: 'thumb_rating_aggregate',
   TAGS_RATING_AGGREGATE: 'tags_rating_aggregate',
-  TEXT_RATING_AGGREGATE: 'text_rating_aggregate'
+  TEXT_RATING_AGGREGATE: 'text_rating_aggregate',
+  ANNOTATION_AGREEMENT: 'annotation_agreement',
+  FULLY_ANNOTATED: 'fully_annotated'
 } as const;
 
 /**
@@ -6396,7 +6884,11 @@ export type DatasetCopyRecordData = {
   /**
    * Project Id
    */
-  project_id: string;
+  project_id?: string | null;
+  /**
+   * Queue Id
+   */
+  queue_id?: string | null;
   /**
    * Ids
    *
@@ -6575,6 +7067,20 @@ export type DatasetIdFilter = {
    * Value
    */
   value: string | Array<string | string>;
+};
+
+/**
+ * DatasetInputJsonField
+ */
+export type DatasetInputJsonField = {
+  /**
+   * Key
+   */
+  key: string;
+  /**
+   * Values
+   */
+  values: Array<JsonValue>;
 };
 
 /**
@@ -7250,6 +7756,9 @@ export type ExperimentMetricsRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
 };
 
@@ -7404,10 +7913,19 @@ export type ExperimentResponse = {
   dataset?: ExperimentDataset | null;
   /**
    * Aggregate Metrics
+   * @deprecated Use `metricAggregates` instead.
    */
   aggregate_metrics?: {
     [key: string]: unknown;
   };
+  /**
+   * Structured Aggregate Metrics
+   *
+   * Structured aggregate metrics keyed by raw metric name with full statistical aggregates. Present only when use_clickhouse_run_aggregates flag is enabled.
+   */
+  structured_aggregate_metrics?: {
+    [key: string]: MetricAggregates;
+  } | null;
   /**
    * Aggregate Feedback
    *
@@ -7639,6 +8157,7 @@ export type ExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -7657,6 +8176,7 @@ export type ExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -7813,11 +8333,31 @@ export type ExtendedAgentSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -7905,6 +8445,9 @@ export type ExtendedAgentSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -7962,6 +8505,7 @@ export type ExtendedAgentSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -7980,6 +8524,7 @@ export type ExtendedAgentSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -8136,11 +8681,31 @@ export type ExtendedAgentSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -8203,6 +8768,329 @@ export type ExtendedAgentSpanRecordWithChildren = {
    * Agent type.
    */
   agent_type?: AgentType;
+};
+
+/**
+ * ExtendedControlSpanRecord
+ */
+export type ExtendedControlSpanRecord = {
+  /**
+   * Type
+   *
+   * Type of the trace, span or session.
+   */
+  type?: 'control';
+  /**
+   * Input
+   *
+   * Input to the trace or span.
+   */
+  input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >;
+  /**
+   * Redacted Input
+   *
+   * Redacted input of the trace or span.
+   */
+  redacted_input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >
+    | null;
+  /**
+   * Output of the trace or span.
+   */
+  output?: ControlResult | null;
+  /**
+   * Redacted output of the trace or span.
+   */
+  redacted_output?: ControlResult | null;
+  /**
+   * Name
+   *
+   * Name of the trace, span or session.
+   */
+  name?: string;
+  /**
+   * Created
+   *
+   * Timestamp of the trace or span's creation.
+   */
+  created_at?: string;
+  /**
+   * User Metadata
+   *
+   * Metadata associated with this trace or span.
+   */
+  user_metadata?: {
+    [key: string]: string;
+  };
+  /**
+   * Tags
+   *
+   * Tags associated with this trace or span.
+   */
+  tags?: Array<string>;
+  /**
+   * Status Code
+   *
+   * Status code of the trace or span. Used for logging failure or error states.
+   */
+  status_code?: number | null;
+  /**
+   * Metrics associated with this trace or span.
+   */
+  metrics?: Metrics;
+  /**
+   * External Id
+   *
+   * A user-provided session, trace or span ID.
+   */
+  external_id?: string | null;
+  /**
+   * Dataset Input
+   *
+   * Input to the dataset associated with this trace
+   */
+  dataset_input?: string | null;
+  /**
+   * Dataset Output
+   *
+   * Output from the dataset associated with this trace
+   */
+  dataset_output?: string | null;
+  /**
+   * Dataset Metadata
+   *
+   * Metadata from the dataset associated with this trace
+   */
+  dataset_metadata?: {
+    [key: string]: string;
+  };
+  /**
+   * ID
+   *
+   * Galileo ID of the session, trace or span
+   */
+  id: string;
+  /**
+   * Session ID
+   *
+   * Galileo ID of the session containing the trace (or the same value as id for a trace)
+   */
+  session_id: string;
+  /**
+   * Trace ID
+   *
+   * Galileo ID of the trace containing the span (or the same value as id for a trace)
+   */
+  trace_id?: string | null;
+  /**
+   * Project ID
+   *
+   * Galileo ID of the project associated with this trace or span
+   */
+  project_id: string;
+  /**
+   * Run ID
+   *
+   * Galileo ID of the run (log stream or experiment) associated with this trace or span
+   */
+  run_id: string;
+  /**
+   * Last Updated
+   *
+   * Timestamp of the session or trace or span's last update
+   */
+  updated_at?: string | null;
+  /**
+   * Has Children
+   *
+   * Whether or not this trace or span has child spans
+   */
+  has_children?: boolean | null;
+  /**
+   * Metrics Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  metrics_batch_id?: string | null;
+  /**
+   * Session Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  session_batch_id?: string | null;
+  /**
+   * Feedback Rating Info
+   *
+   * Feedback information related to the record
+   */
+  feedback_rating_info?: {
+    [key: string]: FeedbackRatingInfo;
+  };
+  /**
+   * Annotations
+   *
+   * Annotations keyed by template ID and annotator ID
+   */
+  annotations?: {
+    [key: string]: {
+      [key: string]: AnnotationRatingInfo;
+    };
+  };
+  /**
+   * File Ids
+   *
+   * IDs of files associated with this record
+   */
+  file_ids?: Array<string>;
+  /**
+   * File Modalities
+   *
+   * Modalities of files associated with this record
+   */
+  file_modalities?: Array<ContentModality>;
+  /**
+   * Annotation Aggregates
+   *
+   * Annotation aggregate information keyed by template ID
+   */
+  annotation_aggregates?: {
+    [key: string]: AnnotationAggregate;
+  };
+  /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
+   * Annotation Queue Ids
+   *
+   * IDs of annotation queues this record is in
+   */
+  annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
+  /**
+   * Metric Info
+   *
+   * Detailed information about the metrics associated with this trace or span
+   */
+  metric_info?: {
+    [key: string]:
+      | ({
+          status_type: 'not_computed';
+        } & MetricNotComputed)
+      | ({
+          status_type: 'pending';
+        } & MetricPending)
+      | ({
+          status_type: 'computing';
+        } & MetricComputing)
+      | ({
+          status_type: 'not_applicable';
+        } & MetricNotApplicable)
+      | ({
+          status_type: 'success';
+        } & MetricSuccess)
+      | ({
+          status_type: 'error';
+        } & MetricError)
+      | ({
+          status_type: 'failed';
+        } & MetricFailed)
+      | ({
+          status_type: 'roll_up';
+        } & MetricRollUp);
+  } | null;
+  /**
+   * Files
+   *
+   * File metadata keyed by file ID for files associated with this record
+   */
+  files?: {
+    [key: string]: FileMetadata;
+  } | null;
+  /**
+   * Parent ID
+   *
+   * Galileo ID of the parent of this span
+   */
+  parent_id: string;
+  /**
+   * Is Complete
+   *
+   * Whether the parent trace is complete or not
+   */
+  is_complete?: boolean;
+  /**
+   * Step Number
+   *
+   * Topological step number of the span.
+   */
+  step_number?: number | null;
+  /**
+   * Control Id
+   *
+   * Identifier of the control definition that produced this span.
+   */
+  control_id?: number | null;
+  /**
+   * Agent Name
+   *
+   * Normalized agent name associated with this control execution.
+   */
+  agent_name?: string | null;
+  /**
+   * Execution stage where the control ran, typically 'pre' or 'post'.
+   */
+  check_stage?: ControlCheckStage | null;
+  /**
+   * Parent execution type the control applied to, for example 'llm_call' or 'tool_call'.
+   */
+  applies_to?: ControlAppliesTo | null;
+  /**
+   * Evaluator Name
+   *
+   * Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+   */
+  evaluator_name?: string | null;
+  /**
+   * Selector Path
+   *
+   * Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+   */
+  selector_path?: string | null;
 };
 
 /**
@@ -8390,11 +9278,31 @@ export type ExtendedLlmSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -8701,11 +9609,31 @@ export type ExtendedRetrieverSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -8789,6 +9717,9 @@ export type ExtendedRetrieverSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -8975,11 +9906,31 @@ export type ExtendedRetrieverSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9098,6 +10049,7 @@ export type ExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -9116,6 +10068,7 @@ export type ExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -9272,11 +10225,31 @@ export type ExtendedSessionRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9389,6 +10362,7 @@ export type ExtendedSessionRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -9407,6 +10381,7 @@ export type ExtendedSessionRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -9563,11 +10538,31 @@ export type ExtendedSessionRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9807,11 +10802,31 @@ export type ExtendedToolSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -9901,6 +10916,9 @@ export type ExtendedToolSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -10087,11 +11105,31 @@ export type ExtendedToolSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -10386,11 +11424,31 @@ export type ExtendedTraceRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -10466,6 +11524,9 @@ export type ExtendedTraceRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -10691,11 +11752,31 @@ export type ExtendedTraceRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -10808,6 +11889,7 @@ export type ExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -10826,6 +11908,7 @@ export type ExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -10982,11 +12065,31 @@ export type ExtendedWorkflowSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -11070,6 +12173,9 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
   >;
   /**
    * Type
@@ -11127,6 +12233,7 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -11145,6 +12252,7 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -11301,11 +12409,31 @@ export type ExtendedWorkflowSpanRecordWithChildren = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -11617,17 +12745,17 @@ export const FileStatus = {
  */
 export type FileStatus = (typeof FileStatus)[keyof typeof FileStatus];
 
-export type FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
 
-    | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-    | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-    | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-    | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
+    | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+    | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+    | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+    | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
 
 /**
- * FilterLeaf[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * FilterLeaf[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * Filter
@@ -11650,7 +12778,10 @@ export type FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRec
         } & LogRecordsCollectionFilter)
       | ({
           type: 'text';
-        } & LogRecordsTextFilter);
+        } & LogRecordsTextFilter)
+      | ({
+          type: 'fully_annotated';
+        } & LogRecordsFullyAnnotatedFilter);
   };
 
 /**
@@ -11798,6 +12929,12 @@ export type GeneratedScorerConfiguration = {
    * Whether ground truth is enabled for this scorer.
    */
   ground_truth?: boolean;
+  /**
+   * Multimodal Capabilities
+   *
+   * Multimodal capabilities required by this scorer.
+   */
+  multimodal_capabilities?: Array<MultimodalCapability> | null;
 };
 
 /**
@@ -12667,6 +13804,17 @@ export type IntegrationDb = {
    * Is Selected
    */
   is_selected?: boolean;
+  /**
+   * Is Disabled
+   */
+  is_disabled?: boolean;
+};
+
+/**
+ * IntegrationDisableRequest
+ */
+export type IntegrationDisableRequest = {
+  integration_name: IntegrationName;
 };
 
 /**
@@ -12715,7 +13863,6 @@ export const IntegrationName = {
   AZURE: 'azure',
   CUSTOM: 'custom',
   DATABRICKS: 'databricks',
-  LABELSTUDIO: 'labelstudio',
   MISTRAL: 'mistral',
   NVIDIA: 'nvidia',
   OPENAI: 'openai',
@@ -12729,6 +13876,17 @@ export const IntegrationName = {
  */
 export type IntegrationName =
   (typeof IntegrationName)[keyof typeof IntegrationName];
+
+/**
+ * IntegrationSelectRequest
+ */
+export type IntegrationSelectRequest = {
+  integration_name: IntegrationName;
+  /**
+   * Integration Id
+   */
+  integration_id: string;
+};
 
 /**
  * InternalToolCall
@@ -12956,6 +14114,15 @@ export type JobProgress = {
    */
   steps_total?: number | null;
 };
+
+export type JsonPrimitive = string | number | number | boolean | null;
+
+export type JsonValue =
+  | JsonPrimitive
+  | Array<JsonValue>
+  | {
+      [key: string]: JsonValue;
+    };
 
 /**
  * LLMExportFormat
@@ -13428,6 +14595,12 @@ export type ListScorersRequest = {
     | ({
         name: 'model_type';
       } & ScorerModelTypeFilter)
+    | ({
+        name: 'exclude_slm_scorers';
+      } & ScorerExcludeSlmScorersFilter)
+    | ({
+        name: 'exclude_multimodal_scorers';
+      } & ScorerExcludeMultimodalScorersFilter)
     | ({
         name: 'tags';
       } & ScorerTagsFilter)
@@ -13964,6 +15137,12 @@ export type LogRecordsColumnInfo = {
    * Type of label color for the column, if this is a multilabel metric column.
    */
   label_color?: 'positive' | 'negative' | null;
+  /**
+   * Metric Key Alias
+   *
+   * Alternate metric key for this column. When store_metric_ids is ON, this holds the legacy metric_name string. Used for dual-key ClickHouse queries.
+   */
+  metric_key_alias?: string | null;
 };
 
 /**
@@ -13991,7 +15170,7 @@ export type LogRecordsCustomMetricsQueryRequest = {
   /**
    * Filter expression tree for complex filtering
    */
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Start Time
    *
@@ -14092,8 +15271,11 @@ export type LogRecordsDeleteRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
 };
 
 /**
@@ -14114,6 +15296,28 @@ export type LogRecordsDeleteResponse = {
  * Request schema for exporting log records (sessions, traces, spans).
  */
 export type LogRecordsExportRequest = {
+  /**
+   * Column Ids
+   *
+   * Column IDs to include in the export. Applies only to CSV exports.
+   */
+  column_ids?: Array<string> | null;
+  /**
+   * Export format
+   */
+  export_format?: LlmExportFormat;
+  /**
+   * Redact
+   *
+   * Redact sensitive data
+   */
+  redact?: boolean;
+  /**
+   * File Name
+   *
+   * Optional filename for the exported file
+   */
+  file_name?: string | null;
   /**
    * Log Stream Id
    *
@@ -14156,34 +15360,15 @@ export type LogRecordsExportRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
   /**
    * Sort clause for the export.  Defaults to native sort (created_at, id descending).
    */
   sort?: LogRecordsSortClause | null;
-  /**
-   * Column Ids
-   *
-   * Column IDs to include in export
-   */
-  column_ids?: Array<string> | null;
-  /**
-   * Export format
-   */
-  export_format?: LlmExportFormat;
   root_type: RootType;
-  /**
-   * Redact
-   *
-   * Redact sensitive data
-   */
-  redact?: boolean;
-  /**
-   * File Name
-   *
-   * Optional filename for the exported file
-   */
-  file_name?: string | null;
 };
 
 /**
@@ -14195,7 +15380,8 @@ export const LogRecordsFilterType = {
   NUMBER: 'number',
   BOOLEAN: 'boolean',
   TEXT: 'text',
-  COLLECTION: 'collection'
+  COLLECTION: 'collection',
+  FULLY_ANNOTATED: 'fully_annotated'
 } as const;
 
 /**
@@ -14203,6 +15389,30 @@ export const LogRecordsFilterType = {
  */
 export type LogRecordsFilterType =
   (typeof LogRecordsFilterType)[keyof typeof LogRecordsFilterType];
+
+/**
+ * LogRecordsFullyAnnotatedFilter
+ *
+ * Queue-scoped filter for records rated across all queue templates.
+ */
+export type LogRecordsFullyAnnotatedFilter = {
+  /**
+   * Column Id
+   *
+   * Queue-scoped filter identifier. This filter only works for annotation-queue searches that provide queue context.
+   */
+  column_id?: 'fully_annotated';
+  /**
+   * Type
+   */
+  type?: 'fully_annotated';
+  /**
+   * User Ids
+   *
+   * Optional queue member IDs to require for full annotation in a queue-scoped search. If omitted, all tracked queue members visible to the requester are used.
+   */
+  user_ids?: Array<string> | null;
+};
 
 /**
  * LogRecordsIDFilter
@@ -14272,6 +15482,9 @@ export type LogRecordsMetricsQueryRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
   /**
    * Start Time
@@ -14418,8 +15631,11 @@ export type LogRecordsPartialQueryRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -14486,6 +15702,9 @@ export type LogRecordsPartialQueryResponse = {
         type: 'retriever';
       } & PartialExtendedRetrieverSpanRecord)
     | ({
+        type: 'control';
+      } & PartialExtendedControlSpanRecord)
+    | ({
         type: 'session';
       } & PartialExtendedSessionRecord)
   >;
@@ -14535,8 +15754,11 @@ export type LogRecordsQueryCountRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
 };
 
 /**
@@ -14607,8 +15829,11 @@ export type LogRecordsQueryRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -14673,6 +15898,9 @@ export type LogRecordsQueryResponse = {
     | ({
         type: 'retriever';
       } & ExtendedRetrieverSpanRecord)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord)
     | ({
         type: 'session';
       } & ExtendedSessionRecord)
@@ -14802,6 +16030,7 @@ export type LogSpanUpdateRequest = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Tags
@@ -14933,6 +16162,9 @@ export type LogSpansIngestRequest = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
   /**
    * Trace Id
@@ -15088,6 +16320,22 @@ export type LogStreamIdFilter = {
    * Value
    */
   value: string | Array<string | string>;
+};
+
+/**
+ * LogStreamInfo
+ *
+ * Minimal log stream representation (id and name only).
+ */
+export type LogStreamInfo = {
+  /**
+   * Id
+   */
+  id: string;
+  /**
+   * Name
+   */
+  name: string;
 };
 
 /**
@@ -15567,7 +16815,8 @@ export type LunaInputTypeEnum =
 export const LunaOutputTypeEnum = {
   FLOAT: 'float',
   STRING: 'string',
-  STRING_LIST: 'string_list'
+  STRING_LIST: 'string_list',
+  BOOL_LIST: 'bool_list'
 } as const;
 
 /**
@@ -15833,6 +17082,62 @@ export type MetadataFilter = {
 };
 
 /**
+ * MetricAggregates
+ *
+ * Structured aggregate values for a single metric, computed from ClickHouse row-level data.
+ */
+export type MetricAggregates = {
+  /**
+   * Avg
+   */
+  avg?: number | null;
+  /**
+   * Sum
+   */
+  sum?: number | null;
+  /**
+   * Min
+   */
+  min?: number | null;
+  /**
+   * Max
+   */
+  max?: number | null;
+  /**
+   * Count
+   */
+  count?: number | null;
+  /**
+   * Pct
+   */
+  pct?: number | null;
+  /**
+   * P50
+   */
+  p50?: number | null;
+  /**
+   * P90
+   */
+  p90?: number | null;
+  /**
+   * P95
+   */
+  p95?: number | null;
+  /**
+   * P99
+   */
+  p99?: number | null;
+  /**
+   * Value Distribution
+   *
+   * Distribution of discrete values as {value: count}. For boolean metrics: {'0': 2, '1': 8}. For categorical metrics: {'low': 5, 'medium': 3, 'high': 2}.
+   */
+  value_distribution?: {
+    [key: string]: number;
+  } | null;
+};
+
+/**
  * MetricAggregation
  */
 export const MetricAggregation = {
@@ -15844,7 +17149,9 @@ export const MetricAggregation = {
   P50: 'P50',
   P90: 'P90',
   P95: 'P95',
-  P99: 'P99'
+  P99: 'P99',
+  PERCENTAGE_FALSE: 'PercentageFalse',
+  PERCENTAGE_TRUE: 'PercentageTrue'
 } as const;
 
 /**
@@ -16059,6 +17366,10 @@ export type MetricComputing = {
   status_type?: 'computing';
   scorer_type?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
+  /**
    * Message
    */
   message?: string;
@@ -16152,6 +17463,10 @@ export type MetricError = {
   status_type?: 'error';
   scorer_type?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
+  /**
    * Message
    */
   message?: string | null;
@@ -16176,6 +17491,10 @@ export type MetricFailed = {
    */
   status_type?: 'failed';
   scorer_type?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
   /**
    * Message
    */
@@ -16202,6 +17521,10 @@ export type MetricNotApplicable = {
   status_type?: 'not_applicable';
   scorer_type?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
+  /**
    * Message
    */
   message?: string;
@@ -16227,6 +17550,10 @@ export type MetricNotComputed = {
   status_type?: 'not_computed';
   scorer_type?: ScorerType | null;
   /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
+  /**
    * Message
    */
   message?: string;
@@ -16241,6 +17568,10 @@ export type MetricPending = {
    */
   status_type?: 'pending';
   scorer_type?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
 };
 
 /**
@@ -16252,6 +17583,10 @@ export type MetricRollUp = {
    */
   status_type?: 'roll_up';
   scorer_type?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
   /**
    * Value
    */
@@ -16348,15 +17683,13 @@ export type MetricRollUp = {
    *
    * Roll up metrics e.g. sum, average, min, max for numeric, and category_count for categorical metrics.
    */
-  roll_up_metrics?:
-    | {
-        [key: string]: number;
-      }
-    | {
-        [key: string]: {
+  roll_up_metrics?: {
+    [key: string]:
+      | number
+      | {
           [key: string]: number;
         };
-      };
+  };
 };
 
 /**
@@ -16402,6 +17735,10 @@ export type MetricSuccess = {
    */
   status_type?: 'success';
   scorer_type?: ScorerType | null;
+  /**
+   * Metric Key Alias
+   */
+  metric_key_alias?: string | null;
   /**
    * Value
    */
@@ -16873,18 +18210,18 @@ export const NodeType = {
 export type NodeType = (typeof NodeType)[keyof typeof NodeType];
 
 /**
- * NotNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * NotNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * Not
      */
     not:
-      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
+      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType;
   };
 
 /**
@@ -17029,18 +18366,18 @@ export type OpenAiToolChoice = {
 };
 
 /**
- * OrNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
+ * OrNode[Annotated[Union[LogRecordsIDFilter, LogRecordsDateFilter, LogRecordsNumberFilter, LogRecordsBooleanFilter, LogRecordsCollectionFilter, LogRecordsTextFilter, LogRecordsFullyAnnotatedFilter], FieldInfo(annotation=NoneType, required=True, discriminator='type')]]
  */
-export type OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
+export type OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType =
   {
     /**
      * Or
      */
     or: Array<
-      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
-      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | FilterLeafAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | AndNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | OrNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
+      | NotNodeAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType
     >;
   };
 
@@ -17330,6 +18667,7 @@ export type PartialExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -17348,6 +18686,7 @@ export type PartialExtendedAgentSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -17504,11 +18843,31 @@ export type PartialExtendedAgentSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -17571,6 +18930,329 @@ export type PartialExtendedAgentSpanRecord = {
    * Agent type.
    */
   agent_type?: AgentType;
+};
+
+/**
+ * PartialExtendedControlSpanRecord
+ */
+export type PartialExtendedControlSpanRecord = {
+  /**
+   * Type
+   *
+   * Type of the trace, span or session.
+   */
+  type?: 'control';
+  /**
+   * Input
+   *
+   * Input to the trace or span.
+   */
+  input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >;
+  /**
+   * Redacted Input
+   *
+   * Redacted input of the trace or span.
+   */
+  redacted_input?:
+    | string
+    | Array<GalileoCoreSchemasLoggingLlmMessage>
+    | Array<
+        | ({
+            type: 'text';
+          } & TextContentPart)
+        | ({
+            type: 'file';
+          } & FileContentPart)
+      >
+    | null;
+  /**
+   * Output of the trace or span.
+   */
+  output?: ControlResult | null;
+  /**
+   * Redacted output of the trace or span.
+   */
+  redacted_output?: ControlResult | null;
+  /**
+   * Name
+   *
+   * Name of the trace, span or session.
+   */
+  name?: string;
+  /**
+   * Created
+   *
+   * Timestamp of the trace or span's creation.
+   */
+  created_at?: string;
+  /**
+   * User Metadata
+   *
+   * Metadata associated with this trace or span.
+   */
+  user_metadata?: {
+    [key: string]: string;
+  };
+  /**
+   * Tags
+   *
+   * Tags associated with this trace or span.
+   */
+  tags?: Array<string>;
+  /**
+   * Status Code
+   *
+   * Status code of the trace or span. Used for logging failure or error states.
+   */
+  status_code?: number | null;
+  /**
+   * Metrics associated with this trace or span.
+   */
+  metrics?: Metrics;
+  /**
+   * External Id
+   *
+   * A user-provided session, trace or span ID.
+   */
+  external_id?: string | null;
+  /**
+   * Dataset Input
+   *
+   * Input to the dataset associated with this trace
+   */
+  dataset_input?: string | null;
+  /**
+   * Dataset Output
+   *
+   * Output from the dataset associated with this trace
+   */
+  dataset_output?: string | null;
+  /**
+   * Dataset Metadata
+   *
+   * Metadata from the dataset associated with this trace
+   */
+  dataset_metadata?: {
+    [key: string]: string;
+  };
+  /**
+   * ID
+   *
+   * Galileo ID of the session, trace or span
+   */
+  id?: string | null;
+  /**
+   * Session ID
+   *
+   * Galileo ID of the session containing the trace (or the same value as id for a trace)
+   */
+  session_id?: string | null;
+  /**
+   * Trace ID
+   *
+   * Galileo ID of the trace containing the span (or the same value as id for a trace)
+   */
+  trace_id?: string | null;
+  /**
+   * Project ID
+   *
+   * Galileo ID of the project associated with this trace or span
+   */
+  project_id?: string | null;
+  /**
+   * Run ID
+   *
+   * Galileo ID of the run (log stream or experiment) associated with this trace or span
+   */
+  run_id?: string | null;
+  /**
+   * Last Updated
+   *
+   * Timestamp of the session or trace or span's last update
+   */
+  updated_at?: string | null;
+  /**
+   * Has Children
+   *
+   * Whether or not this trace or span has child spans
+   */
+  has_children?: boolean | null;
+  /**
+   * Metrics Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  metrics_batch_id?: string | null;
+  /**
+   * Session Batch Id
+   *
+   * Galileo ID of the metrics batch associated with this trace or span
+   */
+  session_batch_id?: string | null;
+  /**
+   * Feedback Rating Info
+   *
+   * Feedback information related to the record
+   */
+  feedback_rating_info?: {
+    [key: string]: FeedbackRatingInfo;
+  };
+  /**
+   * Annotations
+   *
+   * Annotations keyed by template ID and annotator ID
+   */
+  annotations?: {
+    [key: string]: {
+      [key: string]: AnnotationRatingInfo;
+    };
+  };
+  /**
+   * File Ids
+   *
+   * IDs of files associated with this record
+   */
+  file_ids?: Array<string>;
+  /**
+   * File Modalities
+   *
+   * Modalities of files associated with this record
+   */
+  file_modalities?: Array<ContentModality>;
+  /**
+   * Annotation Aggregates
+   *
+   * Annotation aggregate information keyed by template ID
+   */
+  annotation_aggregates?: {
+    [key: string]: AnnotationAggregate;
+  };
+  /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
+   * Annotation Queue Ids
+   *
+   * IDs of annotation queues this record is in
+   */
+  annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
+  /**
+   * Metric Info
+   *
+   * Detailed information about the metrics associated with this trace or span
+   */
+  metric_info?: {
+    [key: string]:
+      | ({
+          status_type: 'not_computed';
+        } & MetricNotComputed)
+      | ({
+          status_type: 'pending';
+        } & MetricPending)
+      | ({
+          status_type: 'computing';
+        } & MetricComputing)
+      | ({
+          status_type: 'not_applicable';
+        } & MetricNotApplicable)
+      | ({
+          status_type: 'success';
+        } & MetricSuccess)
+      | ({
+          status_type: 'error';
+        } & MetricError)
+      | ({
+          status_type: 'failed';
+        } & MetricFailed)
+      | ({
+          status_type: 'roll_up';
+        } & MetricRollUp);
+  } | null;
+  /**
+   * Files
+   *
+   * File metadata keyed by file ID for files associated with this record
+   */
+  files?: {
+    [key: string]: FileMetadata;
+  } | null;
+  /**
+   * Parent ID
+   *
+   * Galileo ID of the parent of this span
+   */
+  parent_id?: string | null;
+  /**
+   * Is Complete
+   *
+   * Whether the parent trace is complete or not
+   */
+  is_complete?: boolean;
+  /**
+   * Step Number
+   *
+   * Topological step number of the span.
+   */
+  step_number?: number | null;
+  /**
+   * Control Id
+   *
+   * Identifier of the control definition that produced this span.
+   */
+  control_id?: number | null;
+  /**
+   * Agent Name
+   *
+   * Normalized agent name associated with this control execution.
+   */
+  agent_name?: string | null;
+  /**
+   * Execution stage where the control ran, typically 'pre' or 'post'.
+   */
+  check_stage?: ControlCheckStage | null;
+  /**
+   * Parent execution type the control applied to, for example 'llm_call' or 'tool_call'.
+   */
+  applies_to?: ControlAppliesTo | null;
+  /**
+   * Evaluator Name
+   *
+   * Representative evaluator name for this control span. For composite controls, this is the primary evaluator chosen for observability identity.
+   */
+  evaluator_name?: string | null;
+  /**
+   * Selector Path
+   *
+   * Representative selector path for this control span. For composite controls, this is the primary selector path chosen for observability identity.
+   */
+  selector_path?: string | null;
 };
 
 /**
@@ -17758,11 +19440,31 @@ export type PartialExtendedLlmSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18069,11 +19771,31 @@ export type PartialExtendedRetrieverSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18192,6 +19914,7 @@ export type PartialExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -18210,6 +19933,7 @@ export type PartialExtendedSessionRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -18366,11 +20090,31 @@ export type PartialExtendedSessionRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18606,11 +20350,31 @@ export type PartialExtendedToolSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -18905,11 +20669,31 @@ export type PartialExtendedTraceRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -19018,6 +20802,7 @@ export type PartialExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -19036,6 +20821,7 @@ export type PartialExtendedWorkflowSpanRecord = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -19192,11 +20978,31 @@ export type PartialExtendedWorkflowSpanRecord = {
     [key: string]: AnnotationAggregate;
   };
   /**
+   * Annotation Agreement
+   *
+   * Annotation agreement scores keyed by template ID
+   */
+  annotation_agreement?: {
+    [key: string]: number;
+  };
+  /**
+   * Overall Annotation Agreement
+   *
+   * Average annotation agreement across all templates in the queue
+   */
+  overall_annotation_agreement?: number | null;
+  /**
    * Annotation Queue Ids
    *
    * IDs of annotation queues this record is in
    */
   annotation_queue_ids?: Array<string>;
+  /**
+   * Fully Annotated
+   *
+   * Whether every field is annotated by every annotator in the queue
+   */
+  fully_annotated?: boolean | null;
   /**
    * Metric Info
    *
@@ -19720,6 +21526,12 @@ export type ProjectItem = {
    * List of labels associated with the project.
    */
   labels?: Array<ProjectLabels>;
+  /**
+   * Log Streams
+   *
+   * Log streams for this project. Only populated when include_logstreams=True.
+   */
+  log_streams?: Array<LogStreamInfo> | null;
 };
 
 /**
@@ -20648,8 +22460,11 @@ export type RecomputeLogRecordsMetricsRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -20994,8 +22809,42 @@ export type RetrieverSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
 };
+
+/**
+ * RollUpMethodDisplayOptions
+ *
+ * Display options for roll up methods when showing rolled up metrics in the UI.
+ *
+ * Separates display intent from computation methods. The computation methods
+ * (NumericRollUpMethod, CategoricalRollUpMethod) control what aggregations are available.
+ * This enum controls how the UI displays the selected roll-up value for a scorer.
+ */
+export const RollUpMethodDisplayOptions = {
+  AVERAGE: 'average',
+  SUM: 'sum',
+  MAX: 'max',
+  MIN: 'min',
+  CATEGORY_COUNT: 'category_count',
+  PERCENTAGE_TRUE: 'percentage_true',
+  PERCENTAGE_FALSE: 'percentage_false'
+} as const;
+
+/**
+ * RollUpMethodDisplayOptions
+ *
+ * Display options for roll up methods when showing rolled up metrics in the UI.
+ *
+ * Separates display intent from computation methods. The computation methods
+ * (NumericRollUpMethod, CategoricalRollUpMethod) control what aggregations are available.
+ * This enum controls how the UI displays the selected roll-up value for a scorer.
+ */
+export type RollUpMethodDisplayOptions =
+  (typeof RollUpMethodDisplayOptions)[keyof typeof RollUpMethodDisplayOptions];
 
 /**
  * RollUpStrategy
@@ -21678,10 +23527,7 @@ export type ScorerConfig = {
    * Multimodal capabilities which this scorer can utilize in its evaluation.
    */
   multimodal_capabilities?: Array<MultimodalCapability> | null;
-  /**
-   * Roll Up Method
-   */
-  roll_up_method?: string | null;
+  roll_up_method?: RollUpMethodDisplayOptions | null;
   /**
    * Score Type
    *
@@ -21821,6 +23667,33 @@ export type ScorerEnabledInRunSort = {
 };
 
 /**
+ * ScorerExcludeMultimodalScorersFilter
+ *
+ * Internal filter: excludes multimodal scorers (non-empty multimodal_capabilities).
+ *
+ * Auto-appended by the service layer when the `multimodal` feature flag is disabled.
+ */
+export type ScorerExcludeMultimodalScorersFilter = {
+  /**
+   * Name
+   */
+  name?: 'exclude_multimodal_scorers';
+};
+
+/**
+ * ScorerExcludeSlmScorersFilter
+ *
+ * Internal filter: excludes scorers with model_type == slm while including
+ * scorers where model_type IS NULL. Auto-appended by the service layer.
+ */
+export type ScorerExcludeSlmScorersFilter = {
+  /**
+   * Name
+   */
+  name?: 'exclude_slm_scorers';
+};
+
+/**
  * ScorerIDFilter
  */
 export type ScorerIdFilter = {
@@ -21872,6 +23745,14 @@ export type ScorerModelTypeFilter = {
    * Name
    */
   name?: 'model_type';
+  /**
+   * Operator
+   */
+  operator: 'eq' | 'ne' | 'one_of' | 'not_in';
+  /**
+   * Value
+   */
+  value: string | Array<string>;
 };
 
 /**
@@ -21958,9 +23839,14 @@ export type ScorerResponse = {
    */
   required_scorers?: Array<string> | null;
   /**
+   * Required Metric Ids
+   */
+  required_metric_ids?: Array<string> | null;
+  /**
    * Deprecated
    */
   deprecated?: boolean | null;
+  roll_up_method?: RollUpMethodDisplayOptions | null;
   roll_up_config?: BaseMetricRollUpConfigDb | null;
   /**
    * Label
@@ -21992,7 +23878,6 @@ export type ScorerResponse = {
    * Updated At
    */
   updated_at?: string | null;
-  roll_up_method?: NumericRollUpMethod | null;
   /**
    * Metric Color Picker Config
    */
@@ -22010,6 +23895,10 @@ export type ScorerResponse = {
         type: 'multi_label';
       } & MetricColorPickerMultiLabel)
     | null;
+  /**
+   * Metric Name
+   */
+  metric_name?: string | null;
 };
 
 /**
@@ -22202,6 +24091,10 @@ export type ScorersConfiguration = {
    * Context Relevance Luna
    */
   context_relevance_luna?: boolean;
+  /**
+   * Chunk Relevance Luna
+   */
+  chunk_relevance_luna?: boolean;
   /**
    * Completeness Nli
    */
@@ -22728,6 +24621,7 @@ export const StepType = {
   TOOL: 'tool',
   WORKFLOW: 'workflow',
   AGENT: 'agent',
+  CONTROL: 'control',
   TRACE: 'trace',
   SESSION: 'session'
 } as const;
@@ -23453,6 +25347,9 @@ export type ToolSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
   /**
    * Tool Call Id
@@ -23691,6 +25588,9 @@ export type Trace = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
 };
 
@@ -23862,11 +25762,7 @@ export type UpdateScorerRequest = {
    * Multimodal Capabilities
    */
   multimodal_capabilities?: Array<MultimodalCapability> | null;
-  /**
-   * Required Scorers
-   */
-  required_scorers?: Array<string> | null;
-  roll_up_method?: NumericRollUpMethod | null;
+  roll_up_method?: RollUpMethodDisplayOptions | null;
   /**
    * Metric Color Picker Config
    */
@@ -23910,7 +25806,11 @@ export type UpsertDatasetContentRequest = {
 export const UserAction = {
   UPDATE: 'update',
   DELETE: 'delete',
-  READ_API_KEYS: 'read_api_keys'
+  READ_API_KEYS: 'read_api_keys',
+  CHANGE_ROLE_TO_ADMIN: 'change_role_to_admin',
+  CHANGE_ROLE_TO_MANAGER: 'change_role_to_manager',
+  CHANGE_ROLE_TO_USER: 'change_role_to_user',
+  CHANGE_ROLE_TO_READ_ONLY: 'change_role_to_read_only'
 } as const;
 
 /**
@@ -24088,6 +25988,20 @@ export type ValidResult = {
 };
 
 /**
+ * ValidateCodeScorerDatasetResponse
+ */
+export type ValidateCodeScorerDatasetResponse = {
+  /**
+   * Metrics Experiment Id
+   */
+  metrics_experiment_id: string;
+  /**
+   * Project Id
+   */
+  project_id: string;
+};
+
+/**
  * ValidateCodeScorerResponse
  */
 export type ValidateCodeScorerResponse = {
@@ -24095,6 +26009,70 @@ export type ValidateCodeScorerResponse = {
    * Task Id
    */
   task_id: string;
+};
+
+/**
+ * ValidateLLMScorerDatasetRequest
+ *
+ * Request to validate a new LLM scorer against a dataset.
+ */
+export type ValidateLlmScorerDatasetRequest = {
+  /**
+   * Query
+   */
+  query: string;
+  /**
+   * Response
+   */
+  response: string;
+  chain_poll_template: ChainPollTemplate;
+  scorer_configuration: GeneratedScorerConfiguration;
+  /**
+   * User Prompt
+   */
+  user_prompt: string;
+  /**
+   * Dataset Id
+   */
+  dataset_id: string;
+  /**
+   * Dataset Version Index
+   */
+  dataset_version_index?: number | null;
+  /**
+   * Limit
+   *
+   * Maximum number of dataset rows to process.
+   */
+  limit?: number;
+  /**
+   * Starting Token
+   *
+   * Pagination offset into dataset rows.
+   */
+  starting_token?: number | null;
+  /**
+   * Sort
+   *
+   * Optional sort configuration for dataset rows.
+   */
+  sort?: {
+    [key: string]: unknown;
+  } | null;
+};
+
+/**
+ * ValidateLLMScorerDatasetResponse
+ */
+export type ValidateLlmScorerDatasetResponse = {
+  /**
+   * Metrics Experiment Id
+   */
+  metrics_experiment_id: string;
+  /**
+   * Project Id
+   */
+  project_id: string;
 };
 
 /**
@@ -24156,8 +26134,11 @@ export type ValidateLlmScorerLogRecordRequest = {
     | ({
         type: 'text';
       } & LogRecordsTextFilter)
+    | ({
+        type: 'fully_annotated';
+      } & LogRecordsFullyAnnotatedFilter)
   >;
-  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
+  filter_tree?: FilterExpressionAnnotatedUnionLogRecordsIdFilterLogRecordsDateFilterLogRecordsNumberFilterLogRecordsBooleanFilterLogRecordsCollectionFilterLogRecordsTextFilterLogRecordsFullyAnnotatedFilterFieldInfoAnnotationNoneTypeRequiredTrueDiscriminatorType | null;
   /**
    * Sort for the query.  Defaults to native sort (created_at, id descending).
    */
@@ -24196,6 +26177,10 @@ export type ValidateLlmScorerLogRecordResponse = {
    * Metrics Experiment Id
    */
   metrics_experiment_id: string;
+  /**
+   * Project Id
+   */
+  project_id: string;
 };
 
 /**
@@ -24214,12 +26199,17 @@ export type ValidateRegisteredScorerResult = {
  * Response model for validating a scorer based on log records.
  *
  * Returns the uuid of the experiment created with the copied log records to store the metric testing results.
+ * Also returns the project_id so callers can poll /projects/{project_id}/traces/search.
  */
 export type ValidateScorerLogRecordResponse = {
   /**
    * Metrics Experiment Id
    */
   metrics_experiment_id: string;
+  /**
+   * Project Id
+   */
+  project_id: string;
 };
 
 /**
@@ -24484,6 +26474,7 @@ export type WorkflowSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Redacted Output
@@ -24502,6 +26493,7 @@ export type WorkflowSpan = {
             type: 'file';
           } & FileContentPart)
       >
+    | ControlResult
     | null;
   /**
    * Name
@@ -24616,6 +26608,9 @@ export type WorkflowSpan = {
     | ({
         type: 'tool';
       } & ToolSpan)
+    | ({
+        type: 'control';
+      } & ControlSpan)
   >;
 };
 
@@ -24890,6 +26885,7 @@ export const GalileoCoreSchemasSharedScorersScorerNameScorerName = {
   CHUNK_ATTRIBUTION_UTILIZATION_LUNA: 'chunk_attribution_utilization_luna',
   CHUNK_ATTRIBUTION_UTILIZATION: 'chunk_attribution_utilization',
   CHUNK_RELEVANCE: 'chunk_relevance',
+  CHUNK_RELEVANCE_LUNA: 'chunk_relevance_luna',
   CONTEXT_PRECISION: 'context_precision',
   PRECISION_AT_K: 'precision_at_k',
   COMPLETENESS_LUNA: 'completeness_luna',
@@ -24901,6 +26897,8 @@ export const GalileoCoreSchemasSharedScorersScorerNameScorerName = {
   CONVERSATION_QUALITY: 'conversation_quality',
   CORRECTNESS: 'correctness',
   GROUND_TRUTH_ADHERENCE: 'ground_truth_adherence',
+  VISUAL_FIDELITY: 'visual_fidelity',
+  VISUAL_QUALITY: 'visual_quality',
   INPUT_PII: 'input_pii',
   INPUT_PII_GPT: 'input_pii_gpt',
   INPUT_SEXIST: 'input_sexist',
@@ -24932,7 +26930,8 @@ export const GalileoCoreSchemasSharedScorersScorerNameScorerName = {
   TOOL_SELECTION_QUALITY: 'tool_selection_quality',
   TOOL_SELECTION_QUALITY_LUNA: 'tool_selection_quality_luna',
   UNCERTAINTY: 'uncertainty',
-  USER_INTENT_CHANGE: 'user_intent_change'
+  USER_INTENT_CHANGE: 'user_intent_change',
+  INTERRUPTION_DETECTION: 'interruption_detection'
 } as const;
 
 /**
@@ -24990,6 +26989,7 @@ export const PromptgalileoSchemasScorerNameScorerName = {
   _CONTEXT_ADHERENCE_LUNA: '_context_adherence_luna',
   _CONTEXT_RELEVANCE: '_context_relevance',
   _CONTEXT_RELEVANCE_LUNA: '_context_relevance_luna',
+  _CHUNK_RELEVANCE_LUNA: '_chunk_relevance_luna',
   _CHUNK_ATTRIBUTION_UTILIZATION_GPT: '_chunk_attribution_utilization_gpt',
   _FACTUALITY: '_factuality',
   _GROUNDEDNESS: '_groundedness',
@@ -27319,642 +29319,6 @@ export type UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSett
 export type UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSettingsPatchResponse =
   UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSettingsPatchResponses[keyof UpdateMetricSettingsProjectsProjectIdLogStreamsLogStreamIdMetricSettingsPatchResponses];
 
-export type LogTracesProjectsProjectIdTracesPostData = {
-  body: LogTracesIngestRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces';
-};
-
-export type LogTracesProjectsProjectIdTracesPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type LogTracesProjectsProjectIdTracesPostError =
-  LogTracesProjectsProjectIdTracesPostErrors[keyof LogTracesProjectsProjectIdTracesPostErrors];
-
-export type LogTracesProjectsProjectIdTracesPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogTracesIngestResponse;
-};
-
-export type LogTracesProjectsProjectIdTracesPostResponse =
-  LogTracesProjectsProjectIdTracesPostResponses[keyof LogTracesProjectsProjectIdTracesPostResponses];
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetData = {
-  body?: never;
-  path: {
-    /**
-     * Trace Id
-     */
-    trace_id: string;
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: {
-    /**
-     * Include Presigned Urls
-     */
-    include_presigned_urls?: boolean;
-  };
-  url: '/projects/{project_id}/traces/{trace_id}';
-};
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetError =
-  GetTraceProjectsProjectIdTracesTraceIdGetErrors[keyof GetTraceProjectsProjectIdTracesTraceIdGetErrors];
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: ExtendedTraceRecordWithChildren;
-};
-
-export type GetTraceProjectsProjectIdTracesTraceIdGetResponse =
-  GetTraceProjectsProjectIdTracesTraceIdGetResponses[keyof GetTraceProjectsProjectIdTracesTraceIdGetResponses];
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchData = {
-  body: LogTraceUpdateRequest;
-  path: {
-    /**
-     * Trace Id
-     */
-    trace_id: string;
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/{trace_id}';
-};
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchError =
-  UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors];
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogTraceUpdateResponse;
-};
-
-export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponse =
-  UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses];
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetData = {
-  body?: never;
-  path: {
-    /**
-     * Span Id
-     */
-    span_id: string;
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: {
-    /**
-     * Include Presigned Urls
-     */
-    include_presigned_urls?: boolean;
-  };
-  url: '/projects/{project_id}/spans/{span_id}';
-};
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetError =
-  GetSpanProjectsProjectIdSpansSpanIdGetErrors[keyof GetSpanProjectsProjectIdSpansSpanIdGetErrors];
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetResponses = {
-  /**
-   * Response Get Span Projects  Project Id  Spans  Span Id  Get
-   *
-   * Successful Response
-   */
-  200:
-    | ({
-        type: 'agent';
-      } & ExtendedAgentSpanRecordWithChildren)
-    | ({
-        type: 'workflow';
-      } & ExtendedWorkflowSpanRecordWithChildren)
-    | ({
-        type: 'llm';
-      } & ExtendedLlmSpanRecord)
-    | ({
-        type: 'tool';
-      } & ExtendedToolSpanRecordWithChildren)
-    | ({
-        type: 'retriever';
-      } & ExtendedRetrieverSpanRecordWithChildren);
-};
-
-export type GetSpanProjectsProjectIdSpansSpanIdGetResponse =
-  GetSpanProjectsProjectIdSpansSpanIdGetResponses[keyof GetSpanProjectsProjectIdSpansSpanIdGetResponses];
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchData = {
-  body: LogSpanUpdateRequest;
-  path: {
-    /**
-     * Span Id
-     */
-    span_id: string;
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/{span_id}';
-};
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchError =
-  UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors];
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogSpanUpdateResponse;
-};
-
-export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponse =
-  UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses];
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostData =
-  {
-    body: MetricsTestingAvailableColumnsRequest;
-    path: {
-      /**
-       * Project Id
-       */
-      project_id: string;
-    };
-    query?: never;
-    url: '/projects/{project_id}/metrics-testing/available_columns';
-  };
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostError =
-  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors];
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsAvailableColumnsResponse;
-  };
-
-export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponse =
-  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses];
-
-export type QueryTracesProjectsProjectIdTracesSearchPostData = {
-  body: LogRecordsQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/search';
-};
-
-export type QueryTracesProjectsProjectIdTracesSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QueryTracesProjectsProjectIdTracesSearchPostError =
-  QueryTracesProjectsProjectIdTracesSearchPostErrors[keyof QueryTracesProjectsProjectIdTracesSearchPostErrors];
-
-export type QueryTracesProjectsProjectIdTracesSearchPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryResponse;
-};
-
-export type QueryTracesProjectsProjectIdTracesSearchPostResponse =
-  QueryTracesProjectsProjectIdTracesSearchPostResponses[keyof QueryTracesProjectsProjectIdTracesSearchPostResponses];
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostData = {
-  body: LogRecordsPartialQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/partial_search';
-};
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostError =
-  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors];
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsPartialQueryResponse;
-  };
-
-export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponse =
-  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses];
-
-export type CountTracesProjectsProjectIdTracesCountPostData = {
-  body: LogRecordsQueryCountRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/count';
-};
-
-export type CountTracesProjectsProjectIdTracesCountPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CountTracesProjectsProjectIdTracesCountPostError =
-  CountTracesProjectsProjectIdTracesCountPostErrors[keyof CountTracesProjectsProjectIdTracesCountPostErrors];
-
-export type CountTracesProjectsProjectIdTracesCountPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryCountResponse;
-};
-
-export type CountTracesProjectsProjectIdTracesCountPostResponse =
-  CountTracesProjectsProjectIdTracesCountPostResponses[keyof CountTracesProjectsProjectIdTracesCountPostResponses];
-
-export type LogSpansProjectsProjectIdSpansPostData = {
-  body: LogSpansIngestRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans';
-};
-
-export type LogSpansProjectsProjectIdSpansPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type LogSpansProjectsProjectIdSpansPostError =
-  LogSpansProjectsProjectIdSpansPostErrors[keyof LogSpansProjectsProjectIdSpansPostErrors];
-
-export type LogSpansProjectsProjectIdSpansPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogSpansIngestResponse;
-};
-
-export type LogSpansProjectsProjectIdSpansPostResponse =
-  LogSpansProjectsProjectIdSpansPostResponses[keyof LogSpansProjectsProjectIdSpansPostResponses];
-
-export type QuerySpansProjectsProjectIdSpansSearchPostData = {
-  body: LogRecordsQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/search';
-};
-
-export type QuerySpansProjectsProjectIdSpansSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QuerySpansProjectsProjectIdSpansSearchPostError =
-  QuerySpansProjectsProjectIdSpansSearchPostErrors[keyof QuerySpansProjectsProjectIdSpansSearchPostErrors];
-
-export type QuerySpansProjectsProjectIdSpansSearchPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryResponse;
-};
-
-export type QuerySpansProjectsProjectIdSpansSearchPostResponse =
-  QuerySpansProjectsProjectIdSpansSearchPostResponses[keyof QuerySpansProjectsProjectIdSpansSearchPostResponses];
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostData = {
-  body: LogRecordsPartialQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/partial_search';
-};
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostError =
-  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors];
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsPartialQueryResponse;
-  };
-
-export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponse =
-  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses];
-
-export type CountSpansProjectsProjectIdSpansCountPostData = {
-  body: LogRecordsQueryCountRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/count';
-};
-
-export type CountSpansProjectsProjectIdSpansCountPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CountSpansProjectsProjectIdSpansCountPostError =
-  CountSpansProjectsProjectIdSpansCountPostErrors[keyof CountSpansProjectsProjectIdSpansCountPostErrors];
-
-export type CountSpansProjectsProjectIdSpansCountPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryCountResponse;
-};
-
-export type CountSpansProjectsProjectIdSpansCountPostResponse =
-  CountSpansProjectsProjectIdSpansCountPostResponses[keyof CountSpansProjectsProjectIdSpansCountPostResponses];
-
-export type CreateSessionProjectsProjectIdSessionsPostData = {
-  body: SessionCreateRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions';
-};
-
-export type CreateSessionProjectsProjectIdSessionsPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CreateSessionProjectsProjectIdSessionsPostError =
-  CreateSessionProjectsProjectIdSessionsPostErrors[keyof CreateSessionProjectsProjectIdSessionsPostErrors];
-
-export type CreateSessionProjectsProjectIdSessionsPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: SessionCreateResponse;
-};
-
-export type CreateSessionProjectsProjectIdSessionsPostResponse =
-  CreateSessionProjectsProjectIdSessionsPostResponses[keyof CreateSessionProjectsProjectIdSessionsPostResponses];
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostData = {
-  body: LogRecordsQueryRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions/search';
-};
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostError =
-  QuerySessionsProjectsProjectIdSessionsSearchPostErrors[keyof QuerySessionsProjectsProjectIdSessionsSearchPostErrors];
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryResponse;
-};
-
-export type QuerySessionsProjectsProjectIdSessionsSearchPostResponse =
-  QuerySessionsProjectsProjectIdSessionsSearchPostResponses[keyof QuerySessionsProjectsProjectIdSessionsSearchPostResponses];
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostData =
-  {
-    body: LogRecordsPartialQueryRequest;
-    path: {
-      /**
-       * Project Id
-       */
-      project_id: string;
-    };
-    query?: never;
-    url: '/projects/{project_id}/sessions/partial_search';
-  };
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostError =
-  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors];
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: LogRecordsPartialQueryResponse;
-  };
-
-export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponse =
-  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses];
-
-export type CountSessionsProjectsProjectIdSessionsCountPostData = {
-  body: LogRecordsQueryCountRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions/count';
-};
-
-export type CountSessionsProjectsProjectIdSessionsCountPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type CountSessionsProjectsProjectIdSessionsCountPostError =
-  CountSessionsProjectsProjectIdSessionsCountPostErrors[keyof CountSessionsProjectsProjectIdSessionsCountPostErrors];
-
-export type CountSessionsProjectsProjectIdSessionsCountPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsQueryCountResponse;
-};
-
-export type CountSessionsProjectsProjectIdSessionsCountPostResponse =
-  CountSessionsProjectsProjectIdSessionsCountPostResponses[keyof CountSessionsProjectsProjectIdSessionsCountPostResponses];
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetData = {
-  body?: never;
-  path: {
-    /**
-     * Session Id
-     */
-    session_id: string;
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: {
-    /**
-     * Include Presigned Urls
-     */
-    include_presigned_urls?: boolean;
-  };
-  url: '/projects/{project_id}/sessions/{session_id}';
-};
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetError =
-  GetSessionProjectsProjectIdSessionsSessionIdGetErrors[keyof GetSessionProjectsProjectIdSessionsSessionIdGetErrors];
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetResponses = {
-  /**
-   * Successful Response
-   */
-  200: ExtendedSessionRecordWithChildren;
-};
-
-export type GetSessionProjectsProjectIdSessionsSessionIdGetResponse =
-  GetSessionProjectsProjectIdSessionsSessionIdGetResponses[keyof GetSessionProjectsProjectIdSessionsSessionIdGetResponses];
-
 export type GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostData = {
   body: AggregatedTraceViewRequest;
   path: {
@@ -27989,35 +29353,6 @@ export type GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponses
 export type GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponse =
   GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponses[keyof GetAggregatedTraceViewProjectsProjectIdTracesAggregatedPostResponses];
 
-export type ExportRecordsProjectsProjectIdExportRecordsPostData = {
-  body: LogRecordsExportRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/export_records';
-};
-
-export type ExportRecordsProjectsProjectIdExportRecordsPostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type ExportRecordsProjectsProjectIdExportRecordsPostError =
-  ExportRecordsProjectsProjectIdExportRecordsPostErrors[keyof ExportRecordsProjectsProjectIdExportRecordsPostErrors];
-
-export type ExportRecordsProjectsProjectIdExportRecordsPostResponses = {
-  /**
-   * Successful Response
-   */
-  200: unknown;
-};
-
 export type RecomputeMetricsProjectsProjectIdRecomputeMetricsPostData = {
   body: RecomputeLogRecordsMetricsRequest;
   path: {
@@ -28046,102 +29381,6 @@ export type RecomputeMetricsProjectsProjectIdRecomputeMetricsPostResponses = {
    */
   200: unknown;
 };
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostData = {
-  body: LogRecordsDeleteRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/traces/delete';
-};
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostError =
-  DeleteTracesProjectsProjectIdTracesDeletePostErrors[keyof DeleteTracesProjectsProjectIdTracesDeletePostErrors];
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsDeleteResponse;
-};
-
-export type DeleteTracesProjectsProjectIdTracesDeletePostResponse =
-  DeleteTracesProjectsProjectIdTracesDeletePostResponses[keyof DeleteTracesProjectsProjectIdTracesDeletePostResponses];
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostData = {
-  body: LogRecordsDeleteRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/spans/delete';
-};
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostError =
-  DeleteSpansProjectsProjectIdSpansDeletePostErrors[keyof DeleteSpansProjectsProjectIdSpansDeletePostErrors];
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsDeleteResponse;
-};
-
-export type DeleteSpansProjectsProjectIdSpansDeletePostResponse =
-  DeleteSpansProjectsProjectIdSpansDeletePostResponses[keyof DeleteSpansProjectsProjectIdSpansDeletePostResponses];
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostData = {
-  body: LogRecordsDeleteRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/sessions/delete';
-};
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostError =
-  DeleteSessionsProjectsProjectIdSessionsDeletePostErrors[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostErrors];
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponses = {
-  /**
-   * Successful Response
-   */
-  200: LogRecordsDeleteResponse;
-};
-
-export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponse =
-  DeleteSessionsProjectsProjectIdSessionsDeletePostResponses[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostResponses];
 
 export type ListExperimentsProjectsProjectIdExperimentsGetData = {
   body?: never;
@@ -28442,79 +29681,6 @@ export type ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColu
 
 export type ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColumnsPostResponse =
   ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColumnsPostResponses[keyof ExperimentsAvailableColumnsProjectsProjectIdExperimentsAvailableColumnsPostResponses];
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostData =
-  {
-    body: ExperimentMetricsRequest;
-    path: {
-      /**
-       * Project Id
-       */
-      project_id: string;
-      /**
-       * Experiment Id
-       */
-      experiment_id: string;
-    };
-    query?: never;
-    url: '/projects/{project_id}/experiments/{experiment_id}/metrics';
-  };
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostError =
-  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors];
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: ExperimentMetricsResponse;
-  };
-
-export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponse =
-  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses];
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostData = {
-  body: ExperimentMetricsRequest;
-  path: {
-    /**
-     * Project Id
-     */
-    project_id: string;
-  };
-  query?: never;
-  url: '/projects/{project_id}/experiments/metrics';
-};
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors =
-  {
-    /**
-     * Validation Error
-     */
-    422: HttpValidationError;
-  };
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostError =
-  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors];
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses =
-  {
-    /**
-     * Successful Response
-     */
-    200: ExperimentMetricsResponse;
-  };
-
-export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponse =
-  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses];
 
 export type GetMetricSettingsProjectsProjectIdExperimentsExperimentIdMetricSettingsGetData =
   {
@@ -30891,25 +32057,6 @@ export type UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTa
 export type UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTagIdPutResponse =
   UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTagIdPutResponses[keyof UpdateTagForExperimentProjectsProjectIdExperimentsExperimentIdTagsTagIdPutResponses];
 
-export type ListIntegrationsIntegrationsGetData = {
-  body?: never;
-  path?: never;
-  query?: never;
-  url: '/integrations';
-};
-
-export type ListIntegrationsIntegrationsGetResponses = {
-  /**
-   * Response List Integrations Integrations Get
-   *
-   * Successful Response
-   */
-  200: Array<IntegrationDb>;
-};
-
-export type ListIntegrationsIntegrationsGetResponse =
-  ListIntegrationsIntegrationsGetResponses[keyof ListIntegrationsIntegrationsGetResponses];
-
 export type ListAvailableIntegrationsIntegrationsAvailableGetData = {
   body?: never;
   path?: never;
@@ -31883,65 +33030,19 @@ export type GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGet
 export type GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGetResponse =
   GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGetResponses[keyof GetAvailableScorerModelsLlmIntegrationsLlmIntegrationScorerModelsGetResponses];
 
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetData = {
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetData = {
   body?: never;
-  path?: never;
-  query?: {
+  path: {
     /**
-     * Multimodal Capabilities
+     * Dataset Id
      */
-    multimodal_capabilities?: Array<MultimodalCapability> | null;
+    dataset_id: string;
   };
-  url: '/llm_integrations';
+  query?: never;
+  url: '/datasets/{dataset_id}/variable_preview';
 };
 
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetErrors = {
-  /**
-   * Validation Error
-   */
-  422: HttpValidationError;
-};
-
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetError =
-  GetIntegrationsAndModelInfoLlmIntegrationsGetErrors[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetErrors];
-
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponses = {
-  /**
-   * Response Get Integrations And Model Info Llm Integrations Get
-   *
-   * Successful Response
-   */
-  200: {
-    [key in LlmIntegration]?: IntegrationModelsResponse;
-  };
-};
-
-export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponse =
-  GetIntegrationsAndModelInfoLlmIntegrationsGetResponses[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetResponses];
-
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetData =
-  {
-    body?: never;
-    path: {
-      /**
-       * Project Id
-       */
-      project_id: string;
-      /**
-       * Run Id
-       */
-      run_id: string;
-    };
-    query?: {
-      /**
-       * Multimodal Capabilities
-       */
-      multimodal_capabilities?: Array<MultimodalCapability> | null;
-    };
-    url: '/llm_integrations/projects/{project_id}/runs/{run_id}';
-  };
-
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors =
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetErrors =
   {
     /**
      * Validation Error
@@ -31949,23 +33050,94 @@ export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRun
     422: HttpValidationError;
   };
 
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetError =
-  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors];
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetError =
+  GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetErrors[keyof GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetErrors];
 
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses =
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponses =
   {
     /**
-     * Response Get Integrations And Model Info For Run Llm Integrations Projects  Project Id  Runs  Run Id  Get
+     * Response Get Dataset Variable Preview Datasets  Dataset Id  Variable Preview Get
      *
      * Successful Response
      */
-    200: {
-      [key in LlmIntegration]?: IntegrationModelsResponse;
-    };
+    200: Array<DatasetInputJsonField>;
   };
 
-export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponse =
-  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses];
+export type GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponse =
+  GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponses[keyof GetDatasetVariablePreviewDatasetsDatasetIdVariablePreviewGetResponses];
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostData =
+  {
+    body: ExperimentMetricsRequest;
+    path: {
+      /**
+       * Project Id
+       */
+      project_id: string;
+      /**
+       * Experiment Id
+       */
+      experiment_id: string;
+    };
+    query?: never;
+    url: '/projects/{project_id}/experiments/{experiment_id}/metrics';
+  };
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostError =
+  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostErrors];
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ExperimentMetricsResponse;
+  };
+
+export type GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponse =
+  GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses[keyof GetExperimentMetricsProjectsProjectIdExperimentsExperimentIdMetricsPostResponses];
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostData = {
+  body: ExperimentMetricsRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/experiments/metrics';
+};
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostError =
+  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostErrors];
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: ExperimentMetricsResponse;
+  };
+
+export type GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponse =
+  GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses[keyof GetExperimentsMetricsProjectsProjectIdExperimentsMetricsPostResponses];
 
 export type CreateScorersPostData = {
   body: CreateScorerRequest;
@@ -32083,6 +33255,266 @@ export type ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponses =
 export type ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponse =
   ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponses[keyof ValidateLlmScorerLogRecordScorersLlmValidateLogRecordPostResponses];
 
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostData = {
+  body: ValidateLlmScorerDatasetRequest;
+  path?: never;
+  query?: never;
+  url: '/scorers/llm/validate/dataset';
+};
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostError =
+  ValidateLlmScorerDatasetScorersLlmValidateDatasetPostErrors[keyof ValidateLlmScorerDatasetScorersLlmValidateDatasetPostErrors];
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: ValidateLlmScorerDatasetResponse;
+};
+
+export type ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponse =
+  ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponses[keyof ValidateLlmScorerDatasetScorersLlmValidateDatasetPostResponses];
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostData = {
+  body: BodyValidateCodeScorerDatasetScorersCodeValidateDatasetPost;
+  path?: never;
+  query?: never;
+  url: '/scorers/code/validate/dataset';
+};
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostError =
+  ValidateCodeScorerDatasetScorersCodeValidateDatasetPostErrors[keyof ValidateCodeScorerDatasetScorersCodeValidateDatasetPostErrors];
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: ValidateCodeScorerDatasetResponse;
+};
+
+export type ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponse =
+  ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponses[keyof ValidateCodeScorerDatasetScorersCodeValidateDatasetPostResponses];
+
+export type LogTracesProjectsProjectIdTracesPostData = {
+  body: LogTracesIngestRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces';
+};
+
+export type LogTracesProjectsProjectIdTracesPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type LogTracesProjectsProjectIdTracesPostError =
+  LogTracesProjectsProjectIdTracesPostErrors[keyof LogTracesProjectsProjectIdTracesPostErrors];
+
+export type LogTracesProjectsProjectIdTracesPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogTracesIngestResponse;
+};
+
+export type LogTracesProjectsProjectIdTracesPostResponse =
+  LogTracesProjectsProjectIdTracesPostResponses[keyof LogTracesProjectsProjectIdTracesPostResponses];
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetData = {
+  body?: never;
+  path: {
+    /**
+     * Trace Id
+     */
+    trace_id: string;
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: {
+    /**
+     * Include Presigned Urls
+     */
+    include_presigned_urls?: boolean;
+  };
+  url: '/projects/{project_id}/traces/{trace_id}';
+};
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetError =
+  GetTraceProjectsProjectIdTracesTraceIdGetErrors[keyof GetTraceProjectsProjectIdTracesTraceIdGetErrors];
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: ExtendedTraceRecordWithChildren;
+};
+
+export type GetTraceProjectsProjectIdTracesTraceIdGetResponse =
+  GetTraceProjectsProjectIdTracesTraceIdGetResponses[keyof GetTraceProjectsProjectIdTracesTraceIdGetResponses];
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchData = {
+  body: LogTraceUpdateRequest;
+  path: {
+    /**
+     * Trace Id
+     */
+    trace_id: string;
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/{trace_id}';
+};
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchError =
+  UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchErrors];
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogTraceUpdateResponse;
+};
+
+export type UpdateTraceProjectsProjectIdTracesTraceIdPatchResponse =
+  UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses[keyof UpdateTraceProjectsProjectIdTracesTraceIdPatchResponses];
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetData = {
+  body?: never;
+  path: {
+    /**
+     * Span Id
+     */
+    span_id: string;
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: {
+    /**
+     * Include Presigned Urls
+     */
+    include_presigned_urls?: boolean;
+  };
+  url: '/projects/{project_id}/spans/{span_id}';
+};
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetError =
+  GetSpanProjectsProjectIdSpansSpanIdGetErrors[keyof GetSpanProjectsProjectIdSpansSpanIdGetErrors];
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetResponses = {
+  /**
+   * Response Get Span Projects  Project Id  Spans  Span Id  Get
+   *
+   * Successful Response
+   */
+  200:
+    | ({
+        type: 'agent';
+      } & ExtendedAgentSpanRecordWithChildren)
+    | ({
+        type: 'workflow';
+      } & ExtendedWorkflowSpanRecordWithChildren)
+    | ({
+        type: 'llm';
+      } & ExtendedLlmSpanRecord)
+    | ({
+        type: 'tool';
+      } & ExtendedToolSpanRecordWithChildren)
+    | ({
+        type: 'retriever';
+      } & ExtendedRetrieverSpanRecordWithChildren)
+    | ({
+        type: 'control';
+      } & ExtendedControlSpanRecord);
+};
+
+export type GetSpanProjectsProjectIdSpansSpanIdGetResponse =
+  GetSpanProjectsProjectIdSpansSpanIdGetResponses[keyof GetSpanProjectsProjectIdSpansSpanIdGetResponses];
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchData = {
+  body: LogSpanUpdateRequest;
+  path: {
+    /**
+     * Span Id
+     */
+    span_id: string;
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/{span_id}';
+};
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchError =
+  UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchErrors];
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogSpanUpdateResponse;
+};
+
+export type UpdateSpanProjectsProjectIdSpansSpanIdPatchResponse =
+  UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses[keyof UpdateSpanProjectsProjectIdSpansSpanIdPatchResponses];
+
 export type TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostData =
   {
     body: LogRecordsAvailableColumnsRequest;
@@ -32117,6 +33549,41 @@ export type TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostRes
 
 export type TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostResponse =
   TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostResponses[keyof TracesAvailableColumnsProjectsProjectIdTracesAvailableColumnsPostResponses];
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostData =
+  {
+    body: MetricsTestingAvailableColumnsRequest;
+    path: {
+      /**
+       * Project Id
+       */
+      project_id: string;
+    };
+    query?: never;
+    url: '/projects/{project_id}/metrics-testing/available_columns';
+  };
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostError =
+  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostErrors];
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsAvailableColumnsResponse;
+  };
+
+export type MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponse =
+  MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses[keyof MetricsTestingAvailableColumnsProjectsProjectIdMetricsTestingAvailableColumnsPostResponses];
 
 export type SpansAvailableColumnsProjectsProjectIdSpansAvailableColumnsPostData =
   {
@@ -32187,6 +33654,232 @@ export type SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPos
 
 export type SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPostResponse =
   SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPostResponses[keyof SessionsAvailableColumnsProjectsProjectIdSessionsAvailableColumnsPostResponses];
+
+export type QueryTracesProjectsProjectIdTracesSearchPostData = {
+  body: LogRecordsQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/search';
+};
+
+export type QueryTracesProjectsProjectIdTracesSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryTracesProjectsProjectIdTracesSearchPostError =
+  QueryTracesProjectsProjectIdTracesSearchPostErrors[keyof QueryTracesProjectsProjectIdTracesSearchPostErrors];
+
+export type QueryTracesProjectsProjectIdTracesSearchPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryResponse;
+};
+
+export type QueryTracesProjectsProjectIdTracesSearchPostResponse =
+  QueryTracesProjectsProjectIdTracesSearchPostResponses[keyof QueryTracesProjectsProjectIdTracesSearchPostResponses];
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostData = {
+  body: LogRecordsPartialQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/partial_search';
+};
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostError =
+  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostErrors];
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsPartialQueryResponse;
+  };
+
+export type QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponse =
+  QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses[keyof QueryPartialTracesProjectsProjectIdTracesPartialSearchPostResponses];
+
+export type CountTracesProjectsProjectIdTracesCountPostData = {
+  body: LogRecordsQueryCountRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/count';
+};
+
+export type CountTracesProjectsProjectIdTracesCountPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CountTracesProjectsProjectIdTracesCountPostError =
+  CountTracesProjectsProjectIdTracesCountPostErrors[keyof CountTracesProjectsProjectIdTracesCountPostErrors];
+
+export type CountTracesProjectsProjectIdTracesCountPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryCountResponse;
+};
+
+export type CountTracesProjectsProjectIdTracesCountPostResponse =
+  CountTracesProjectsProjectIdTracesCountPostResponses[keyof CountTracesProjectsProjectIdTracesCountPostResponses];
+
+export type LogSpansProjectsProjectIdSpansPostData = {
+  body: LogSpansIngestRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans';
+};
+
+export type LogSpansProjectsProjectIdSpansPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type LogSpansProjectsProjectIdSpansPostError =
+  LogSpansProjectsProjectIdSpansPostErrors[keyof LogSpansProjectsProjectIdSpansPostErrors];
+
+export type LogSpansProjectsProjectIdSpansPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogSpansIngestResponse;
+};
+
+export type LogSpansProjectsProjectIdSpansPostResponse =
+  LogSpansProjectsProjectIdSpansPostResponses[keyof LogSpansProjectsProjectIdSpansPostResponses];
+
+export type QuerySpansProjectsProjectIdSpansSearchPostData = {
+  body: LogRecordsQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/search';
+};
+
+export type QuerySpansProjectsProjectIdSpansSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QuerySpansProjectsProjectIdSpansSearchPostError =
+  QuerySpansProjectsProjectIdSpansSearchPostErrors[keyof QuerySpansProjectsProjectIdSpansSearchPostErrors];
+
+export type QuerySpansProjectsProjectIdSpansSearchPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryResponse;
+};
+
+export type QuerySpansProjectsProjectIdSpansSearchPostResponse =
+  QuerySpansProjectsProjectIdSpansSearchPostResponses[keyof QuerySpansProjectsProjectIdSpansSearchPostResponses];
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostData = {
+  body: LogRecordsPartialQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/partial_search';
+};
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostError =
+  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostErrors];
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsPartialQueryResponse;
+  };
+
+export type QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponse =
+  QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses[keyof QueryPartialSpansProjectsProjectIdSpansPartialSearchPostResponses];
+
+export type CountSpansProjectsProjectIdSpansCountPostData = {
+  body: LogRecordsQueryCountRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/count';
+};
+
+export type CountSpansProjectsProjectIdSpansCountPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CountSpansProjectsProjectIdSpansCountPostError =
+  CountSpansProjectsProjectIdSpansCountPostErrors[keyof CountSpansProjectsProjectIdSpansCountPostErrors];
+
+export type CountSpansProjectsProjectIdSpansCountPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryCountResponse;
+};
+
+export type CountSpansProjectsProjectIdSpansCountPostResponse =
+  CountSpansProjectsProjectIdSpansCountPostResponses[keyof CountSpansProjectsProjectIdSpansCountPostResponses];
 
 export type QueryMetricsProjectsProjectIdMetricsSearchPostData = {
   body: LogRecordsMetricsQueryRequest;
@@ -32284,3 +33977,516 @@ export type QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponses 
 
 export type QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponse =
   QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponses[keyof QueryCustomMetricsProjectsProjectIdMetricsCustomSearchPostResponses];
+
+export type CreateSessionProjectsProjectIdSessionsPostData = {
+  body: SessionCreateRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions';
+};
+
+export type CreateSessionProjectsProjectIdSessionsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateSessionProjectsProjectIdSessionsPostError =
+  CreateSessionProjectsProjectIdSessionsPostErrors[keyof CreateSessionProjectsProjectIdSessionsPostErrors];
+
+export type CreateSessionProjectsProjectIdSessionsPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: SessionCreateResponse;
+};
+
+export type CreateSessionProjectsProjectIdSessionsPostResponse =
+  CreateSessionProjectsProjectIdSessionsPostResponses[keyof CreateSessionProjectsProjectIdSessionsPostResponses];
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostData = {
+  body: LogRecordsQueryRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions/search';
+};
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostError =
+  QuerySessionsProjectsProjectIdSessionsSearchPostErrors[keyof QuerySessionsProjectsProjectIdSessionsSearchPostErrors];
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryResponse;
+};
+
+export type QuerySessionsProjectsProjectIdSessionsSearchPostResponse =
+  QuerySessionsProjectsProjectIdSessionsSearchPostResponses[keyof QuerySessionsProjectsProjectIdSessionsSearchPostResponses];
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostData =
+  {
+    body: LogRecordsPartialQueryRequest;
+    path: {
+      /**
+       * Project Id
+       */
+      project_id: string;
+    };
+    query?: never;
+    url: '/projects/{project_id}/sessions/partial_search';
+  };
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostError =
+  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostErrors];
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: LogRecordsPartialQueryResponse;
+  };
+
+export type QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponse =
+  QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses[keyof QueryPartialSessionsProjectsProjectIdSessionsPartialSearchPostResponses];
+
+export type CountSessionsProjectsProjectIdSessionsCountPostData = {
+  body: LogRecordsQueryCountRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions/count';
+};
+
+export type CountSessionsProjectsProjectIdSessionsCountPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CountSessionsProjectsProjectIdSessionsCountPostError =
+  CountSessionsProjectsProjectIdSessionsCountPostErrors[keyof CountSessionsProjectsProjectIdSessionsCountPostErrors];
+
+export type CountSessionsProjectsProjectIdSessionsCountPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsQueryCountResponse;
+};
+
+export type CountSessionsProjectsProjectIdSessionsCountPostResponse =
+  CountSessionsProjectsProjectIdSessionsCountPostResponses[keyof CountSessionsProjectsProjectIdSessionsCountPostResponses];
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetData = {
+  body?: never;
+  path: {
+    /**
+     * Session Id
+     */
+    session_id: string;
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: {
+    /**
+     * Include Presigned Urls
+     */
+    include_presigned_urls?: boolean;
+  };
+  url: '/projects/{project_id}/sessions/{session_id}';
+};
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetError =
+  GetSessionProjectsProjectIdSessionsSessionIdGetErrors[keyof GetSessionProjectsProjectIdSessionsSessionIdGetErrors];
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetResponses = {
+  /**
+   * Successful Response
+   */
+  200: ExtendedSessionRecordWithChildren;
+};
+
+export type GetSessionProjectsProjectIdSessionsSessionIdGetResponse =
+  GetSessionProjectsProjectIdSessionsSessionIdGetResponses[keyof GetSessionProjectsProjectIdSessionsSessionIdGetResponses];
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostData = {
+  body: LogRecordsExportRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/export_records';
+};
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostError =
+  ExportRecordsProjectsProjectIdExportRecordsPostErrors[keyof ExportRecordsProjectsProjectIdExportRecordsPostErrors];
+
+export type ExportRecordsProjectsProjectIdExportRecordsPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: unknown;
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostData = {
+  body: LogRecordsDeleteRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/traces/delete';
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostError =
+  DeleteTracesProjectsProjectIdTracesDeletePostErrors[keyof DeleteTracesProjectsProjectIdTracesDeletePostErrors];
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsDeleteResponse;
+};
+
+export type DeleteTracesProjectsProjectIdTracesDeletePostResponse =
+  DeleteTracesProjectsProjectIdTracesDeletePostResponses[keyof DeleteTracesProjectsProjectIdTracesDeletePostResponses];
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostData = {
+  body: LogRecordsDeleteRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/spans/delete';
+};
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostError =
+  DeleteSpansProjectsProjectIdSpansDeletePostErrors[keyof DeleteSpansProjectsProjectIdSpansDeletePostErrors];
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsDeleteResponse;
+};
+
+export type DeleteSpansProjectsProjectIdSpansDeletePostResponse =
+  DeleteSpansProjectsProjectIdSpansDeletePostResponses[keyof DeleteSpansProjectsProjectIdSpansDeletePostResponses];
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostData = {
+  body: LogRecordsDeleteRequest;
+  path: {
+    /**
+     * Project Id
+     */
+    project_id: string;
+  };
+  query?: never;
+  url: '/projects/{project_id}/sessions/delete';
+};
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostError =
+  DeleteSessionsProjectsProjectIdSessionsDeletePostErrors[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostErrors];
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: LogRecordsDeleteResponse;
+};
+
+export type DeleteSessionsProjectsProjectIdSessionsDeletePostResponse =
+  DeleteSessionsProjectsProjectIdSessionsDeletePostResponses[keyof DeleteSessionsProjectsProjectIdSessionsDeletePostResponses];
+
+export type ListIntegrationsIntegrationsGetData = {
+  body?: never;
+  path?: never;
+  query?: never;
+  url: '/integrations';
+};
+
+export type ListIntegrationsIntegrationsGetResponses = {
+  /**
+   * Response List Integrations Integrations Get
+   *
+   * Successful Response
+   */
+  200: Array<IntegrationDb>;
+};
+
+export type ListIntegrationsIntegrationsGetResponse =
+  ListIntegrationsIntegrationsGetResponses[keyof ListIntegrationsIntegrationsGetResponses];
+
+export type SelectIntegrationIntegrationsSelectPostData = {
+  body: IntegrationSelectRequest;
+  path?: never;
+  query?: never;
+  url: '/integrations/select';
+};
+
+export type SelectIntegrationIntegrationsSelectPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type SelectIntegrationIntegrationsSelectPostError =
+  SelectIntegrationIntegrationsSelectPostErrors[keyof SelectIntegrationIntegrationsSelectPostErrors];
+
+export type SelectIntegrationIntegrationsSelectPostResponses = {
+  /**
+   * Successful Response
+   */
+  200: IntegrationDb;
+};
+
+export type SelectIntegrationIntegrationsSelectPostResponse =
+  SelectIntegrationIntegrationsSelectPostResponses[keyof SelectIntegrationIntegrationsSelectPostResponses];
+
+export type DisableIntegrationIntegrationsDisablePostData = {
+  body: IntegrationDisableRequest;
+  path?: never;
+  query?: never;
+  url: '/integrations/disable';
+};
+
+export type DisableIntegrationIntegrationsDisablePostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type DisableIntegrationIntegrationsDisablePostError =
+  DisableIntegrationIntegrationsDisablePostErrors[keyof DisableIntegrationIntegrationsDisablePostErrors];
+
+export type DisableIntegrationIntegrationsDisablePostResponses = {
+  /**
+   * Successful Response
+   */
+  200: unknown;
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetData = {
+  body?: never;
+  path?: never;
+  query?: {
+    /**
+     * Multimodal Capabilities
+     */
+    multimodal_capabilities?: Array<MultimodalCapability> | null;
+  };
+  url: '/llm_integrations';
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetError =
+  GetIntegrationsAndModelInfoLlmIntegrationsGetErrors[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetErrors];
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponses = {
+  /**
+   * Response Get Integrations And Model Info Llm Integrations Get
+   *
+   * Successful Response
+   */
+  200: {
+    [key in LlmIntegration]?: IntegrationModelsResponse;
+  };
+};
+
+export type GetIntegrationsAndModelInfoLlmIntegrationsGetResponse =
+  GetIntegrationsAndModelInfoLlmIntegrationsGetResponses[keyof GetIntegrationsAndModelInfoLlmIntegrationsGetResponses];
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetData =
+  {
+    body?: never;
+    path: {
+      /**
+       * Project Id
+       */
+      project_id: string;
+      /**
+       * Run Id
+       */
+      run_id: string;
+    };
+    query?: {
+      /**
+       * Multimodal Capabilities
+       */
+      multimodal_capabilities?: Array<MultimodalCapability> | null;
+    };
+    url: '/llm_integrations/projects/{project_id}/runs/{run_id}';
+  };
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetError =
+  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetErrors];
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses =
+  {
+    /**
+     * Response Get Integrations And Model Info For Run Llm Integrations Projects  Project Id  Runs  Run Id  Get
+     *
+     * Successful Response
+     */
+    200: {
+      [key in LlmIntegration]?: IntegrationModelsResponse;
+    };
+  };
+
+export type GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponse =
+  GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses[keyof GetIntegrationsAndModelInfoForRunLlmIntegrationsProjectsProjectIdRunsRunIdGetResponses];
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostData = {
+  body: CreateCodeMetricGenerationRequest;
+  path?: never;
+  query?: never;
+  url: '/code-metric-generations';
+};
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostErrors = {
+  /**
+   * Validation Error
+   */
+  422: HttpValidationError;
+};
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostError =
+  CreateCodeMetricGenerationCodeMetricGenerationsPostErrors[keyof CreateCodeMetricGenerationCodeMetricGenerationsPostErrors];
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostResponses = {
+  /**
+   * Successful Response
+   */
+  202: CreateCodeMetricGenerationResponse;
+};
+
+export type CreateCodeMetricGenerationCodeMetricGenerationsPostResponse =
+  CreateCodeMetricGenerationCodeMetricGenerationsPostResponses[keyof CreateCodeMetricGenerationCodeMetricGenerationsPostResponses];
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetData =
+  {
+    body?: never;
+    path: {
+      /**
+       * Generation Id
+       */
+      generation_id: string;
+    };
+    query?: never;
+    url: '/code-metric-generations/{generation_id}/status';
+  };
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetErrors =
+  {
+    /**
+     * Validation Error
+     */
+    422: HttpValidationError;
+  };
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetError =
+  GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetErrors[keyof GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetErrors];
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponses =
+  {
+    /**
+     * Successful Response
+     */
+    200: CodeMetricGenerationStatusResponse;
+  };
+
+export type GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponse =
+  GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponses[keyof GetCodeMetricGenerationStatusCodeMetricGenerationsGenerationIdStatusGetResponses];

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -2,6 +2,7 @@ import type {
   ExperimentResponseType,
   ExperimentDatasetRequest,
   ExperimentUpdateRequest,
+  ExperimentsAvailableColumnsResponse,
   RunExperimentParams,
   RunExperimentOutput
 } from '../types/experiment.types';
@@ -157,4 +158,30 @@ export async function deleteExperiment(options: {
   }
   const experiments = new Experiments();
   return await experiments.deleteExperiment(options);
+}
+
+/**
+ * Returns available columns for the experiment comparison table.
+ *
+ * Scorer-backed metric columns have IDs of the form `"metrics/{scorer-uuid}"`, which maps
+ * directly to the keys in `experiment.metricAggregates`. Use `column.metricKeyAlias` for
+ * the legacy snake_case metric name and `column.label` for the human-readable display label.
+ * System metrics (e.g. 'cost', 'duration_ns') appear in `metricAggregates` under raw string
+ * keys but do **not** appear in the columns returned here.
+ *
+ * @example
+ * const cols = await getExperimentColumns({ projectName: 'My Project' });
+ * const colMap = Object.fromEntries((cols.columns ?? []).map(c => [c.id, c]));
+ * for (const [metricId, agg] of Object.entries(experiment.metricAggregates ?? {})) {
+ *   const col = colMap[`metrics/${metricId}`];   // undefined for system metrics
+ *   const label = col?.label ?? metricId;
+ *   console.log(`${label}: avg=${agg.avg}`);
+ * }
+ */
+export async function getExperimentColumns(options: {
+  projectId?: string;
+  projectName?: string;
+}): Promise<ExperimentsAvailableColumnsResponse> {
+  const experiments = new Experiments();
+  return experiments.getExperimentColumns(options);
 }

--- a/src/utils/experiments.ts
+++ b/src/utils/experiments.ts
@@ -167,13 +167,14 @@ export async function deleteExperiment(options: {
  * directly to the keys in `experiment.metricAggregates`. Use `column.metricKeyAlias` for
  * the legacy snake_case metric name and `column.label` for the human-readable display label.
  * System metrics (e.g. 'cost', 'duration_ns') appear in `metricAggregates` under raw string
- * keys but do **not** appear in the columns returned here.
+ * keys and may also appear as `metrics/{raw_key}` columns (e.g. `metrics/duration_ns`) with
+ * `metricKeyAlias: null`.
  *
  * @example
  * const cols = await getExperimentColumns({ projectName: 'My Project' });
  * const colMap = Object.fromEntries((cols.columns ?? []).map(c => [c.id, c]));
  * for (const [metricId, agg] of Object.entries(experiment.metricAggregates ?? {})) {
- *   const col = colMap[`metrics/${metricId}`];   // undefined for system metrics
+ *   const col = colMap[`metrics/${metricId}`];
  *   const label = col?.label ?? metricId;
  *   console.log(`${label}: avg=${agg.avg}`);
  * }

--- a/tests/utils/experiments.test.ts
+++ b/tests/utils/experiments.test.ts
@@ -306,7 +306,7 @@ describe('experiments utility', () => {
 
       // Verify the correct method was called with the right ID
       expect(mockGetExperiment).toHaveBeenCalledWith(experimentId);
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
     });
 
     it('should fetch experiments and find by name when name is provided', async () => {
@@ -316,7 +316,7 @@ describe('experiments utility', () => {
       // Verify getExperiments was called and the result is correct
       expect(mockGetExperiments).toHaveBeenCalled();
       expect(mockGetExperiment).not.toHaveBeenCalled(); // Should not call getExperiment
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
     });
 
     it('should return undefined when searching by name and no matching experiment is found', async () => {
@@ -345,7 +345,7 @@ describe('experiments utility', () => {
       // Verify only getExperiment was called with the ID
       expect(mockGetExperiment).toHaveBeenCalledWith(experimentId);
       expect(mockGetExperiments).not.toHaveBeenCalled();
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
     });
 
     it('should handle API errors gracefully', async () => {
@@ -394,7 +394,7 @@ describe('experiments utility', () => {
         'Test Experiment',
         undefined
       );
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
     });
     it('should throw an error if name is empty', async () => {
       await expect(createExperiment('', projectName)).rejects.toThrow(
@@ -740,7 +740,7 @@ describe('experiments utility', () => {
         undefined,
         [GalileoMetrics.correctness]
       );
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
       expect(mockCreateExperiment).toHaveBeenCalled();
     });
   });
@@ -755,7 +755,7 @@ describe('experiments utility', () => {
         projectId: commonMockProject.id,
         updateRequest
       });
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
       expect(mockUpdateExperiment).toHaveBeenCalledWith(
         EXAMPLE_EXPERIMENT_ID,
         updateRequest
@@ -771,7 +771,7 @@ describe('experiments utility', () => {
         projectName: commonMockProject.name as string,
         updateRequest
       });
-      expect(result).toEqual(mockExperiment);
+      expect(result).toEqual(expect.objectContaining(mockExperiment));
       expect(mockUpdateExperiment).toHaveBeenCalledWith(
         EXAMPLE_EXPERIMENT_ID,
         updateRequest
@@ -974,6 +974,97 @@ describe('experiments utility', () => {
       const sysCol = cols.find((c) => c.id === 'metrics/duration_ns');
       expect(uuidCol?.metricKeyAlias).toBe('correctness');
       expect(sysCol?.metricKeyAlias).toBeNull();
+    });
+  });
+
+  describe('getMetricAggregate', () => {
+    const scorerUuid = '550e8400-e29b-41d4-a716-446655440000';
+    const mockAgg = { avg: 0.85, count: 8, p90: 0.92 };
+    const mockColumns = {
+      columns: [
+        {
+          id: `metrics/${scorerUuid}`,
+          label: 'Correctness',
+          category: 'metric',
+          dataType: 'floating_point',
+          metricKeyAlias: 'correctness'
+        }
+      ]
+    };
+
+    async function experimentWithMetrics() {
+      const experimentWithMetrics = {
+        ...mockExperiment,
+        projectId: commonMockProject.id,
+        structuredAggregateMetrics: { [scorerUuid]: mockAgg }
+      };
+      mockGetExperiment.mockResolvedValue(experimentWithMetrics);
+      mockGetExperimentsAvailableColumns.mockResolvedValue(mockColumns);
+      return await getExperiment({
+        id: EXAMPLE_EXPERIMENT_ID,
+        projectName: 'test-project'
+      });
+    }
+
+    it('should return undefined when metricAggregates is not populated', async () => {
+      // Given: experiment with no structuredAggregateMetrics
+      mockGetExperiment.mockResolvedValue({
+        ...mockExperiment,
+        projectId: commonMockProject.id
+      });
+
+      const result = await getExperiment({
+        id: EXAMPLE_EXPERIMENT_ID,
+        projectName: 'test-project'
+      });
+
+      // When/Then: getMetricAggregate returns undefined
+      expect(await result?.getMetricAggregate?.('Correctness')).toBeUndefined();
+    });
+
+    it('should look up by UUID string directly without calling columns API', async () => {
+      // Given: experiment with UUID-keyed metrics
+      const experiment = await experimentWithMetrics();
+
+      // When: looking up by raw UUID
+      const result = await experiment?.getMetricAggregate?.(scorerUuid);
+
+      // Then: aggregate returned without calling getExperimentsAvailableColumns
+      expect(result).toEqual(mockAgg);
+      expect(mockGetExperimentsAvailableColumns).not.toHaveBeenCalled();
+    });
+
+    it('should look up by GalileoMetrics value (human-readable label)', async () => {
+      // Given: experiment with UUID-keyed metrics and GalileoMetrics.correctness == "Correctness"
+      const experiment = await experimentWithMetrics();
+
+      // When: looking up by GalileoMetrics value (which IS the label string)
+      const result = await experiment?.getMetricAggregate?.('Correctness');
+
+      // Then: aggregate returned via label match
+      expect(result).toEqual(mockAgg);
+    });
+
+    it('should look up by metricKeyAlias as fallback', async () => {
+      // Given: experiment with UUID-keyed metrics
+      const experiment = await experimentWithMetrics();
+
+      // When: looking up by legacy snake_case alias
+      const result = await experiment?.getMetricAggregate?.('correctness');
+
+      // Then: aggregate returned via alias fallback
+      expect(result).toEqual(mockAgg);
+    });
+
+    it('should return undefined for an unknown metric', async () => {
+      // Given: experiment with UUID-keyed metrics
+      const experiment = await experimentWithMetrics();
+
+      // When: looking up a metric that does not exist
+      const result = await experiment?.getMetricAggregate?.('Toxicity');
+
+      // Then: undefined is returned
+      expect(result).toBeUndefined();
     });
   });
 });

--- a/tests/utils/experiments.test.ts
+++ b/tests/utils/experiments.test.ts
@@ -4,7 +4,8 @@ import {
   getExperiments,
   runExperiment,
   updateExperiment,
-  deleteExperiment
+  deleteExperiment,
+  getExperimentColumns
 } from '../../src';
 import type {
   ExperimentResponseType,
@@ -47,6 +48,7 @@ const mockIngestTraces = jest.fn();
 const mockGetScorerVersion = jest.fn();
 const mockGetGlobalProjectByName = jest.fn();
 const mockListDatasetProjects = jest.fn();
+const mockGetExperimentsAvailableColumns = jest.fn();
 
 jest.mock('../../src/api-client', () => {
   return {
@@ -75,7 +77,8 @@ jest.mock('../../src/api-client', () => {
           getDatasetContent: mockGetDatasetContent,
           ingestTraces: mockIngestTraces,
           getGlobalProjectByName: mockGetGlobalProjectByName,
-          listDatasetProjects: mockListDatasetProjects
+          listDatasetProjects: mockListDatasetProjects,
+          getExperimentsAvailableColumns: mockGetExperimentsAvailableColumns
         };
       }),
       {
@@ -819,6 +822,158 @@ describe('experiments utility', () => {
       ).rejects.toThrow(
         'Experiment id and projectId are required to delete an experiment'
       );
+    });
+  });
+
+  describe('metricAggregates', () => {
+    const scorerUuid = '550e8400-e29b-41d4-a716-446655440000';
+    const mockAgg = { avg: 0.85, count: 8, p90: 0.92 };
+
+    it('should populate metricAggregates from structuredAggregateMetrics on getExperiment', async () => {
+      // Given: API returns an experiment with structuredAggregateMetrics keyed by UUID
+      const experimentWithMetrics = {
+        ...mockExperiment,
+        structuredAggregateMetrics: { [scorerUuid]: mockAgg }
+      };
+      mockGetExperiment.mockResolvedValue(experimentWithMetrics);
+
+      // When: getExperiment is called
+      const result = await getExperiment({
+        id: EXAMPLE_EXPERIMENT_ID,
+        projectName: 'test-project'
+      });
+
+      // Then: metricAggregates mirrors structuredAggregateMetrics
+      expect(result?.metricAggregates).toEqual({ [scorerUuid]: mockAgg });
+    });
+
+    it('should populate metricAggregates from structuredAggregateMetrics on createExperiment', async () => {
+      // Given: API returns an experiment with structuredAggregateMetrics
+      const experimentWithMetrics = {
+        ...mockExperiment,
+        structuredAggregateMetrics: {
+          [scorerUuid]: mockAgg,
+          cost: { avg: 0.01 }
+        }
+      };
+      mockCreateExperiment.mockResolvedValue(experimentWithMetrics);
+
+      // When: createExperiment is called
+      const result = await createExperiment('new-experiment', 'test-project');
+
+      // Then: both UUID and system metric keys are present
+      expect(result.metricAggregates).toEqual({
+        [scorerUuid]: mockAgg,
+        cost: { avg: 0.01 }
+      });
+    });
+
+    it('should set metricAggregates to undefined when structuredAggregateMetrics is absent', async () => {
+      // Given: experiment has no structuredAggregateMetrics
+      mockGetExperiment.mockResolvedValue({ ...mockExperiment });
+
+      // When: getExperiment is called
+      const result = await getExperiment({
+        id: EXAMPLE_EXPERIMENT_ID,
+        projectName: 'test-project'
+      });
+
+      // Then: metricAggregates is undefined
+      expect(result?.metricAggregates).toBeUndefined();
+    });
+  });
+
+  describe('aggregateMetrics deprecation', () => {
+    it('should still return the original value when aggregateMetrics is accessed (backward-compat)', async () => {
+      // Given: API returns an experiment with aggregateMetrics
+      const experimentWithMetrics = {
+        ...mockExperiment,
+        aggregateMetrics: { average_correctness: 0.9 }
+      };
+      mockGetExperiment.mockResolvedValue(experimentWithMetrics);
+
+      // When: getExperiment is called and aggregateMetrics is accessed
+      const result = await getExperiment({
+        id: EXAMPLE_EXPERIMENT_ID,
+        projectName: 'test-project'
+      });
+
+      // Then: the value is still accessible (backward-compatible)
+      // Note: sdkLogger.warn fires internally but is not easily assertable without
+      // mocking the galileo-generated module at module load time.
+      expect(result?.aggregateMetrics).toEqual({ average_correctness: 0.9 });
+    });
+
+    it('should expose aggregateMetrics as a getter (not a plain property)', async () => {
+      // Given: API returns an experiment
+      mockGetExperiment.mockResolvedValue(mockExperiment);
+
+      // When: the enriched experiment is returned
+      const result = await getExperiment({
+        id: EXAMPLE_EXPERIMENT_ID,
+        projectName: 'test-project'
+      });
+
+      // Then: aggregateMetrics is defined as a getter on the object
+      const descriptor = Object.getOwnPropertyDescriptor(
+        result,
+        'aggregateMetrics'
+      );
+      expect(descriptor?.get).toBeDefined();
+    });
+  });
+
+  describe('getExperimentColumns', () => {
+    const mockColumns = {
+      columns: [
+        {
+          id: 'metrics/550e8400-e29b-41d4-a716-446655440000',
+          label: 'Correctness',
+          category: 'metric',
+          dataType: 'floating_point',
+          metricKeyAlias: 'correctness'
+        },
+        {
+          id: 'metrics/duration_ns',
+          label: 'Latency',
+          category: 'metric',
+          dataType: 'integer',
+          metricKeyAlias: null
+        }
+      ]
+    };
+
+    it('should return the columns from the API', async () => {
+      // Given: API returns available columns including UUID-keyed metric columns
+      mockGetExperimentsAvailableColumns.mockResolvedValue(mockColumns);
+
+      // When: getExperimentColumns is called
+      const result = await getExperimentColumns({
+        projectName: 'test-project'
+      });
+
+      // Then: the columns are returned and the API was called
+      expect(result).toEqual(mockColumns);
+      expect(mockGetExperimentsAvailableColumns).toHaveBeenCalledTimes(1);
+    });
+
+    it('should expose metricKeyAlias on UUID-keyed columns', async () => {
+      // Given: a column with metricKeyAlias set
+      mockGetExperimentsAvailableColumns.mockResolvedValue(mockColumns);
+
+      // When: getExperimentColumns is called
+      const result = await getExperimentColumns({
+        projectName: 'test-project'
+      });
+
+      // Then: the UUID column has metricKeyAlias and the system metric column has null alias
+      const cols = result.columns ?? [];
+      const uuidCol = cols.find(
+        (c) => c.id === 'metrics/550e8400-e29b-41d4-a716-446655440000'
+      );
+      const sysCol = cols.find((c) => c.id === 'metrics/duration_ns');
+      expect(uuidCol?.metricKeyAlias).toBe('correctness');
+      expect(sysCol?.metricKeyAlias).toBeNull();
     });
   });
 });


### PR DESCRIPTION
# User description
## Summary

- **`experiment.metricAggregates`** — new field populated from `structuredAggregateMetrics`, keyed by scorer UUID for scorer-backed metrics and raw string for system metrics (e.g. `"cost"`, `"durationNs"`). Full statistical aggregates: `avg`, `min`, `max`, `sum`, `count`, `p50`, `p90`, `p95`, `p99`, `value_distribution`.
- **`getExperimentColumns()` / `experiments.getExperimentColumns()`** — new utility + entity method calling the experiments `available_columns` endpoint; returned columns have `metricKeyAlias` (legacy snake_case name) and `label` (display name) for UUID→label resolution.
- **`experiment.aggregateMetrics` deprecated** — field gets JSDoc `@deprecated`; accessing it at runtime triggers `sdkLogger.warn()` pointing to `metricAggregates`. Property remains functional for backward compat.
- **UUID key restoration** — `ts-case-convert`'s `objectToCamel()` mangles UUID keys in `structuredAggregateMetrics` by treating hyphens as word separators (e.g. `a14a1c2f-23f0-4aad-8eee-cc09d2a42287` → `a14a1c2f23f04aad8eeeCc09d2a42287`). `_restoreUuidKeys()` detects 32-char hex strings and restores standard UUID format before populating `metricAggregates`. Caught and fixed during local integration testing.
- **Schema regen** from production spec + targeted patches: `MetricAggregates` type, `structuredAggregateMetrics` on `ExperimentResponse`, `metricKeyAlias` on `ColumnInfo`, `StepType.control` (new step type in spec).
- `getExperimentColumns` exported from `src/index.ts`.

Depends on API changes from SC-64064 (merged to main).

## UUID → label resolution pattern

```typescript
const experiment = await getExperiment({ id: expId, projectName: 'My Project' });
const cols = await getExperimentColumns({ projectName: 'My Project' });
const colMap = Object.fromEntries((cols.columns ?? []).map(c => [c.id, c]));

for (const [metricId, agg] of Object.entries(experiment.metricAggregates ?? {})) {
  const col = colMap[\`metrics/\${metricId}\`];   // undefined for system metrics
  const label = col?.label ?? metricId;
  const alias = col?.metricKeyAlias;           // legacy snake_case name
  console.log(\`\${label} (\${alias}): avg=\${agg.avg?.toFixed(3)}\`);
}
```

## Test plan

- [x] Unit tests: `metricAggregates` populated from `structuredAggregateMetrics`, `aggregateMetrics` getter, `getExperimentColumns` returns columns with `metricKeyAlias`
- [x] Local integration (validate_metric_aggregates.ts): full end-to-end pass — UUID → label resolution working, `getExperimentColumns` returns 17 UUID-keyed columns, deprecation getter wired, UUID key restoration fix verified
- [x] Build clean: `npm run build` exits 0
- [ ] CI

SC-64066

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
getExperimentColumns_("getExperimentColumns"):::added
EXPERIMENTS_API_("EXPERIMENTS_API"):::modified
Experiments_enrichExperimentResponse_("Experiments._enrichExperimentResponse"):::added
Experiments_getExperiment_("Experiments.getExperiment"):::modified
Experiments_createExperiment_("Experiments.createExperiment"):::modified
Experiments_updateExperiment_("Experiments.updateExperiment"):::modified
BaseClient_convertToCamelCase_("BaseClient.convertToCamelCase"):::modified
objectToCamelPreservingUuids_("objectToCamelPreservingUuids"):::added
getExperimentColumns_ -- "Added getExperimentColumns wrapper using available_columns API." --> EXPERIMENTS_API_
Experiments_enrichExperimentResponse_ -- "Enrichment resolves metric IDs via columns lookup." --> getExperimentColumns_
Experiments_getExperiment_ -- "Now enriches fetched experiment response with helpers." --> EXPERIMENTS_API_
Experiments_getExperiment_ -- "Adds metricAggregates aliasing and deprecated aggregateMetrics warning." --> Experiments_enrichExperimentResponse_
Experiments_createExperiment_ -- "Create experiment response now enriched for metric aggregation." --> EXPERIMENTS_API_
Experiments_updateExperiment_ -- "Patch experiment response enriched with metric aggregates helpers." --> EXPERIMENTS_API_
BaseClient_convertToCamelCase_ -- "Camel-casing preserves UUID keys via custom converter." --> objectToCamelPreservingUuids_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Preserve UUID metric keys when camel-casing API responses, enrich experiment entities with new <code>metricAggregates</code> computed from structured aggregate data, deprecate the legacy <code>aggregateMetrics</code> property while keeping it accessible, and add explicit helpers for metrics metadata (columns, columns API, schema updates, and new control/logging types) so downstream flows can resolve scorer UUIDs to labels/aliases and observe richer metric/control telemetry.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/591?tool=ast&topic=UUID-aware+metric+aggregates>UUID-aware metric aggregates</a>
        </td><td>Ensure case conversion doesn’t mangle UUID keys and wire structured aggregate metrics into SDK responses. The BaseClient now preserves UUIDs when converting API payloads, experiments enrich responses with <code>metricAggregates</code>, and tests validate the getter, deprecation wrapper, columns lookup, and label/alias resolution for UUID-backed metrics.<details><summary>Modified files (4)</summary><ul><li>src/api-client/base-client.ts</li>
<li>src/entities/experiments.ts</li>
<li>src/utils/experiments.ts</li>
<li>tests/utils/experiments.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>fix: remove this-alias...</td><td>May 06, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/591?tool=ast&topic=Logging+step%2Fcontrol+enrichment>Logging step/control enrichment</a>
        </td><td>Align logging step types with the new control telemetry category exposed through the regenerated schemas so the SDK recognizes control spans/steps and can route control-specific results through existing log-record flows.<details><summary>Modified files (1)</summary><ul><li>src/types/logging/step.types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>feat: add metricAggreg...</td><td>May 05, 2026</td></tr>
<tr><td>Murike</td><td>feat(wrapper): New fea...</td><td>February 13, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/591?tool=ast&topic=Other>Other</a>
        </td><td>Other files<details><summary>Modified files (1)</summary><ul><li>src/types/api.types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>feat: add metricAggreg...</td><td>May 05, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/591?tool=ast&topic=Schema+%2B+API+surface+refresh>Schema + API surface refresh</a>
        </td><td>Regenerate and extend API types with new ClickHouse/metric aggregate schema, control span metadata, log-stream helpers, dataset preview endpoints, integration lifecycle actions, code-metric generation polling/status flows, and richer user action/step enums, ensuring all downstream code can consume the expanded telemetry and metadata fields introduced by the backend.<details><summary>Modified files (2)</summary><ul><li>src/types/new-api.types.ts</li>
<li>src/types/openapi.types.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>feat: add experiment.g...</td><td>May 06, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/591?tool=ast&topic=Experiment+columns+utility>Experiment columns utility</a>
        </td><td>Expand experiment utilities to expose available columns, export them from the SDK entry point, and leverage them when resolving scorer UUIDs/aliases and system metrics. This adds the new <code>getExperimentColumns</code> helper, wires it through the public surface, and tests its behavior.<details><summary>Modified files (4)</summary><ul><li>src/entities/experiments.ts</li>
<li>src/index.ts</li>
<li>src/utils/experiments.ts</li>
<li>tests/utils/experiments.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>quinn@rungalileo.io</td><td>fix: remove this-alias...</td><td>May 06, 2026</td></tr>
<tr><td>Focadecombate</td><td>feat: add OpenTelemetr...</td><td>May 01, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/591?tool=ast>(Baz)</a>.