### PR TITLE
feat: add outputType to CreateCustomCodeMetricParams

### DIFF
--- a/src/types/metrics.types.ts
+++ b/src/types/metrics.types.ts
@@ -119,6 +119,7 @@ export interface CreateCustomCodeMetricParams {
   nodeLevel: StepType;
   description?: string;
   tags?: string[];
+  outputType?: OutputType;
   /** Maximum time to wait for code validation in milliseconds (default: 60000ms / 1 minute) */
   timeoutMs?: number;
   /** Interval between validation polling attempts in milliseconds (default: 1000ms) */

--- a/src/utils/metrics.ts
+++ b/src/utils/metrics.ts
@@ -95,6 +95,7 @@ export class Metrics {
     nodeLevel,
     description = '',
     tags = [],
+    outputType,
     timeoutMs,
     pollIntervalMs,
     requiredMetrics
@@ -155,7 +156,7 @@ export class Metrics {
       undefined, // No model type
       undefined, // No default version ID
       scoreableNodeTypes,
-      undefined
+      outputType
     );
     console.log(`Metric created: ${scorer.id}`);
 

--- a/tests/utils/metrics.test.ts
+++ b/tests/utils/metrics.test.ts
@@ -546,6 +546,31 @@ describe('metrics utils', () => {
       );
     });
 
+    it('should forward outputType to createScorer when provided', async () => {
+      await createCustomCodeMetric({
+        name: 'my_code_metric',
+        codePath: validCodeFile,
+        nodeLevel: StepType.llm,
+        outputType: OutputType.PERCENTAGE
+      });
+
+      expect(mockCreateScorer).toHaveBeenCalledWith(
+        expect.objectContaining({ outputType: OutputType.PERCENTAGE })
+      );
+    });
+
+    it('should pass outputType as undefined to createScorer when omitted', async () => {
+      await createCustomCodeMetric({
+        name: 'my_code_metric',
+        codePath: validCodeFile,
+        nodeLevel: StepType.llm
+      });
+
+      expect(mockCreateScorer).toHaveBeenCalledWith(
+        expect.objectContaining({ outputType: undefined })
+      );
+    });
+
     it('should throw error when file does not exist', async () => {
       await expect(
         createCustomCodeMetric({


### PR DESCRIPTION
# User description
## Summary

- Added `outputType?: OutputType` field to `CreateCustomCodeMetricParams` in `src/types/metrics.types.ts`
- Destructured `outputType` in `createCustomCodeMetric` (`src/utils/metrics.ts`) and forwarded it to `createScorer` instead of the previously hardcoded `undefined`

## Why

The Galileo API now requires an `output_type` on all code scorer versions. Without this change, calls to `createCustomCodeMetric` would result in a 422 response from the API. This fix makes `outputType` an optional parameter so existing callers are unaffected, while new callers can supply the required value.

## Test plan

- [ ] Call `createCustomCodeMetric` with an explicit `outputType` and confirm the scorer is created without a 422 error
- [ ] Call `createCustomCodeMetric` without `outputType` and confirm backward-compatible behavior is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
Metrics_createCustomCodeMetric_("Metrics.createCustomCodeMetric"):::modified
CreateCustomCodeMetricParams_("CreateCustomCodeMetricParams"):::modified
Metrics_createCustomCodeMetric_ -- "Propagates outputType into scorer configuration during custom metric creation." --> CreateCustomCodeMetricParams_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Add the optional <code>outputType</code> parameter to <code>CreateCustomCodeMetricParams</code> so <code>createCustomCodeMetric</code> can forward it through <code>createScorer</code> and satisfy the Galileo API requirement, while keeping the rest of the metric creation payload intact. Validate this behavior by ensuring the metric creation tests assert <code>createScorer</code> receives the provided <code>outputType</code> or undefined when omitted.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/613?tool=ast&topic=Metric+creation>Metric creation</a>
        </td><td>Add <code>outputType</code> to <code>CreateCustomCodeMetricParams</code> and forward it through <code>createCustomCodeMetric</code> into <code>createScorer</code> so the metric creation payload meets the Galileo API’s required scorer fields without breaking existing callers.<details><summary>Modified files (2)</summary><ul><li>src/types/metrics.types.ts</li>
<li>src/utils/metrics.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>jweiler@galileo.ai</td><td>feat: add outputType t...</td><td>May 26, 2026</td></tr>
<tr><td>Murike</td><td>feat(scorers): Created...</td><td>December 09, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/613?tool=ast&topic=Metric+tests>Metric tests</a>
        </td><td>Add tests that call <code>createCustomCodeMetric</code> with and without <code>outputType</code> to assert <code>createScorer</code> receives the correct value.<details><summary>Modified files (1)</summary><ul><li>tests/utils/metrics.test.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>jweiler@galileo.ai</td><td>test: add outputType f...</td><td>May 26, 2026</td></tr>
<tr><td>Murike</td><td>feat(scorers): Created...</td><td>December 09, 2025</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-js/613?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>