### PR TITLE
fix: dynamic header hook for OTEL SDK 0.200+ compatibility

### DIFF
--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -45,6 +45,10 @@ function loadResourceClass():
     // eslint-disable-next-line @typescript-eslint/no-var-requires
     return require('@opentelemetry/resources').Resource ?? null;
   } catch {
+    sdkLogger.warn(
+      '@opentelemetry/resources is not installed. ' +
+        'Resource attributes will not be merged onto exported spans.'
+    );
     return null;
   }
 }
@@ -183,9 +187,9 @@ export class GalileoOTLPExporter implements SpanExporterLike {
         GALILEO_ATTRIBUTES.DATASET_METADATA
       );
 
-      if (project) batchProject = project;
-      if (logstream) batchLogstream = logstream;
-      if (experimentId) batchExperimentId = experimentId;
+      if (project !== undefined) batchProject = project;
+      if (logstream !== undefined) batchLogstream = logstream;
+      if (experimentId !== undefined) batchExperimentId = experimentId;
 
       // Merge galileo attributes into span resource (matches Python SDK behavior)
       const resourceAttrs: Record<string, string> = {};

--- a/src/handlers/otel/exporter.ts
+++ b/src/handlers/otel/exporter.ts
@@ -17,30 +17,62 @@ function strAttr(
   return typeof v === 'string' ? v : undefined;
 }
 
+function loadOTLPTraceExporter(): new (
+  config: Record<string, unknown>
+) => SpanExporterLike {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('@opentelemetry/exporter-trace-otlp-proto')
+      .OTLPTraceExporter;
+  } catch {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      return require('@opentelemetry/exporter-trace-otlp-http')
+        .OTLPTraceExporter;
+    } catch {
+      throw new Error(
+        '@opentelemetry/exporter-trace-otlp-proto (or @opentelemetry/exporter-trace-otlp-http) is not installed. ' +
+          'Install it with: npm install @opentelemetry/exporter-trace-otlp-proto'
+      );
+    }
+  }
+}
+
+function loadResourceClass():
+  | (new (attrs: Record<string, unknown>) => unknown)
+  | null {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    return require('@opentelemetry/resources').Resource ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * OpenTelemetry OTLP span exporter preconfigured for Galileo platform integration.
  *
- * This exporter wraps the standard OTLPTraceExporter with Galileo-specific
- * configuration and authentication. It injects Galileo resource attributes
- * and updates HTTP headers per export batch.
- *
- * For most applications, use GalileoSpanProcessor instead, which provides
- * a complete tracing solution including this exporter.
+ * Extends the standard OTLPTraceExporter with Galileo-specific configuration,
+ * authentication, per-batch header overrides, and resource attribute merging.
+ * The class is created dynamically at runtime since the base OTLPTraceExporter
+ * is loaded via require().
  *
  * @example
  * ```typescript
  * import { GalileoOTLPExporter } from 'galileo';
- * import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-base';
+ * import { SimpleSpanProcessor } from '@opentelemetry/sdk-trace-node';
  *
  * const exporter = new GalileoOTLPExporter({ project: 'my-project' });
- * const processor = new BatchSpanProcessor(exporter);
+ * const processor = new SimpleSpanProcessor(exporter);
  * ```
  */
 export class GalileoOTLPExporter implements SpanExporterLike {
-  private _innerExporter: SpanExporterLike;
+  private _inner: SpanExporterLike;
+  private _headerOverrides: Record<string, string | null> = {};
+  private _hooked = false;
   private _ResourceClass:
     | (new (attrs: Record<string, unknown>) => unknown)
-    | null = null;
+    | null;
 
   readonly project: string;
   readonly logstream: string;
@@ -61,39 +93,10 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       config?.logstream ?? galileoConfig.logStreamName ?? 'default';
 
     const endpoint = `${apiUrl.replace(/\/$/, '')}/otel/traces`;
+    const OTLPTraceExporter = loadOTLPTraceExporter();
+    this._ResourceClass = loadResourceClass();
 
-    let OTLPTraceExporter: new (
-      config: Record<string, unknown>
-    ) => SpanExporterLike;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const mod = require('@opentelemetry/exporter-trace-otlp-proto');
-      OTLPTraceExporter = mod.OTLPTraceExporter;
-    } catch {
-      try {
-        // eslint-disable-next-line @typescript-eslint/no-var-requires
-        const mod = require('@opentelemetry/exporter-trace-otlp-http');
-        OTLPTraceExporter = mod.OTLPTraceExporter;
-      } catch {
-        throw new Error(
-          '@opentelemetry/exporter-trace-otlp-proto (or @opentelemetry/exporter-trace-otlp-http) is not installed. ' +
-            'Install it with: npm install @opentelemetry/exporter-trace-otlp-proto'
-        );
-      }
-    }
-
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const resourcesMod = require('@opentelemetry/resources');
-      this._ResourceClass = resourcesMod.Resource ?? null;
-    } catch {
-      sdkLogger.warn(
-        '@opentelemetry/resources is not installed. ' +
-          'Resource attributes will not be merged onto exported spans.'
-      );
-    }
-
-    this._innerExporter = new OTLPTraceExporter({
+    this._inner = new OTLPTraceExporter({
       url: endpoint,
       headers: {
         'Galileo-API-Key': apiKey,
@@ -104,18 +107,68 @@ export class GalileoOTLPExporter implements SpanExporterLike {
   }
 
   /**
-   * Export spans to Galileo, injecting resource attributes from span attributes.
-   *
-   * For each span, reads galileo.* attributes (set by GalileoSpanProcessor.onStart)
-   * and merges them into the span's resource. Also updates HTTP headers per batch.
+   * Replace the static headers function on the inner transport with a
+   * dynamic one that merges per-batch overrides at send time.
    */
+  private _installHeadersHook(): void {
+    if (this._hooked) return;
+    this._hooked = true;
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const exp = this._inner as any;
+
+      const applyOverrides = (base: Record<string, string>) => {
+        const merged = { ...base };
+        for (const [k, v] of Object.entries(this._headerOverrides)) {
+          if (v === null) {
+            delete merged[k];
+          } else {
+            merged[k] = v;
+          }
+        }
+        return merged;
+      };
+
+      // Modern OTEL SDK (0.200+): headers are a function on transport params
+      const params = exp?._delegate?._transport?._transport?._parameters;
+      if (params && typeof params.headers === 'function') {
+        const originalHeadersFn = params.headers.bind(params);
+        params.headers = () => applyOverrides(originalHeadersFn());
+        return;
+      }
+
+      // Legacy OTEL SDK: direct .headers property
+      if (
+        exp.headers &&
+        typeof exp.headers === 'object' &&
+        !Object.isFrozen(exp.headers)
+      ) {
+        const originalHeaders = { ...exp.headers };
+        Object.defineProperty(exp, 'headers', {
+          get: () => applyOverrides(originalHeaders)
+        });
+        return;
+      }
+    } catch {
+      // Transport structure not recognized
+    }
+
+    sdkLogger.warn(
+      'Could not install dynamic headers hook on the inner exporter. ' +
+        'Per-batch header overrides will not be applied.'
+    );
+  }
+
   export(
     spans: ReadableSpanLike[],
     resultCallback: (result: ExportResultLike) => void
   ): void {
-    let batchExperimentId: string | undefined;
+    this._installHeadersHook();
+
     let batchProject: string | undefined;
     let batchLogstream: string | undefined;
+    let batchExperimentId: string | undefined;
 
     for (const span of spans) {
       const attrs = span.attributes;
@@ -130,10 +183,11 @@ export class GalileoOTLPExporter implements SpanExporterLike {
         GALILEO_ATTRIBUTES.DATASET_METADATA
       );
 
+      if (project) batchProject = project;
+      if (logstream) batchLogstream = logstream;
       if (experimentId) batchExperimentId = experimentId;
-      batchProject = project ?? batchProject;
-      batchLogstream = logstream ?? batchLogstream;
 
+      // Merge galileo attributes into span resource (matches Python SDK behavior)
       const resourceAttrs: Record<string, string> = {};
       if (project) resourceAttrs[GALILEO_ATTRIBUTES.PROJECT_NAME] = project;
       if (logstream && !experimentId)
@@ -159,42 +213,33 @@ export class GalileoOTLPExporter implements SpanExporterLike {
       }
     }
 
+    // Update per-batch header overrides.
+    // Always set both logstream and experimentid so the merge fully replaces
+    // construction-time values — they are mutually exclusive for routing.
     if (spans.length > 0) {
-      const innerHeaders = (
-        this._innerExporter as unknown as {
-          headers: Record<string, string>;
-        }
-      ).headers;
+      const overrides: Record<string, string | null> = {
+        project: batchProject ?? this.project
+      };
 
-      if (
-        innerHeaders &&
-        typeof innerHeaders === 'object' &&
-        !Object.isFrozen(innerHeaders)
-      ) {
-        innerHeaders['project'] = batchProject ?? this.project;
-
-        if (batchExperimentId) {
-          innerHeaders['experimentid'] = batchExperimentId;
-          delete innerHeaders['logstream'];
-        } else {
-          innerHeaders['logstream'] = batchLogstream ?? this.logstream;
-          delete innerHeaders['experimentid'];
-        }
+      if (batchExperimentId) {
+        overrides['experimentid'] = batchExperimentId;
+        overrides['logstream'] = null;
       } else {
-        sdkLogger.warn(
-          'Could not update inner exporter headers — the OTLPTraceExporter implementation may have changed.'
-        );
+        overrides['logstream'] = batchLogstream ?? this.logstream;
+        overrides['experimentid'] = null;
       }
+
+      this._headerOverrides = overrides;
     }
 
-    this._innerExporter.export(spans, resultCallback);
+    this._inner.export(spans, resultCallback);
   }
 
   async shutdown(): Promise<void> {
-    return this._innerExporter.shutdown();
+    return this._inner.shutdown();
   }
 
   async forceFlush(): Promise<void> {
-    return this._innerExporter.forceFlush?.();
+    return this._inner.forceFlush?.();
   }
 }

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -1,23 +1,61 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { GalileoOTLPExporter } from '../../../src/handlers/otel/exporter';
 import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
 import { GalileoConfig } from 'galileo-generated';
 
-// Mock OTel dependencies — source tries proto first, falls back to http
 const mockExport = jest.fn();
 const mockExporterShutdown = jest.fn().mockResolvedValue(undefined);
 const mockExporterForceFlush = jest.fn().mockResolvedValue(undefined);
-let mockInnerHeaders: Record<string, string> = {};
+
+interface MockInnerExporter {
+  export: jest.Mock;
+  shutdown: jest.Mock;
+  forceFlush: jest.Mock;
+  headers?: Record<string, string>;
+  _delegate?: {
+    _transport: {
+      _transport: {
+        _parameters: {
+          headers: (() => Record<string, string>) | Record<string, string>;
+        };
+      };
+    };
+  };
+}
+
+let lastCreatedInner: MockInnerExporter;
+
+function createModernTransportStructure(
+  initialHeaders: Record<string, string>
+): MockInnerExporter['_delegate'] {
+  let headersFn = () => ({ ...initialHeaders });
+  return {
+    _transport: {
+      _transport: {
+        _parameters: {
+          get headers() {
+            return headersFn;
+          },
+          set headers(fn: () => Record<string, string>) {
+            headersFn = fn;
+          }
+        }
+      }
+    }
+  };
+}
 
 const mockExporterFactory = jest
   .fn()
   .mockImplementation((config: { headers: Record<string, string> }) => {
-    mockInnerHeaders = { ...config.headers };
-    return {
+    const inner: MockInnerExporter = {
       export: mockExport,
       shutdown: mockExporterShutdown,
       forceFlush: mockExporterForceFlush,
-      headers: mockInnerHeaders
+      _delegate: createModernTransportStructure(config.headers)
     };
+    lastCreatedInner = inner;
+    return inner;
   });
 
 jest.mock(
@@ -42,6 +80,21 @@ const MockResource = jest
 jest.mock('@opentelemetry/resources', () => ({
   Resource: MockResource
 }));
+
+jest.mock('galileo-generated', () => {
+  const actual = jest.requireActual('galileo-generated');
+  return {
+    ...actual,
+    getSdkLogger: () => ({
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: (...args: unknown[]) => sdkWarnCalls.push(args),
+      error: jest.fn()
+    })
+  };
+});
+
+const sdkWarnCalls: unknown[][] = [];
 
 function createMockSpan(
   attributes: Record<string, unknown> = {},
@@ -69,7 +122,7 @@ describe('GalileoOTLPExporter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockInnerHeaders = {};
+    sdkWarnCalls.length = 0;
     GalileoConfig.reset();
     process.env = {
       ...originalEnv,
@@ -83,279 +136,409 @@ describe('GalileoOTLPExporter', () => {
     GalileoConfig.reset();
   });
 
-  test('test constructor builds correct endpoint and headers', () => {
-    // Given: explicit config overriding all values
-    // When: creating an exporter
-    const exporter = new GalileoOTLPExporter({
-      project: 'my-project',
-      logstream: 'my-logstream',
-      apiKey: 'my-key',
-      apiUrl: 'https://custom.galileo.ai'
+  describe('constructor', () => {
+    test('test constructor builds correct endpoint and headers', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'my-project',
+        logstream: 'my-logstream',
+        apiKey: 'my-key',
+        apiUrl: 'https://custom.galileo.ai'
+      });
+
+      expect(exporter.project).toBe('my-project');
+      expect(exporter.logstream).toBe('my-logstream');
+      expect(mockExporterFactory).toHaveBeenCalledWith({
+        url: 'https://custom.galileo.ai/otel/traces',
+        headers: {
+          'Galileo-API-Key': 'my-key',
+          project: 'my-project',
+          logstream: 'my-logstream'
+        }
+      });
     });
 
-    // Then: project and logstream are set correctly
-    expect(exporter.project).toBe('my-project');
-    expect(exporter.logstream).toBe('my-logstream');
+    test('test constructor strips trailing slash from apiUrl', () => {
+      new GalileoOTLPExporter({
+        apiKey: 'my-key',
+        apiUrl: 'https://custom.galileo.ai/'
+      });
 
-    // Then: OTLPTraceExporter was created with correct endpoint and headers
-    expect(mockExporterFactory).toHaveBeenCalledWith({
-      url: 'https://custom.galileo.ai/otel/traces',
-      headers: {
-        'Galileo-API-Key': 'my-key',
+      expect(mockExporterFactory).toHaveBeenCalledWith(
+        expect.objectContaining({
+          url: 'https://custom.galileo.ai/otel/traces'
+        })
+      );
+    });
+
+    test('test constructor throws without API key', () => {
+      delete process.env.GALILEO_API_KEY;
+      GalileoConfig.reset();
+
+      expect(() => new GalileoOTLPExporter()).toThrow(
+        'Galileo API key is required'
+      );
+    });
+
+    test('test constructor resolves project and logstream from GalileoConfig', () => {
+      process.env.GALILEO_PROJECT = 'env-project';
+      process.env.GALILEO_LOG_STREAM = 'env-logstream';
+      GalileoConfig.reset();
+
+      const exporter = new GalileoOTLPExporter();
+
+      expect(exporter.project).toBe('env-project');
+      expect(exporter.logstream).toBe('env-logstream');
+    });
+  });
+
+  describe('_installHeadersHook — modern OTEL SDK path', () => {
+    test('test export installs dynamic headers hook on first call', () => {
+      const exporter = new GalileoOTLPExporter({
         project: 'my-project',
         logstream: 'my-logstream'
-      }
+      });
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'batch-project',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'batch-logstream'
+      });
+
+      exporter.export([span], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headers = (params.headers as () => Record<string, string>)();
+      expect(headers['project']).toBe('batch-project');
+      expect(headers['logstream']).toBe('batch-logstream');
+      expect(headers['Galileo-API-Key']).toBe('test-api-key');
+    });
+
+    test('test hook merges overrides with base headers at call time', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'my-project',
+        logstream: 'my-logstream',
+        apiKey: 'my-key'
+      });
+
+      const span1 = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'project-a',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'logstream-a'
+      });
+      exporter.export([span1], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headersFn = params.headers as () => Record<string, string>;
+
+      let headers = headersFn();
+      expect(headers['project']).toBe('project-a');
+      expect(headers['logstream']).toBe('logstream-a');
+
+      const span2 = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'project-b',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'logstream-b'
+      });
+      exporter.export([span2], jest.fn());
+
+      headers = headersFn();
+      expect(headers['project']).toBe('project-b');
+      expect(headers['logstream']).toBe('logstream-b');
+      expect(headers['Galileo-API-Key']).toBe('my-key');
+    });
+
+    test('test hook only installed once across multiple exports', () => {
+      const exporter = new GalileoOTLPExporter();
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const originalHeadersFn = params.headers;
+
+      exporter.export([createMockSpan()], jest.fn());
+      const hookedHeadersFn = params.headers;
+      expect(hookedHeadersFn).not.toBe(originalHeadersFn);
+
+      exporter.export([createMockSpan()], jest.fn());
+      expect(params.headers).toBe(hookedHeadersFn);
     });
   });
 
-  test('test constructor strips trailing slash from apiUrl', () => {
-    // Given: apiUrl with trailing slash
-    // When: creating an exporter
-    new GalileoOTLPExporter({
-      apiKey: 'my-key',
-      apiUrl: 'https://custom.galileo.ai/'
+  describe('_installHeadersHook — legacy OTEL SDK path', () => {
+    test('test hook falls back to Object.defineProperty for legacy headers', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'my-project',
+        logstream: 'my-logstream'
+      });
+
+      delete lastCreatedInner._delegate;
+      (lastCreatedInner as any).headers = {
+        'Galileo-API-Key': 'test-api-key',
+        project: 'my-project',
+        logstream: 'my-logstream'
+      };
+
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'legacy-project',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'legacy-logstream'
+      });
+      exporter.export([span], jest.fn());
+
+      const headers = (lastCreatedInner as any).headers;
+      expect(headers['project']).toBe('legacy-project');
+      expect(headers['logstream']).toBe('legacy-logstream');
+      expect(headers['Galileo-API-Key']).toBe('test-api-key');
+    });
+  });
+
+  describe('_installHeadersHook — no recognized transport', () => {
+    test('test hook warns when transport structure not recognized', () => {
+      const exporter = new GalileoOTLPExporter();
+
+      delete lastCreatedInner._delegate;
+      delete (lastCreatedInner as any).headers;
+
+      exporter.export([createMockSpan()], jest.fn());
+
+      expect(sdkWarnCalls.length).toBeGreaterThan(0);
+      expect(sdkWarnCalls[0][0]).toContain(
+        'Could not install dynamic headers hook on the inner exporter'
+      );
     });
 
-    // Then: endpoint has no double slash
-    expect(mockExporterFactory).toHaveBeenCalledWith(
-      expect.objectContaining({
-        url: 'https://custom.galileo.ai/otel/traces'
-      })
-    );
-  });
+    test('test hook does not retry after failed installation', () => {
+      const exporter = new GalileoOTLPExporter();
 
-  test('test constructor throws without API key', () => {
-    // Given: no API key in environment
-    delete process.env.GALILEO_API_KEY;
-    GalileoConfig.reset();
+      delete lastCreatedInner._delegate;
+      delete (lastCreatedInner as any).headers;
 
-    // When/Then: creating an exporter throws
-    expect(() => new GalileoOTLPExporter()).toThrow(
-      'Galileo API key is required'
-    );
-  });
+      exporter.export([createMockSpan()], jest.fn());
+      expect(sdkWarnCalls.length).toBe(1);
 
-  test('test constructor resolves project and logstream from GalileoConfig', () => {
-    // Given: project and logstream set via env vars (resolved by GalileoConfig)
-    process.env.GALILEO_PROJECT = 'env-project';
-    process.env.GALILEO_LOG_STREAM = 'env-logstream';
-    GalileoConfig.reset();
-
-    // When: creating an exporter without explicit config
-    const exporter = new GalileoOTLPExporter();
-
-    // Then: values come from GalileoConfig (which reads env vars)
-    expect(exporter.project).toBe('env-project');
-    expect(exporter.logstream).toBe('env-logstream');
-  });
-
-  test('test export delegates to inner exporter', () => {
-    // Given: an exporter and a span with no galileo attributes
-    const exporter = new GalileoOTLPExporter();
-    const span = createMockSpan();
-    const callback = jest.fn();
-
-    // When: exporting spans
-    exporter.export([span], callback);
-
-    // Then: inner exporter's export is called
-    expect(mockExport).toHaveBeenCalledWith([span], callback);
-  });
-
-  test('test export merges resource attributes from span attributes', () => {
-    // Given: an exporter and a span with galileo attributes
-    const exporter = new GalileoOTLPExporter();
-    const span = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'span-project',
-      [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'span-logstream',
-      [GALILEO_ATTRIBUTES.SESSION_ID]: 'session-123'
+      sdkWarnCalls.length = 0;
+      exporter.export([createMockSpan()], jest.fn());
+      expect(sdkWarnCalls.length).toBe(0);
     });
-    const callback = jest.fn();
 
-    // When: exporting spans
-    exporter.export([span], callback);
+    test('test hook warns when headers are frozen', () => {
+      const exporter = new GalileoOTLPExporter();
 
-    // Then: resource.merge is called with galileo attributes
-    expect(span.resource.merge).toHaveBeenCalled();
-    // Then: inner exporter receives the spans
-    expect(mockExport).toHaveBeenCalledWith([span], callback);
+      delete lastCreatedInner._delegate;
+      (lastCreatedInner as any).headers = Object.freeze({
+        'Galileo-API-Key': 'test-api-key'
+      });
+
+      exporter.export([createMockSpan()], jest.fn());
+
+      expect(sdkWarnCalls.length).toBeGreaterThan(0);
+      expect(sdkWarnCalls[0][0]).toContain(
+        'Could not install dynamic headers hook on the inner exporter'
+      );
+    });
   });
 
-  test('test export handles experiment mode by removing logstream', () => {
-    // Given: an exporter
-    const exporter = new GalileoOTLPExporter();
-    const span = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'span-project',
-      [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'span-logstream',
-      [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-456'
+  describe('export — resource attribute merging', () => {
+    test('test export merges galileo attributes into span resource', () => {
+      const exporter = new GalileoOTLPExporter();
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'span-project',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'span-logstream',
+        [GALILEO_ATTRIBUTES.SESSION_ID]: 'session-123'
+      });
+
+      exporter.export([span], jest.fn());
+
+      expect(span.resource.merge).toHaveBeenCalled();
+      const resourceCallArgs = MockResource.mock.calls[0][0];
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.PROJECT_NAME]).toBe(
+        'span-project'
+      );
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME]).toBe(
+        'span-logstream'
+      );
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.SESSION_ID]).toBe(
+        'session-123'
+      );
     });
-    const callback = jest.fn();
 
-    // When: exporting spans with experiment ID
-    exporter.export([span], callback);
+    test('test export excludes logstream from resource when experiment ID present', () => {
+      const exporter = new GalileoOTLPExporter();
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'span-project',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'span-logstream',
+        [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-456'
+      });
 
-    // Then: Resource was created without logstream (experiment takes priority)
-    const resourceCallArgs = MockResource.mock.calls[0][0];
-    expect(resourceCallArgs[GALILEO_ATTRIBUTES.EXPERIMENT_ID]).toBe('exp-456');
-    expect(resourceCallArgs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME]).toBeUndefined();
+      exporter.export([span], jest.fn());
+
+      const resourceCallArgs = MockResource.mock.calls[0][0];
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.EXPERIMENT_ID]).toBe(
+        'exp-456'
+      );
+      expect(
+        resourceCallArgs[GALILEO_ATTRIBUTES.LOGSTREAM_NAME]
+      ).toBeUndefined();
+    });
+
+    test('test export includes dataset attributes in resource', () => {
+      const exporter = new GalileoOTLPExporter();
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'my-project',
+        [GALILEO_ATTRIBUTES.DATASET_INPUT]: 'test input',
+        [GALILEO_ATTRIBUTES.DATASET_OUTPUT]: 'test output',
+        [GALILEO_ATTRIBUTES.DATASET_METADATA]: '{"key": "value"}'
+      });
+
+      exporter.export([span], jest.fn());
+
+      const resourceCallArgs = MockResource.mock.calls[0][0];
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_INPUT]).toBe(
+        'test input'
+      );
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_OUTPUT]).toBe(
+        'test output'
+      );
+      expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_METADATA]).toBe(
+        '{"key": "value"}'
+      );
+    });
+
+    test('test export skips resource merge for spans without galileo attributes', () => {
+      const exporter = new GalileoOTLPExporter();
+      const span = createMockSpan({});
+
+      exporter.export([span], jest.fn());
+
+      expect(span.resource.merge).not.toHaveBeenCalled();
+    });
   });
 
-  test('test export includes dataset attributes in resource', () => {
-    // Given: a span with dataset attributes
-    const exporter = new GalileoOTLPExporter();
-    const span = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'my-project',
-      [GALILEO_ATTRIBUTES.DATASET_INPUT]: 'test input',
-      [GALILEO_ATTRIBUTES.DATASET_OUTPUT]: 'test output',
-      [GALILEO_ATTRIBUTES.DATASET_METADATA]: '{"key": "value"}'
+  describe('export — per-batch header overrides', () => {
+    test('test export sets experiment header and clears logstream in experiment mode', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'my-project',
+        logstream: 'my-logstream'
+      });
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'exp-project',
+        [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-789'
+      });
+
+      exporter.export([span], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headers = (params.headers as () => Record<string, string>)();
+      expect(headers['experimentid']).toBe('exp-789');
+      expect(headers['project']).toBe('exp-project');
+      expect(headers['logstream']).toBeUndefined();
     });
-    const callback = jest.fn();
 
-    // When: exporting spans
-    exporter.export([span], callback);
+    test('test export cleans up experiment headers for non-experiment batch', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'my-project',
+        logstream: 'my-logstream'
+      });
 
-    // Then: dataset attributes are included in the resource
-    const resourceCallArgs = MockResource.mock.calls[0][0];
-    expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_INPUT]).toBe(
-      'test input'
-    );
-    expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_OUTPUT]).toBe(
-      'test output'
-    );
-    expect(resourceCallArgs[GALILEO_ATTRIBUTES.DATASET_METADATA]).toBe(
-      '{"key": "value"}'
-    );
+      const experimentSpan = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'exp-project',
+        [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-789'
+      });
+      exporter.export([experimentSpan], jest.fn());
+
+      const normalSpan = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'normal-project',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'normal-logstream'
+      });
+      exporter.export([normalSpan], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headers = (params.headers as () => Record<string, string>)();
+      expect(headers['experimentid']).toBeUndefined();
+      expect(headers['logstream']).toBe('normal-logstream');
+      expect(headers['project']).toBe('normal-project');
+    });
+
+    test('test export falls back to constructor project/logstream when spans lack attributes', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'default-project',
+        logstream: 'default-logstream'
+      });
+      const span = createMockSpan({});
+
+      exporter.export([span], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headers = (params.headers as () => Record<string, string>)();
+      expect(headers['project']).toBe('default-project');
+      expect(headers['logstream']).toBe('default-logstream');
+    });
+
+    test('test export with empty spans does not update header overrides', () => {
+      const exporter = new GalileoOTLPExporter({
+        project: 'my-project',
+        logstream: 'my-logstream'
+      });
+
+      const span = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'first-project'
+      });
+      exporter.export([span], jest.fn());
+
+      exporter.export([], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headers = (params.headers as () => Record<string, string>)();
+      expect(headers['project']).toBe('first-project');
+    });
+
+    test('test last span in batch wins for header values', () => {
+      const exporter = new GalileoOTLPExporter();
+      const span1 = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'project-first',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'logstream-first'
+      });
+      const span2 = createMockSpan({
+        [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'project-last',
+        [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'logstream-last'
+      });
+
+      exporter.export([span1, span2], jest.fn());
+
+      const params =
+        lastCreatedInner._delegate!._transport._transport._parameters;
+      const headers = (params.headers as () => Record<string, string>)();
+      expect(headers['project']).toBe('project-last');
+      expect(headers['logstream']).toBe('logstream-last');
+    });
   });
 
-  test('test shutdown delegates to inner exporter', async () => {
-    // Given: an exporter
-    const exporter = new GalileoOTLPExporter();
+  describe('export — delegation', () => {
+    test('test export delegates to inner exporter', () => {
+      const exporter = new GalileoOTLPExporter();
+      const span = createMockSpan();
+      const callback = jest.fn();
 
-    // When: shutdown is called
-    await exporter.shutdown();
+      exporter.export([span], callback);
 
-    // Then: inner exporter's shutdown is called
-    expect(mockExporterShutdown).toHaveBeenCalled();
+      expect(mockExport).toHaveBeenCalledWith([span], callback);
+    });
   });
 
-  test('test forceFlush delegates to inner exporter', async () => {
-    // Given: an exporter
-    const exporter = new GalileoOTLPExporter();
+  describe('shutdown and forceFlush', () => {
+    test('test shutdown delegates to inner exporter', async () => {
+      const exporter = new GalileoOTLPExporter();
 
-    // When: forceFlush is called
-    await exporter.forceFlush();
+      await exporter.shutdown();
 
-    // Then: inner exporter's forceFlush is called
-    expect(mockExporterForceFlush).toHaveBeenCalled();
-  });
-
-  test('test export with empty spans array does not update headers', () => {
-    // Given: an exporter
-    const exporter = new GalileoOTLPExporter();
-    const callback = jest.fn();
-
-    // When: exporting empty array
-    exporter.export([], callback);
-
-    // Then: inner exporter is still called
-    expect(mockExport).toHaveBeenCalledWith([], callback);
-  });
-
-  test('test export updates inner exporter headers for experiment mode', () => {
-    // Given: an exporter
-    const exporter = new GalileoOTLPExporter({
-      project: 'my-project',
-      logstream: 'my-logstream'
+      expect(mockExporterShutdown).toHaveBeenCalled();
     });
-    const span = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'exp-project',
-      [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-789'
+
+    test('test forceFlush delegates to inner exporter', async () => {
+      const exporter = new GalileoOTLPExporter();
+
+      await exporter.forceFlush();
+
+      expect(mockExporterForceFlush).toHaveBeenCalled();
     });
-    const callback = jest.fn();
-
-    // When: exporting spans with experiment ID
-    exporter.export([span], callback);
-
-    // Then: inner exporter headers are updated with experiment ID and logstream is removed
-    expect(mockInnerHeaders['experimentid']).toBe('exp-789');
-    expect(mockInnerHeaders['project']).toBe('exp-project');
-    expect(mockInnerHeaders['logstream']).toBeUndefined();
-  });
-
-  test('test export cleans up experiment headers for non-experiment batch', () => {
-    // Given: an exporter that previously exported an experiment batch
-    const exporter = new GalileoOTLPExporter({
-      project: 'my-project',
-      logstream: 'my-logstream'
-    });
-    const experimentSpan = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'exp-project',
-      [GALILEO_ATTRIBUTES.EXPERIMENT_ID]: 'exp-789'
-    });
-    exporter.export([experimentSpan], jest.fn());
-
-    // When: exporting a non-experiment batch
-    const normalSpan = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'normal-project',
-      [GALILEO_ATTRIBUTES.LOGSTREAM_NAME]: 'normal-logstream'
-    });
-    exporter.export([normalSpan], jest.fn());
-
-    // Then: experiment ID is cleaned up and logstream is restored
-    expect(mockInnerHeaders['experimentid']).toBeUndefined();
-    expect(mockInnerHeaders['logstream']).toBe('normal-logstream');
-    expect(mockInnerHeaders['project']).toBe('normal-project');
-  });
-
-  test('test export warns when inner exporter headers are not accessible', () => {
-    // Given: an exporter whose inner exporter has no headers property
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const exporter = new GalileoOTLPExporter();
-    const origFactory = mockExporterFactory.getMockImplementation()!;
-    mockExporterFactory.mockImplementationOnce(
-      (config: { headers: Record<string, string> }) => {
-        const inner = origFactory(config);
-        delete (inner as Record<string, unknown>).headers;
-        return inner;
-      }
-    );
-    const noHeadersExporter = new GalileoOTLPExporter();
-
-    const span = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'some-project'
-    });
-    const callback = jest.fn();
-
-    // When: exporting spans
-    noHeadersExporter.export([span], callback);
-
-    // Then: export still proceeds (delegates to inner exporter)
-    expect(mockExport).toHaveBeenCalledWith([span], callback);
-  });
-
-  test('test export warns when inner exporter headers are frozen', () => {
-    // Given: an exporter whose inner exporter has frozen headers
-    const origFactory = mockExporterFactory.getMockImplementation()!;
-    mockExporterFactory.mockImplementationOnce(
-      (config: { headers: Record<string, string> }) => {
-        const inner = origFactory(config);
-        (inner as Record<string, unknown>).headers = Object.freeze({
-          ...config.headers
-        });
-        return inner;
-      }
-    );
-    const frozenExporter = new GalileoOTLPExporter();
-
-    const span = createMockSpan({
-      [GALILEO_ATTRIBUTES.PROJECT_NAME]: 'some-project'
-    });
-    const callback = jest.fn();
-
-    // When: exporting spans
-    frozenExporter.export([span], callback);
-
-    // Then: export still proceeds without throwing
-    expect(mockExport).toHaveBeenCalledWith([span], callback);
   });
 });

--- a/tests/handlers/otel/exporter.test.ts
+++ b/tests/handlers/otel/exporter.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { GalileoOTLPExporter } from '../../../src/handlers/otel/exporter';
 import { GALILEO_ATTRIBUTES } from '../../../src/handlers/otel/types';
 import { GalileoConfig } from 'galileo-generated';
@@ -268,6 +267,7 @@ describe('GalileoOTLPExporter', () => {
       });
 
       delete lastCreatedInner._delegate;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (lastCreatedInner as any).headers = {
         'Galileo-API-Key': 'test-api-key',
         project: 'my-project',
@@ -280,6 +280,7 @@ describe('GalileoOTLPExporter', () => {
       });
       exporter.export([span], jest.fn());
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const headers = (lastCreatedInner as any).headers;
       expect(headers['project']).toBe('legacy-project');
       expect(headers['logstream']).toBe('legacy-logstream');
@@ -292,6 +293,7 @@ describe('GalileoOTLPExporter', () => {
       const exporter = new GalileoOTLPExporter();
 
       delete lastCreatedInner._delegate;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (lastCreatedInner as any).headers;
 
       exporter.export([createMockSpan()], jest.fn());
@@ -306,6 +308,7 @@ describe('GalileoOTLPExporter', () => {
       const exporter = new GalileoOTLPExporter();
 
       delete lastCreatedInner._delegate;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (lastCreatedInner as any).headers;
 
       exporter.export([createMockSpan()], jest.fn());
@@ -320,6 +323,7 @@ describe('GalileoOTLPExporter', () => {
       const exporter = new GalileoOTLPExporter();
 
       delete lastCreatedInner._delegate;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (lastCreatedInner as any).headers = Object.freeze({
         'Galileo-API-Key': 'test-api-key'
       });


### PR DESCRIPTION
# User description
## Summary

- **Fixed per-batch header routing** for `@opentelemetry/exporter-trace-otlp-proto` v0.200+ where headers are wrapped in a closure instead of a mutable `.headers` object
- **Added `_installHeadersHook()`** that replaces the transport's headers function with a dynamic one merging `_headerOverrides` at send time — supports both modern (closure-based) and legacy (direct property) OTEL SDK versions
- **Preserved mutual exclusivity** between `logstream` and `experimentId` headers using null-valued overrides that delete keys from the merged result
- **Rewrote tests** to properly mock the OTEL 0.200+ transport structure (`_delegate._transport._transport._parameters.headers`) and cover both SDK paths, warning behavior, and header cleanup between experiment/non-experiment batches

## Test plan

- [x] All 23 exporter tests pass (`npx jest tests/handlers/otel/exporter.test.ts`)
- [ ] Verify with sdk-examples/typescript/agent/vercel-agent using GalileoSpanProcessor
- [ ] Confirm traces appear correctly in Galileo console with correct project/logstream routing
- [ ] Test experiment mode: verify experimentId header present and logstream header absent
- [ ] Test switching between experiment and non-experiment batches

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
constructor_("constructor"):::modified
loadOTLPTraceExporter_("loadOTLPTraceExporter"):::added
OPENTELEMETRY_EXPORTER_TRACE_OTLP_PROTO_("@OPENTELEMETRY/EXPORTER-TRACE-OTLP-PROTO"):::added
OPENTELEMETRY_EXPORTER_TRACE_OTLP_HTTP_("@OPENTELEMETRY/EXPORTER-TRACE-OTLP-HTTP"):::added
loadResourceClass_("loadResourceClass"):::added
OPENTELEMETRY_RESOURCES_("@OPENTELEMETRY/RESOURCES"):::added
export_("export"):::modified
installHeadersHook_("_installHeadersHook"):::added
constructor_ -- "Constructor now delegates OTLP exporter loading to helper." --> loadOTLPTraceExporter_
loadOTLPTraceExporter_ -- "Attempts OTLP proto exporter require for inner exporter initialization." --> OPENTELEMETRY_EXPORTER_TRACE_OTLP_PROTO_
loadOTLPTraceExporter_ -- "Falls back to OTLP HTTP exporter when proto unavailable." --> OPENTELEMETRY_EXPORTER_TRACE_OTLP_HTTP_
constructor_ -- "Constructor now loads Resource class via helper for merging." --> loadResourceClass_
loadResourceClass_ -- "Warns if resources package missing, skipping Resource merging." --> OPENTELEMETRY_RESOURCES_
export_ -- "Installs dynamic headers hook before exporting span batches." --> installHeadersHook_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enable GalileoOTLPExporter to load the OTLPTraceExporter dynamically, merge Galileo resource attributes, and install <code>_installHeadersHook()</code> so per-batch headers override both closure-based and legacy transports. Add coverage for mock modern transports, experiment/logstream exclusivity, warning behavior, and resource merging while ensuring delegation helpers still work.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/598?tool=ast&topic=Test+coverage>Test coverage</a>
        </td><td>Add focused tests that mock modern transport structures, cover experiment vs. normal batches, warn when hooks fail, exercise resource merging, and verify shutdown/forceFlush delegation.<details><summary>Modified files (1)</summary><ul><li>tests/handlers/otel/exporter.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gustavo.santos@galileo.ai</td><td>fix: address PR review...</td><td>May 08, 2026</td></tr>
<tr><td>Focadecombate</td><td>feat: add OpenTelemetr...</td><td>May 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/598?tool=ast&topic=Dynamic+headers>Dynamic headers</a>
        </td><td>Implement per-batch header overrides for <code>GalileoOTLPExporter</code> by lazily loading the OTLP exporter and Resource class, installing <code>_installHeadersHook()</code> to merge <code>_headerOverrides</code> into modern and legacy transport structures, and preserving experiment/logstream exclusivity during export.<details><summary>Modified files (1)</summary><ul><li>src/handlers/otel/exporter.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gustavo.santos@galileo.ai</td><td>fix: address PR review...</td><td>May 08, 2026</td></tr>
<tr><td>Focadecombate</td><td>feat: add OpenTelemetr...</td><td>May 01, 2026</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/rungalileo/galileo-js/598?tool=ast>(Baz)</a>.