### PR TITLE
feat(metrics): expose groundTruth flag on createCustomLlmMetric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 ## [2.1.2](https://github.com/rungalileo/galileo-js/compare/v2.1.1...v2.1.2) (2026-05-14)
 
-
 ### Bug Fixes
 
-* **logStreamName:** Updated fields using previous format to logStreamName. ([#600](https://github.com/rungalileo/galileo-js/issues/600)) ([0bc6147](https://github.com/rungalileo/galileo-js/commit/0bc6147987f77be1d1b401f6a556b974568acde1))
-* **utils:** Small refactoring to remove functions not exposed in equivalent Python SDK implementation. ([#590](https://github.com/rungalileo/galileo-js/issues/590)) ([9d7212a](https://github.com/rungalileo/galileo-js/commit/9d7212adb99f5993aa8c4cd61c8a281a4b67e492))
+- **logStreamName:** Updated fields using previous format to logStreamName. ([#600](https://github.com/rungalileo/galileo-js/issues/600)) ([0bc6147](https://github.com/rungalileo/galileo-js/commit/0bc6147987f77be1d1b401f6a556b974568acde1))
+- **utils:** Small refactoring to remove functions not exposed in equivalent Python SDK implementation. ([#590](https://github.com/rungalileo/galileo-js/issues/590)) ([9d7212a](https://github.com/rungalileo/galileo-js/commit/9d7212adb99f5993aa8c4cd61c8a281a4b67e492))
 
 ## Unreleased
 

--- a/src/entities/scorers.ts
+++ b/src/entities/scorers.ts
@@ -158,6 +158,7 @@ export class Scorers {
     scoreableNodeTypes?: StepType[];
     outputType?: OutputType;
     inputType?: InputType;
+    groundTruth?: boolean;
   }): Promise<ScorerResponse> {
     const client = await this.ensureClient();
     return await client.createScorer(options);

--- a/src/types/metrics.types.ts
+++ b/src/types/metrics.types.ts
@@ -101,6 +101,7 @@ export interface CreateCustomLlmMetricParams {
   description?: string;
   tags?: string[];
   outputType?: OutputType;
+  groundTruth?: boolean;
 }
 
 export interface CreateCustomCodeMetricParams {

--- a/src/types/scorer.types.ts
+++ b/src/types/scorer.types.ts
@@ -198,4 +198,5 @@ export type createScorerOptions = {
   scoreableNodeTypes?: StepType[];
   outputType?: OutputType;
   inputType?: InputType;
+  groundTruth?: boolean;
 };

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -67,7 +67,8 @@ export class Metrics {
     numJudges = 3,
     description = '',
     tags = [],
-    outputType = OutputType.BOOLEAN
+    outputType = OutputType.BOOLEAN,
+    groundTruth
   }: CreateCustomLlmMetricParams): Promise<BaseScorerVersionResponse> {
     const scoreableNodeTypes = [nodeLevel];
 
@@ -84,7 +85,8 @@ export class Metrics {
       undefined,
       scoreableNodeTypes,
       outputType,
-      undefined
+      undefined,
+      groundTruth
     );
 
     return await createLlmScorerVersion({

--- a/src/utils/scorers.ts
+++ b/src/utils/scorers.ts
@@ -143,6 +143,7 @@ export const createRunScorerSettings = async ({
  * @param scoreableNodeTypes - (Optional) The node types that can be scored.
  * @param outputType - (Optional) The output type for the scorer.
  * @param inputType - (Optional) The input type for the scorer.
+ * @param groundTruth - (Optional) Whether the scorer requires ground truth (`reference_output`) from the dataset. When true, the judge LLM receives the row's ground-truth value in its prompt.
  * @returns A promise that resolves to the created scorer.
  * @internal Used by metrics.ts; not part of the public API. Use Scorers.create() instead.
  */
@@ -156,7 +157,8 @@ export const createScorer = async (
   defaultVersionId?: string,
   scoreableNodeTypes?: StepType[],
   outputType?: OutputType,
-  inputType?: InputType
+  inputType?: InputType,
+  groundTruth?: boolean
 ): Promise<ScorerResponse> => {
   const scorersService = new Scorers();
   return await scorersService.create({
@@ -169,7 +171,8 @@ export const createScorer = async (
     defaultVersionId,
     scoreableNodeTypes,
     outputType,
-    inputType
+    inputType,
+    groundTruth
   });
 };
 

--- a/tests/utils/metrics.test.ts
+++ b/tests/utils/metrics.test.ts
@@ -237,7 +237,8 @@ describe('metrics utils', () => {
         defaultVersionId: undefined,
         scoreableNodeTypes: ['trace'],
         outputType: 'categorical',
-        inputType: undefined
+        inputType: undefined,
+        groundTruth: undefined
       });
       expect(mockCreateLlmScorerVersion).toHaveBeenCalledWith(
         EXAMPLE_CUSTOM_SCORER.id,
@@ -266,8 +267,21 @@ describe('metrics utils', () => {
         defaultVersionId: undefined,
         scoreableNodeTypes: ['llm'],
         outputType: 'boolean',
-        inputType: undefined
+        inputType: undefined,
+        groundTruth: undefined
       });
+    });
+
+    it('should forward groundTruth to createScorer when enabled', async () => {
+      await createCustomLlmMetric({
+        name: 'gt_metric',
+        userPrompt: 'Compare against the reference_output.',
+        groundTruth: true
+      });
+
+      expect(mockCreateScorer).toHaveBeenCalledWith(
+        expect.objectContaining({ groundTruth: true })
+      );
     });
 
     it('should call createLlmScorerVersion with the correct parameters for object-based API', async () => {


### PR DESCRIPTION
# User description
## Summary

Custom LLM-judge scorers have a server-side `ground_truth` flag (the **Use ground truth in prompt** toggle in the UI). When `true`, the runner renames the dataset's `output` column to `reference_output` so the judge LLM sees the row's ground-truth value in its prompt — turning the judge into a real correctness check rather than a model-knowledge check.

The SDK helper `createCustomLlmMetric` never accepted this parameter, so users could not enable the toggle through the SDK. The wire shape `CreateScorerRequest.groundTruth` already exists in the auto-generated `new-api.types.ts`, so this is purely a public-surface gap.

## Causal chain (before this PR)

1. User calls `createCustomLlmMetric({ ..., groundTruth: true })`.
   ❌ Param does not exist on `CreateCustomLlmMetricParams` — TS error.
2. Falling back to manual `Scorers.create({ ..., groundTruth: true })` — also rejected (option type was missing the field).
3. Workaround: hand-rolled HTTP POST or UI toggle only.

## What changed

- `src/types/metrics.types.ts` — add `groundTruth?: boolean` to `CreateCustomLlmMetricParams`.
- `src/types/scorer.types.ts` — add `groundTruth?: boolean` to `createScorerOptions`.
- `src/entities/scorers.ts` — add `groundTruth?: boolean` to `Scorers.create()` options.
- `src/utils/scorers.ts` — add `groundTruth?: boolean` to internal positional `createScorer` helper.
- `src/utils/metrics.ts` — destructure `groundTruth`, forward to `createScorer`.
- `tests/utils/metrics.test.ts` — update existing object-equality assertions to include `groundTruth: undefined`; add a new test asserting that `groundTruth: true` reaches `createScorer`.

## Cross-repo context

Pairs with the server-side fix in [rungalileo/orbit#709](https://github.com/rungalileo/orbit/pull/709) (`fix(scorers): propagate ground_truth flag for custom LLM scorers`). That PR fixes the `ScorerTypes.llm` branch in `scorer_factory.get_scorer_settings` to actually plumb `scorer.ground_truth` into the runner — without it, even servers that stored `ground_truth=true` silently scored without the reference output.

The Python SDK (`galileo` on PyPI) has the same gap in `create_custom_llm_metric` — separate PR will follow on `rungalileo/galileo-python`.

## Usage

```ts
import { createCustomLlmMetric } from 'galileo';
import { OutputType } from 'galileo/types';

await createCustomLlmMetric({
  name: 'matches-expected-output',
  userPrompt: 'Compare the response against reference_output. Return true if equivalent.',
  outputType: OutputType.BOOLEAN,
  groundTruth: true  // new — enables the "Use ground truth in prompt" toggle
});
```

## Test plan

- [x] `npx jest tests/utils/metrics.test.ts` — 34/34 pass (1 new)
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [ ] Manual smoke against staging once merged: run an experiment with a custom GT scorer + the orbit fix and confirm the judge's rationale references `reference_output`

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Metrics_createCustomLlmMetric_("Metrics.createCustomLlmMetric"):::modified
CreateCustomLlmMetricParams_("CreateCustomLlmMetricParams"):::modified
createScorer_("createScorer"):::modified
Scorers_create_("Scorers.create"):::modified
Metrics_createCustomLlmMetric_ -- "Exposes groundTruth parameter for LLM metrics configuration." --> CreateCustomLlmMetricParams_
Metrics_createCustomLlmMetric_ -- "Passes groundTruth flag when creating custom LLM scorer." --> createScorer_
createScorer_ -- "Forwards groundTruth to Scorers.create for persistence and prompting." --> Scorers_create_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enable the SDK&#39;s custom-LLM metric helpers to accept and forward the <code>groundTruth</code> option so the scorer creation pipeline can opt into reference-output judging when building metrics and scorers. Update the entity client, helper utilities, and exported types that back <code>Metrics.createCustomLlmMetric</code> to handle the flag consistently.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/607?tool=ast&topic=Release+notes>Release notes</a>
        </td><td>Document the release impact of the SDK change by bumping the <code>CHANGELOG.md</code> entry so consumers know the 2.1.2 release now supports the <code>groundTruth</code> flag on custom metrics.<details><summary>Modified files (1)</summary><ul><li>CHANGELOG.md</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>AnkushMalaker</td><td>chore: prettier-format...</td><td>May 19, 2026</td></tr>
<tr><td>ci@rungalileo.io</td><td>chore(release): v2.1.2</td><td>May 14, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/607?tool=ast&topic=Ground+truth+flow>Ground truth flow</a>
        </td><td>Enable <code>groundTruth</code> across the custom LLM metric pipeline by adding the option to <code>CreateCustomLlmMetricParams</code>, <code>createScorerOptions</code>, <code>Scorers.create</code>, the <code>createScorer</code> helper, and the metrics helper so that the SDK can toggle reference-output judging for LLM scorers and the new behavior is asserted in <code>tests/utils/metrics.test.ts</code>.<details><summary>Modified files (6)</summary><ul><li>src/entities/scorers.ts</li>
<li>src/types/metrics.types.ts</li>
<li>src/types/scorer.types.ts</li>
<li>src/utils/metrics.ts</li>
<li>src/utils/scorers.ts</li>
<li>tests/utils/metrics.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>AnkushMalaker</td><td>feat(metrics): expose ...</td><td>May 19, 2026</td></tr>
<tr><td>quinn-galileo</td><td>feat!: improve metric ...</td><td>April 02, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-js/607?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>