### PR TITLE
fix(conclude): Updated conclude contract to run without parameters.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "@openai/agents": ">=0.4.0",
         "@opentelemetry/api": ">=1.4.0",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+        "@opentelemetry/exporter-trace-otlp-proto": ">=0.41.0",
         "@opentelemetry/resources": ">=1.15.0",
         "@opentelemetry/sdk-trace-base": ">=1.15.0",
         "openai": ">=4.0.0"
@@ -76,6 +77,9 @@
           "optional": true
         },
         "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
           "optional": true
         },
         "@opentelemetry/resources": {

--- a/src/utils/galileo-logger.ts
+++ b/src/utils/galileo-logger.ts
@@ -865,19 +865,17 @@ class GalileoLogger implements IGalileoLogger {
    * @returns The current parent after concluding, or undefined if all traces/spans were concluded.
    * @throws Error if no trace or span exists to conclude.
    */
-  conclude({
-    output,
-    redactedOutput,
-    durationNs,
-    statusCode,
-    concludeAll
-  }: {
-    output?: string;
-    redactedOutput?: string;
-    durationNs?: number;
-    statusCode?: number;
-    concludeAll?: boolean;
-  }): StepWithChildSpans | undefined {
+  conclude(
+    options: {
+      output?: string;
+      redactedOutput?: string;
+      durationNs?: number;
+      statusCode?: number;
+      concludeAll?: boolean;
+    } = {}
+  ): StepWithChildSpans | undefined {
+    const { output, redactedOutput, durationNs, statusCode, concludeAll } =
+      options;
     if (!concludeAll) {
       return this.concludeCurrentParent({
         output,

--- a/tests/utils/galileo-logger.test.ts
+++ b/tests/utils/galileo-logger.test.ts
@@ -839,7 +839,7 @@ describe('GalileoLogger', () => {
     });
 
     it('should throw error when concluding without an active trace', () => {
-      expect(() => logger.conclude({})).toThrow(
+      expect(() => logger.conclude()).toThrow(
         'No existing workflow to conclude'
       );
     });


### PR DESCRIPTION
# User description
# conclude function call accept no parameter
 - [sc-61131](https://app.shortcut.com/galileo/story/61131/conclude-function-call-accept-no-parameter)

## Description
* Updated conclude contract to run without parameters.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update <code>GalileoLogger</code>'s <code>conclude</code> contract to accept a default options object so traces can be ended without passing explicit parameters. Add the optional <code>@opentelemetry/exporter-trace-otlp-proto</code> dependency so tracing instrumentation has the matching exporter available.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/592?tool=ast&topic=Conclude+Flow>Conclude Flow</a>
        </td><td>Allow <code>GalileoLogger</code>'s <code>conclude</code> to destructure a defaulted options object and let tests call it without arguments so concluding flows no longer need placeholder params.<details><summary>Modified files (2)</summary><ul><li>src/utils/galileo-logger.ts</li>
<li>tests/utils/galileo-logger.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ricardo.maurique@galil...</td><td>fix(conclude): Updated...</td><td>May 05, 2026</td></tr>
<tr><td>Murike</td><td>feat(terminate): Imple...</td><td>May 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/592?tool=ast&topic=Tracing+Dependency>Tracing Dependency</a>
        </td><td>Add the optional proto exporter dependency to mirror updated tracing requirements.<details><summary>Modified files (1)</summary><ul><li>package-lock.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ricardo.maurique@galil...</td><td>fix(conclude): Updated...</td><td>May 05, 2026</td></tr>
<tr><td>Focadecombate</td><td>feat: add OpenTelemetr...</td><td>May 01, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/592?tool=ast>(Baz)</a>.