### PR TITLE
fix(logStreamName): Updated fields using previous format to logStreamName.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ node examples/logger/workflow.js     # Run an example
 ### Logger and Singleton
 
 - **GalileoLogger** (`src/utils/galileo-logger.ts`): Primary logging class. Two modes—**batch** (collect in memory, upload on `flush()`) and **streaming** (ingest via TaskHandler as spans are created). Hierarchical spans: Trace → Workflow/Agent (can have children) → Leaf (LLM, Tool, Retriever). Uses `parentStack` for nesting.
-- **GalileoSingleton** (`src/singleton.ts`): Manages loggers keyed by (project, logstream/experimentId, mode). Global helpers: `init()`, `getLogger()`, `flush()`, `flushAll()`, `reset()`, `resetAll()`. Uses `AsyncLocalStorage` (`experimentContext`, `loggerContext`) for context across async boundaries.
+- **GalileoSingleton** (`src/singleton.ts`): Manages loggers keyed by (project, logStreamName/experimentId, mode). Global helpers: `init()`, `getLogger()`, `flush()`, `flushAll()`, `reset()`, `resetAll()`. Uses `AsyncLocalStorage` (`experimentContext`, `loggerContext`) for context across async boundaries.
 
 ### API Client and Services
 
@@ -73,7 +73,7 @@ node examples/logger/workflow.js     # Run an example
 ```typescript
 import { init, getLogger, flush } from 'galileo';
 
-await init({ projectName: 'my-project', logstream: 'default' });
+await init({ projectName: 'my-project', logStreamName: 'default' });
 const logger = getLogger({ projectName: 'my-project' });
 // ... use logger
 await flush();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
-# Unreleased
+## Unreleased
 
-### Features
+### BREAKING CHANGES
 
-- **singleton:** `init()`, `getLogger()`, `reset()`, `flush()` now accept `logStreamName` instead of `logstream`. This reverts the parameter renames introduced in PR #373 and restores consistency with `GalileoLoggerConfig.logStreamName`, `enableMetrics({ logStreamName })`, and the env var `GALILEO_LOG_STREAM_NAME`. The new name disambiguates the _name string_ from the `LogStream` entity. **Breaking:** callers must rename the property at call sites — no runtime fallback. OTel handler config (`GalileoOTLPExporterConfig.logstream`) and `GalileoSpanProcessor` are not affected by this change and remain on `logstream` until a separate follow-up.
+- **singleton:** `init()`, `getLogger()`, `reset()`, `flush()` now accept `logStreamName` instead of `logstream`. This reverts the parameter renames introduced in PR #373 and restores consistency with `GalileoLoggerConfig.logStreamName`, `enableMetrics({ logStreamName })`, and the env var `GALILEO_LOG_STREAM_NAME`. The new name disambiguates the _name string_ from the `LogStream` entity. Callers must rename the property at call sites — no runtime fallback. OTel handler config (`GalileoOTLPExporterConfig.logstream`) and `GalileoSpanProcessor` are not affected by this change and remain on `logstream` until a separate follow-up.
+
+### Bug Fixes
+
 - **singleton:** `init()` now forwards `projectId` to `getLogger()` (previously dropped — latent bug).
 
 ## [2.1.1](https://github.com/rungalileo/galileo-js/compare/v2.1.0...v2.1.1) (2026-05-08)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Unreleased
+
+### Features
+
+- **singleton:** `init()`, `getLogger()`, `reset()`, `flush()` now accept `logStreamName` instead of `logstream`. This reverts the parameter renames introduced in PR #373 and restores consistency with `GalileoLoggerConfig.logStreamName`, `enableMetrics({ logStreamName })`, and the env var `GALILEO_LOG_STREAM_NAME`. The new name disambiguates the _name string_ from the `LogStream` entity. **Breaking:** callers must rename the property at call sites — no runtime fallback. OTel handler config (`GalileoOTLPExporterConfig.logstream`) and `GalileoSpanProcessor` are not affected by this change and remain on `logstream` until a separate follow-up.
+- **singleton:** `init()` now forwards `projectId` to `getLogger()` (previously dropped — latent bug).
+
 ## [2.1.1](https://github.com/rungalileo/galileo-js/compare/v2.1.0...v2.1.1) (2026-05-08)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ const callOpenAI = async (input) => {
 // Optionally initialize the logger if you haven't set GALILEO_PROJECT and GALILEO_LOG_STREAM environment variables
 const config = {
   projectName: 'My Test Project',
-  logstream: 'my-ts-test-log-stream'
+  logStreamName: 'my-ts-test-log-stream'
 };
 await init(config);
 

--- a/src/singleton.ts
+++ b/src/singleton.ts
@@ -50,7 +50,7 @@ export interface LoggerContext {
 export const loggerContext = new AsyncLocalStorage<LoggerContext>();
 
 /**
- * Options for identifying a logger by its key (project, logstream/experimentId, mode).
+ * Options for identifying a logger by its key (project, logStreamName/experimentId, mode).
  */
 export interface LoggerKeyOptions {
   /** (Optional) The project name */
@@ -58,8 +58,8 @@ export interface LoggerKeyOptions {
   /** (Optional) The project ID */
   projectId?: string;
   /** (Optional) The log stream name (used when experimentId is not provided) */
-  logstream?: string;
-  /** (Optional) The experiment ID (takes precedence over logstream) */
+  logStreamName?: string;
+  /** (Optional) The experiment ID (takes precedence over logStreamName) */
   experimentId?: string;
   /** (Optional) The logger mode (defaults to 'batch') */
   mode?: string;
@@ -104,16 +104,16 @@ export class GalileoSingleton {
   }
 
   /**
-   * Generates a key string based on project, logstream/experimentId, and mode parameters.
+   * Generates a key string based on project, logStreamName/experimentId, and mode parameters.
    * @param projectName - (Optional) The project name
-   * @param logstream - (Optional) The log stream name (used when experimentId is not provided)
-   * @param experimentId - (Optional) The experiment ID (takes precedence over logstream)
+   * @param logStreamName - (Optional) The log stream name (used when experimentId is not provided)
+   * @param experimentId - (Optional) The experiment ID (takes precedence over logStreamName)
    * @param mode - (Optional) The logger mode (defaults to "batch")
    * @returns A string key used for caching
    */
   private static _getKey(
     projectName?: string,
-    logstream?: string,
+    logStreamName?: string,
     experimentId?: string,
     mode?: string
   ): string {
@@ -128,7 +128,7 @@ export class GalileoSingleton {
       process.env.GALILEO_PROJECT_NAME ??
       'default';
     const finalLogStream =
-      logstream ??
+      logStreamName ??
       process.env.GALILEO_LOG_STREAM ??
       process.env.GALILEO_LOG_STREAM_NAME ??
       'default';
@@ -144,8 +144,8 @@ export class GalileoSingleton {
    * Retrieves an existing GalileoLogger or creates a new one if it does not exist.
    * @param options - Configuration options
    * @param options.projectName - (Optional) The project name
-   * @param options.logstream - (Optional) The log stream name (used when experimentId is not provided)
-   * @param options.experimentId - (Optional) The experiment ID (takes precedence over logstream)
+   * @param options.logStreamName - (Optional) The log stream name (used when experimentId is not provided)
+   * @param options.experimentId - (Optional) The experiment ID (takes precedence over logStreamName)
    * @param options.mode - (Optional) The logger mode (defaults to "batch")
    * @param options.localMetrics - (Optional) Local metrics to run on traces/spans (only used when initializing a new logger)
    * @returns An instance of GalileoLogger corresponding to the key
@@ -157,7 +157,7 @@ export class GalileoSingleton {
     // Compute the key based on provided parameters, context, or environment variables
     const key = GalileoSingleton._getKey(
       options.projectName,
-      options.logstream,
+      options.logStreamName,
       options.experimentId,
       options.mode
     );
@@ -177,7 +177,7 @@ export class GalileoSingleton {
         process.env.GALILEO_PROJECT_NAME,
       projectId: options.projectId ?? context?.projectId,
       logStreamName:
-        options.logstream ??
+        options.logStreamName ??
         process.env.GALILEO_LOG_STREAM ??
         process.env.GALILEO_LOG_STREAM_NAME,
       experimentId: options.experimentId ?? context?.experimentId,
@@ -224,7 +224,7 @@ export class GalileoSingleton {
    * Resets (terminates and removes) a GalileoLogger instance.
    * @param options - Configuration options to identify which logger to reset
    * @param options.projectName - (Optional) The project name
-   * @param options.logstream - (Optional) The log stream name
+   * @param options.logStreamName - (Optional) The log stream name
    * @param options.experimentId - (Optional) The experiment ID
    * @param options.mode - (Optional) The logger mode
    * @returns A promise that resolves when the logger is reset
@@ -232,7 +232,7 @@ export class GalileoSingleton {
   public async reset(options: LoggerKeyOptions = {}): Promise<void> {
     const key = GalileoSingleton._getKey(
       options.projectName,
-      options.logstream,
+      options.logStreamName,
       options.experimentId,
       options.mode
     );
@@ -265,7 +265,7 @@ export class GalileoSingleton {
    * Flushes (uploads) a GalileoLogger instance.
    * @param options - Configuration options to identify which logger to flush
    * @param options.projectName - (Optional) The project name
-   * @param options.logstream - (Optional) The log stream name
+   * @param options.logStreamName - (Optional) The log stream name
    * @param options.experimentId - (Optional) The experiment ID
    * @param options.mode - (Optional) The logger mode
    * @returns A promise that resolves when the logger is flushed
@@ -273,7 +273,7 @@ export class GalileoSingleton {
   public async flush(options: LoggerKeyOptions = {}): Promise<void> {
     const key = GalileoSingleton._getKey(
       options.projectName,
-      options.logstream,
+      options.logStreamName,
       options.experimentId,
       options.mode
     );
@@ -319,7 +319,7 @@ export class GalileoSingleton {
  *
  * @param options - Configuration options to initialize the logger
  * @param options.projectName - (Optional) The project name
- * @param options.logstream - (Optional) The log stream name
+ * @param options.logStreamName - (Optional) The log stream name
  * @param options.experimentId - (Optional) The experiment ID
  * @param options.mode - (Optional) The logger mode
  * @param options.localMetrics - (Optional) Local metrics to run on traces/spans (only used when initializing a new logger)
@@ -344,7 +344,8 @@ export const init = async (
   const singleton = GalileoSingleton.getInstance();
   const logger = singleton.getLogger({
     projectName: options.projectName,
-    logstream: options.logstream,
+    projectId: options.projectId,
+    logStreamName: options.logStreamName,
     experimentId: options.experimentId,
     mode: options.mode,
     localMetrics: options.localMetrics
@@ -364,8 +365,8 @@ export const init = async (
  * Retrieves an existing GalileoLogger or creates a new one if it does not exist.
  * @param options - Configuration options
  * @param options.projectName - (Optional) The project name
- * @param options.logstream - (Optional) The log stream name (used when experimentId is not provided)
- * @param options.experimentId - (Optional) The experiment ID (takes precedence over logstream)
+ * @param options.logStreamName - (Optional) The log stream name (used when experimentId is not provided)
+ * @param options.experimentId - (Optional) The experiment ID (takes precedence over logStreamName)
  * @param options.mode - (Optional) The logger mode (defaults to "batch")
  * @param options.localMetrics - (Optional) Local metrics to run on traces/spans (only used when initializing a new logger)
  * @returns An instance of GalileoLogger corresponding to the key
@@ -384,7 +385,7 @@ const getLoggerFromContext = (): GalileoLogger => {
   return GalileoSingleton.getInstance().getLogger({
     projectName: exp?.projectName,
     experimentId: exp?.experimentId,
-    logstream: logStore?.logStreamName ?? exp?.logStreamName
+    logStreamName: logStore?.logStreamName ?? exp?.logStreamName
   });
 };
 
@@ -438,7 +439,7 @@ export const getAllLoggers = () => {
  * Resets (terminates and removes) a specific logger instance.
  * @param options - Configuration options to identify which logger to reset
  * @param options.projectName - (Optional) The project name
- * @param options.logstream - (Optional) The log stream name
+ * @param options.logStreamName - (Optional) The log stream name
  * @param options.experimentId - (Optional) The experiment ID
  * @param options.mode - (Optional) The logger mode
  * @returns A promise that resolves when the logger is reset
@@ -459,7 +460,7 @@ export const resetAll = async () => {
  * Flushes (uploads) traces from a specific logger to the Galileo platform.
  * @param options - Configuration options to identify which logger to flush
  * @param options.projectName - (Optional) The project name
- * @param options.logstream - (Optional) The log stream name
+ * @param options.logStreamName - (Optional) The log stream name
  * @param options.experimentId - (Optional) The experiment ID
  * @param options.mode - (Optional) The logger mode
  * @returns A promise that resolves when the logger is flushed

--- a/src/wrappers.ts
+++ b/src/wrappers.ts
@@ -241,7 +241,7 @@ export function log<T extends unknown[], R>(
       };
 
       try {
-        // Use getLogger() with current context so the wrapper respects project/experiment/logstream
+        // Use getLogger() with current context so the wrapper respects project/experiment/logStreamName
         // set via experimentContext.run() or init(). If no context exists, use getClient() to
         // retrieve the last logger configured during the ongoing workflow.
         const exp = experimentContext.getStore();
@@ -254,7 +254,7 @@ export function log<T extends unknown[], R>(
           logger = GalileoSingleton.getInstance().getLogger({
             projectName: exp?.projectName,
             experimentId: exp?.experimentId,
-            logstream: exp?.logStreamName
+            logStreamName: exp?.logStreamName
           });
         } else {
           // Fallback to last available logger

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -834,6 +834,17 @@ describe('Singleton utility functions', () => {
           externalId: 'external-id'
         });
       });
+
+      it('should forward projectId to GalileoLogger', async () => {
+        await init({
+          projectId: 'proj-init-123',
+          logStreamName: 'test-stream'
+        });
+
+        expect(GalileoLogger).toHaveBeenCalledWith(
+          expect.objectContaining({ projectId: 'proj-init-123' })
+        );
+      });
     });
 
     describe('Session parameters', () => {

--- a/tests/singleton.test.ts
+++ b/tests/singleton.test.ts
@@ -69,10 +69,10 @@ describe('Singleton utility functions', () => {
       expect(GalileoLogger).toHaveBeenCalled();
     });
 
-    it('should create logger with project and logstream', () => {
+    it('should create logger with project and logStreamName', () => {
       const logger = getLogger({
         projectName: 'test-project',
-        logstream: 'test-log-stream'
+        logStreamName: 'test-log-stream'
       });
       expect(logger).toBeDefined();
       // Verify the logger was created with correct parameters
@@ -87,11 +87,11 @@ describe('Singleton utility functions', () => {
     it('should return the same logger instance for the same key', () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       const logger2 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       expect(logger1).toBe(logger2);
     });
@@ -99,11 +99,11 @@ describe('Singleton utility functions', () => {
     it('should create different loggers for different keys', () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       const logger2 = getLogger({
         projectName: 'project2',
-        logstream: 'stream2'
+        logStreamName: 'stream2'
       });
       expect(logger1).not.toBe(logger2);
     });
@@ -123,10 +123,10 @@ describe('Singleton utility functions', () => {
       );
     });
 
-    it('should prioritize experimentId over logstream', () => {
+    it('should prioritize experimentId over logStreamName', () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1',
+        logStreamName: 'stream1',
         experimentId: 'experiment1'
       });
       const logger2 = getLogger({
@@ -140,12 +140,12 @@ describe('Singleton utility functions', () => {
     it('should support different modes', () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1',
+        logStreamName: 'stream1',
         mode: 'batch'
       });
       const logger2 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1',
+        logStreamName: 'stream1',
         mode: 'streaming'
       });
       expect(logger1).not.toBe(logger2);
@@ -160,7 +160,7 @@ describe('Singleton utility functions', () => {
       ];
       const logger = getLogger({
         projectName: 'project1',
-        logstream: 'stream1',
+        logStreamName: 'stream1',
         localMetrics: localMetrics
       });
       expect(logger).toBeDefined();
@@ -210,12 +210,12 @@ describe('Singleton utility functions', () => {
     it('should reset a specific logger', async () => {
       const logger = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
 
       await reset({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
 
       expect(logger.terminate).toHaveBeenCalled();
@@ -223,7 +223,7 @@ describe('Singleton utility functions', () => {
       // Getting the same key should create a new logger
       const newLogger = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       expect(newLogger).not.toBe(logger);
     });
@@ -247,11 +247,11 @@ describe('Singleton utility functions', () => {
     it('should reset all loggers', async () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       const logger2 = getLogger({
         projectName: 'project2',
-        logstream: 'stream2'
+        logStreamName: 'stream2'
       });
 
       await resetAll();
@@ -268,12 +268,12 @@ describe('Singleton utility functions', () => {
     it('should flush a specific logger', async () => {
       const logger = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
 
       await flush({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
 
       expect(logger.flush).toHaveBeenCalled();
@@ -283,7 +283,7 @@ describe('Singleton utility functions', () => {
       await expect(
         flush({
           projectName: 'nonexistent',
-          logstream: 'nonexistent'
+          logStreamName: 'nonexistent'
         })
       ).resolves.not.toThrow();
     });
@@ -293,11 +293,11 @@ describe('Singleton utility functions', () => {
     it('should flush all loggers', async () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       const logger2 = getLogger({
         projectName: 'project2',
-        logstream: 'stream2'
+        logStreamName: 'stream2'
       });
 
       await flushAll();
@@ -309,15 +309,15 @@ describe('Singleton utility functions', () => {
 
   describe('getAllLoggers', () => {
     it('should return a copy of all loggers', () => {
-      getLogger({ projectName: 'project1', logstream: 'stream1' });
-      getLogger({ projectName: 'project2', logstream: 'stream2' });
+      getLogger({ projectName: 'project1', logStreamName: 'stream1' });
+      getLogger({ projectName: 'project2', logStreamName: 'stream2' });
 
       const allLoggers = getAllLoggers();
       expect(allLoggers.size).toBe(2);
     });
 
     it('should return a copy that does not affect the original', () => {
-      getLogger({ projectName: 'project1', logstream: 'stream1' });
+      getLogger({ projectName: 'project1', logStreamName: 'stream1' });
 
       const allLoggers = getAllLoggers();
       allLoggers.clear();
@@ -338,13 +338,13 @@ describe('Singleton utility functions', () => {
       });
 
       it('should return default logger even when other loggers exist', () => {
-        getLogger({ projectName: 'project1', logstream: 'stream1' });
+        getLogger({ projectName: 'project1', logStreamName: 'stream1' });
         const defaultLogger = getLogger();
         expect(defaultLogger).toBeDefined();
         // Should be different from the explicitly created logger
         const explicitLogger = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
         expect(defaultLogger).not.toBe(explicitLogger);
       });
@@ -355,11 +355,11 @@ describe('Singleton utility functions', () => {
     it('should handle empty strings', () => {
       const logger1 = getLogger({
         projectName: '',
-        logstream: ''
+        logStreamName: ''
       });
       const logger2 = getLogger({
         projectName: '',
-        logstream: ''
+        logStreamName: ''
       });
       expect(logger1).toBe(logger2);
     });
@@ -369,11 +369,11 @@ describe('Singleton utility functions', () => {
     it('should work with flushAll exported function', async () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       const logger2 = getLogger({
         projectName: 'project2',
-        logstream: 'stream2'
+        logStreamName: 'stream2'
       });
 
       await flushAll();
@@ -385,11 +385,11 @@ describe('Singleton utility functions', () => {
     it('should work with resetAll exported function', async () => {
       const logger1 = getLogger({
         projectName: 'project1',
-        logstream: 'stream1'
+        logStreamName: 'stream1'
       });
       const logger2 = getLogger({
         projectName: 'project2',
-        logstream: 'stream2'
+        logStreamName: 'stream2'
       });
 
       await resetAll();
@@ -553,8 +553,8 @@ describe('Singleton utility functions', () => {
         await experimentContext.run(
           { projectName: 'ctx-project' },
           async () => {
-            const logger1 = getLogger({ logstream: 'stream1' });
-            const logger2 = getLogger({ logstream: 'stream1' });
+            const logger1 = getLogger({ logStreamName: 'stream1' });
+            const logger2 = getLogger({ logStreamName: 'stream1' });
             // Should be the same logger because key includes context projectName
             expect(logger1).toBe(logger2);
           }
@@ -658,7 +658,7 @@ describe('Singleton utility functions', () => {
       it('should return lastAvailableLogger when available', () => {
         const logger1 = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -680,7 +680,7 @@ describe('Singleton utility functions', () => {
       it('should update lastAvailableLogger when creating new logger', () => {
         const logger1 = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -689,7 +689,7 @@ describe('Singleton utility functions', () => {
 
         const logger2 = getLogger({
           projectName: 'project2',
-          logstream: 'stream2'
+          logStreamName: 'stream2'
         });
 
         const client2 = singleton.getClient();
@@ -699,7 +699,7 @@ describe('Singleton utility functions', () => {
       it('should return null lastAvailableLogger after reset()', async () => {
         const logger = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -707,7 +707,7 @@ describe('Singleton utility functions', () => {
 
         await reset({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         // After reset, getClient should create a new logger
@@ -791,7 +791,7 @@ describe('Singleton utility functions', () => {
       it('should create logger without session', async () => {
         await init({
           projectName: 'test-project',
-          logstream: 'test-stream'
+          logStreamName: 'test-stream'
         });
 
         expect(GalileoLogger).toHaveBeenCalled();
@@ -804,7 +804,7 @@ describe('Singleton utility functions', () => {
       it('should create logger with startNewSession: true', async () => {
         await init({
           projectName: 'test-project',
-          logstream: 'test-stream',
+          logStreamName: 'test-stream',
           startNewSession: true
         });
 
@@ -818,7 +818,7 @@ describe('Singleton utility functions', () => {
       it('should call logger.startSession() with correct params', async () => {
         await init({
           projectName: 'test-project',
-          logstream: 'test-stream',
+          logStreamName: 'test-stream',
           startNewSession: true,
           sessionName: 'test-session',
           previousSessionId: 'prev-session-id',
@@ -1078,10 +1078,10 @@ describe('Singleton utility functions', () => {
 
     describe('Mode defaulting', () => {
       it('should default mode to batch when not provided', () => {
-        const logger1 = getLogger({ projectName: 'p1', logstream: 's1' });
+        const logger1 = getLogger({ projectName: 'p1', logStreamName: 's1' });
         const logger2 = getLogger({
           projectName: 'p1',
-          logstream: 's1',
+          logStreamName: 's1',
           mode: 'batch'
         });
         // Should be the same logger because mode defaults to 'batch'
@@ -1091,12 +1091,12 @@ describe('Singleton utility functions', () => {
       it('should include mode in key generation', () => {
         const logger1 = getLogger({
           projectName: 'p1',
-          logstream: 's1',
+          logStreamName: 's1',
           mode: 'batch'
         });
         const logger2 = getLogger({
           projectName: 'p1',
-          logstream: 's1',
+          logStreamName: 's1',
           mode: 'streaming'
         });
         expect(logger1).not.toBe(logger2);
@@ -1104,10 +1104,10 @@ describe('Singleton utility functions', () => {
     });
 
     describe('Identifier logic', () => {
-      it('should prioritize experimentId over logstream', () => {
+      it('should prioritize experimentId over logStreamName', () => {
         const logger1 = getLogger({
           projectName: 'p1',
-          logstream: 'stream1',
+          logStreamName: 'stream1',
           experimentId: 'exp1'
         });
         const logger2 = getLogger({
@@ -1118,7 +1118,7 @@ describe('Singleton utility functions', () => {
         expect(logger1).toBe(logger2);
       });
 
-      it('should prioritize experimentId from context over logstream from env', async () => {
+      it('should prioritize experimentId from context over logStreamName from env', async () => {
         process.env.GALILEO_LOG_STREAM = 'env-stream';
 
         await experimentContext.run(
@@ -1135,14 +1135,14 @@ describe('Singleton utility functions', () => {
         );
       });
 
-      it('should use logstream when experimentId not provided', () => {
+      it('should use logStreamName when experimentId not provided', () => {
         const logger1 = getLogger({
           projectName: 'p1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
         const logger2 = getLogger({
           projectName: 'p1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
         expect(logger1).toBe(logger2);
       });
@@ -1154,7 +1154,7 @@ describe('Singleton utility functions', () => {
       it('should update lastAvailableLogger when new logger created', () => {
         const logger1 = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1162,7 +1162,7 @@ describe('Singleton utility functions', () => {
 
         const logger2 = getLogger({
           projectName: 'project2',
-          logstream: 'stream2'
+          logStreamName: 'stream2'
         });
 
         expect(singleton.getClient()).toBe(logger2);
@@ -1171,7 +1171,7 @@ describe('Singleton utility functions', () => {
       it('should clear lastAvailableLogger when logger reset', async () => {
         const logger = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1179,7 +1179,7 @@ describe('Singleton utility functions', () => {
 
         await reset({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         // After reset, getClient should create a new logger (not return null)
@@ -1191,7 +1191,7 @@ describe('Singleton utility functions', () => {
       it('should clear lastAvailableLogger when resetAll() called', async () => {
         const logger = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1208,11 +1208,11 @@ describe('Singleton utility functions', () => {
       it('should persist lastAvailableLogger when different logger reset', async () => {
         getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
         const logger2 = getLogger({
           projectName: 'project2',
-          logstream: 'stream2'
+          logStreamName: 'stream2'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1220,7 +1220,7 @@ describe('Singleton utility functions', () => {
 
         await reset({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         // logger2 should still be lastAvailableLogger
@@ -1232,7 +1232,7 @@ describe('Singleton utility functions', () => {
       it('should use tracked logger in getClient()', () => {
         const logger = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1258,7 +1258,7 @@ describe('Singleton utility functions', () => {
       it('should handle undefined params correctly', () => {
         const logger1 = getLogger({
           projectName: undefined,
-          logstream: undefined,
+          logStreamName: undefined,
           experimentId: undefined,
           mode: undefined
         });
@@ -1270,7 +1270,7 @@ describe('Singleton utility functions', () => {
       it('should handle mixed undefined and defined params', () => {
         const logger1 = getLogger({
           projectName: 'project1',
-          logstream: undefined
+          logStreamName: undefined
         });
         const logger2 = getLogger({
           projectName: 'project1'
@@ -1284,11 +1284,11 @@ describe('Singleton utility functions', () => {
       it('should handle empty strings vs undefined differently in key generation', () => {
         const logger1 = getLogger({
           projectName: '',
-          logstream: ''
+          logStreamName: ''
         });
         const logger2 = getLogger({
           projectName: undefined,
-          logstream: undefined
+          logStreamName: undefined
         });
         // Empty strings should create different key than undefined (which uses defaults)
         expect(logger1).not.toBe(logger2);
@@ -1299,15 +1299,15 @@ describe('Singleton utility functions', () => {
       it('should track lastAvailableLogger correctly with multiple loggers', () => {
         getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
         getLogger({
           projectName: 'project2',
-          logstream: 'stream2'
+          logStreamName: 'stream2'
         });
         const logger3 = getLogger({
           projectName: 'project3',
-          logstream: 'stream3'
+          logStreamName: 'stream3'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1317,11 +1317,11 @@ describe('Singleton utility functions', () => {
       it('should update lastAvailableLogger based on reset order', async () => {
         const logger1 = getLogger({
           projectName: 'project1',
-          logstream: 'stream1'
+          logStreamName: 'stream1'
         });
         const logger2 = getLogger({
           projectName: 'project2',
-          logstream: 'stream2'
+          logStreamName: 'stream2'
         });
 
         const singleton = GalileoSingleton.getInstance();
@@ -1329,7 +1329,7 @@ describe('Singleton utility functions', () => {
 
         await reset({
           projectName: 'project2',
-          logstream: 'stream2'
+          logStreamName: 'stream2'
         });
 
         // When logger2 (lastAvailableLogger) is reset, lastAvailableLogger becomes null
@@ -1353,7 +1353,7 @@ describe('Singleton utility functions', () => {
     it('should accept projectId in getLogger options', () => {
       const logger = getLogger({
         projectId: 'proj-123',
-        logstream: 'test-stream'
+        logStreamName: 'test-stream'
       });
 
       expect(logger).toBeDefined();
@@ -1392,7 +1392,7 @@ describe('Singleton utility functions', () => {
     it('should use projectName when projectId not provided', () => {
       const logger = getLogger({
         projectName: 'my-project',
-        logstream: 'stream'
+        logStreamName: 'stream'
       });
 
       expect(logger).toBeDefined();
@@ -1408,7 +1408,7 @@ describe('Singleton utility functions', () => {
       const logger = getLogger({
         projectId: 'proj-789',
         projectName: 'my-project',
-        logstream: 'stream'
+        logStreamName: 'stream'
       });
 
       expect(logger).toBeDefined();
@@ -1452,7 +1452,7 @@ describe('Singleton utility functions', () => {
       delete process.env.GALILEO_LOG_STREAM_NAME;
     });
 
-    it('should use GALILEO_LOG_STREAM when no logstream provided', () => {
+    it('should use GALILEO_LOG_STREAM when no logStreamName provided', () => {
       process.env.GALILEO_LOG_STREAM = 'env-stream';
 
       const logger = getLogger();
@@ -1465,10 +1465,10 @@ describe('Singleton utility functions', () => {
       );
     });
 
-    it('should prefer options.logstream over GALILEO_LOG_STREAM', () => {
+    it('should prefer options.logStreamName over GALILEO_LOG_STREAM', () => {
       process.env.GALILEO_LOG_STREAM = 'env-stream';
 
-      const logger = getLogger({ logstream: 'explicit-stream' });
+      const logger = getLogger({ logStreamName: 'explicit-stream' });
 
       expect(logger).toBeDefined();
       expect(GalileoLogger).toHaveBeenCalledWith(
@@ -1497,10 +1497,10 @@ describe('Singleton utility functions', () => {
       );
     });
 
-    it('should combine GALILEO_PROJECT with explicit logstream', () => {
+    it('should combine GALILEO_PROJECT with explicit logStreamName', () => {
       process.env.GALILEO_PROJECT = 'env-project';
 
-      const logger = getLogger({ logstream: 'explicit-stream' });
+      const logger = getLogger({ logStreamName: 'explicit-stream' });
 
       expect(logger).toBeDefined();
       expect(GalileoLogger).toHaveBeenCalledWith(
@@ -1545,7 +1545,7 @@ describe('Singleton utility functions', () => {
     test('test direct terminate() removes logger from singleton map', async () => {
       const logger = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-a'
+        logStreamName: 'stream-a'
       });
       expect(getAllLoggers().size).toBe(1);
 
@@ -1557,7 +1557,7 @@ describe('Singleton utility functions', () => {
     test('test direct terminate() nullifies lastAvailableLogger when it matched', async () => {
       const logger = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-b'
+        logStreamName: 'stream-b'
       });
 
       await logger.terminate();
@@ -1571,14 +1571,14 @@ describe('Singleton utility functions', () => {
     test('test subsequent getLogger() with same key returns a fresh instance after terminate', async () => {
       const logger = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-c'
+        logStreamName: 'stream-c'
       });
 
       await logger.terminate();
 
       const fresh = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-c'
+        logStreamName: 'stream-c'
       });
       expect(fresh).not.toBe(logger);
     });
@@ -1586,11 +1586,11 @@ describe('Singleton utility functions', () => {
     test('test singleton reset() still works and does not double-remove', async () => {
       const logger = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-d'
+        logStreamName: 'stream-d'
       });
 
       await expect(
-        reset({ projectName: 'direct-term', logstream: 'stream-d' })
+        reset({ projectName: 'direct-term', logStreamName: 'stream-d' })
       ).resolves.not.toThrow();
       expect(logger.terminate).toHaveBeenCalledTimes(1);
       expect(getAllLoggers().size).toBe(0);
@@ -1599,11 +1599,11 @@ describe('Singleton utility functions', () => {
     test('test singleton resetAll() still works end-to-end', async () => {
       const l1 = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-e'
+        logStreamName: 'stream-e'
       });
       const l2 = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-f'
+        logStreamName: 'stream-f'
       });
 
       await resetAll();
@@ -1616,11 +1616,11 @@ describe('Singleton utility functions', () => {
     test('test lastAvailableLogger unaffected when a non-last logger is terminated', async () => {
       const first = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-g'
+        logStreamName: 'stream-g'
       });
       const last = getLogger({
         projectName: 'direct-term',
-        logstream: 'stream-h'
+        logStreamName: 'stream-h'
       });
 
       await first.terminate();
@@ -1653,7 +1653,7 @@ describe('Singleton utility functions', () => {
     test('test reset cleans up logger when terminate completes without firing onTerminate (defensive)', async () => {
       const logger = getLogger({
         projectName: 'no-hook',
-        logstream: 'no-hook-stream'
+        logStreamName: 'no-hook-stream'
       });
 
       // Simulate any path where terminate() completes without invoking the
@@ -1670,7 +1670,7 @@ describe('Singleton utility functions', () => {
 
       await reset({
         projectName: 'no-hook',
-        logstream: 'no-hook-stream'
+        logStreamName: 'no-hook-stream'
       });
 
       expect(logger.terminate).toHaveBeenCalled();
@@ -1681,18 +1681,18 @@ describe('Singleton utility functions', () => {
     test('test reset backstop is idempotent when onTerminate already cleaned up', async () => {
       const logger1 = getLogger({
         projectName: 'idempotent',
-        logstream: 'stream-1'
+        logStreamName: 'stream-1'
       });
       const logger2 = getLogger({
         projectName: 'idempotent',
-        logstream: 'stream-2'
+        logStreamName: 'stream-2'
       });
       expect(getAllLoggers().size).toBe(2);
 
       // logger1 has onTerminate installed (created via getLogger), so the
       // hook removes it; the backstop sees `get(key) === logger` is false
       // and skips. logger2 must remain untouched.
-      await reset({ projectName: 'idempotent', logstream: 'stream-1' });
+      await reset({ projectName: 'idempotent', logStreamName: 'stream-1' });
 
       expect(logger1.terminate).toHaveBeenCalledTimes(1);
       expect(getAllLoggers().size).toBe(1);


### PR DESCRIPTION
# User description
# Naming convention for 'logStreamName' parameter in TypeScript SDK
 - [sc-61132](https://app.shortcut.com/galileo/story/61132/naming-convention-for-logstreamname-parameter-in-typescript-sdk)

## Description
- Updated public instances where 'logstream' is used to represent the name of a LogStream, with 'logStreamName';
- Updated documentation accordingly;
- Updated tests accordingly;

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
log_("log"):::modified
getLogger_("getLogger"):::modified
getKey_("_getKey"):::modified
init_("init"):::modified
getLoggerFromContext_("getLoggerFromContext"):::modified
reset_("reset"):::modified
flush_("flush"):::modified
log_ -- "Passes experiment-context logStreamName into getLogger for correct keying." --> getLogger_
getLogger_ -- "Uses options.logStreamName to compute cache key consistently." --> getKey_
init_ -- "Init now provides projectId and logStreamName when calling getLogger." --> getLogger_
getLoggerFromContext_ -- "Derives logStreamName from logStore/experiment context for getLogger reuse." --> getLogger_
reset_ -- "reset selects cached logger via options.logStreamName in _getKey." --> getKey_
flush_ -- "flush identifies logger via options.logStreamName passed to _getKey." --> getKey_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Use <code>logStreamName</code> consistently when configuring and retrieving loggers so <code>GalileoSingleton</code> keying logic, init helpers, and wrappers treat that parameter as the log stream identifier. Document the new naming convention and keep tests aligned while also forwarding <code>projectId</code> through init to the underlying logger creation.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/600?tool=ast&topic=Init+projectId+fix>Init projectId fix</a>
        </td><td>Forward <code>projectId</code> from the exported <code>init</code> helper into <code>GalileoLogger</code> creation so singleton initialization keeps providing project identifiers, and add a regression test covering the behavior.<details><summary>Modified files (2)</summary><ul><li>src/singleton.ts</li>
<li>tests/singleton.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ricardo.maurique@galil...</td><td>feat(test): Added test...</td><td>May 12, 2026</td></tr>
<tr><td>Murike</td><td>feat(terminate): Imple...</td><td>May 01, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/600?tool=ast&topic=LogStreamName+rename>LogStreamName rename</a>
        </td><td>Rename <code>logstream</code> usages across <code>GalileoSingleton</code>, init helpers, and wrappers to <code>logStreamName</code>, ensuring key generation, AsyncLocalStorage fallbacks, exported helpers, and docs/examples reflect the new parameter while keeping tests updated.<details><summary>Modified files (6)</summary><ul><li>AGENTS.md</li>
<li>CHANGELOG.md</li>
<li>README.md</li>
<li>src/singleton.ts</li>
<li>src/wrappers.ts</li>
<li>tests/singleton.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ricardo.maurique@galil...</td><td>feat(changelog): Small...</td><td>May 12, 2026</td></tr>
<tr><td>Murike</td><td>fix(utils): Small refa...</td><td>May 11, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-js/600?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>