### PR TITLE
fix(security): update axios to 1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # [2.2.0](https://github.com/rungalileo/galileo-js/compare/v2.1.2...v2.2.0) (2026-05-26)
 
-
 ### Features
 
-* add outputType to CreateCustomCodeMetricParams ([#613](https://github.com/rungalileo/galileo-js/issues/613)) ([61b9bf7](https://github.com/rungalileo/galileo-js/commit/61b9bf7e2f5e6464411cd5e6109915c7ef26d1dc))
-* **metrics:** expose groundTruth flag on createCustomLlmMetric ([#607](https://github.com/rungalileo/galileo-js/issues/607)) ([cf49ba9](https://github.com/rungalileo/galileo-js/commit/cf49ba9f95e742f6e8605a0e828cdbd0602c9043))
+- add outputType to CreateCustomCodeMetricParams ([#613](https://github.com/rungalileo/galileo-js/issues/613)) ([61b9bf7](https://github.com/rungalileo/galileo-js/commit/61b9bf7e2f5e6464411cd5e6109915c7ef26d1dc))
+- **metrics:** expose groundTruth flag on createCustomLlmMetric ([#607](https://github.com/rungalileo/galileo-js/issues/607)) ([cf49ba9](https://github.com/rungalileo/galileo-js/commit/cf49ba9f95e742f6e8605a0e828cdbd0602c9043))
 
 ## [2.1.2](https://github.com/rungalileo/galileo-js/compare/v2.1.1...v2.1.2) (2026-05-14)
 

--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -20,6 +20,95 @@
         "zod": "^4.0.0"
       }
     },
+    "..": {
+      "name": "galileo",
+      "version": "2.2.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/cli-progress": "^3.11.6",
+        "axios": "1.16.0",
+        "cli-progress": "^3.12.0",
+        "form-data": "^4.0.5",
+        "galileo-generated": "^0.2.14",
+        "jsonwebtoken": "^9.0.2",
+        "openapi-fetch": "^0.13.3",
+        "openapi-typescript-helpers": "^0.0.15",
+        "p-retry": "^4.6.2",
+        "set-cookie-parser": "^2.7.2",
+        "ts-case-convert": "^2.1.0"
+      },
+      "devDependencies": {
+        "@hey-api/openapi-ts": "^0.88.0",
+        "@langchain/core": "^0.3.13",
+        "@opentelemetry/api": "^1.9.0",
+        "@opentelemetry/exporter-trace-otlp-http": "^0.52.0",
+        "@opentelemetry/resources": "^1.25.0",
+        "@opentelemetry/sdk-trace-base": "^1.25.0",
+        "@types/jest": "^29.5.14",
+        "@types/jsonwebtoken": "^9.0.6",
+        "@types/lodash": "^4.17.17",
+        "@types/set-cookie-parser": "^2.4.10",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "eslint": "^8.57.0",
+        "eslint-config-standard-with-typescript": "^43.0.1",
+        "eslint-plugin-import": "^2.29.1",
+        "eslint-plugin-n": "^16.6.2",
+        "eslint-plugin-promise": "^6.1.1",
+        "jest": "^29.7.0",
+        "lodash": "^4.17.21",
+        "msw": "^2.7.0",
+        "openai": "^4.85.2",
+        "openapi-typescript": "^7.4.4",
+        "prettier": "4.0.0-alpha.8",
+        "ts-jest": "^29.2.6",
+        "typedoc": "^0.28.5",
+        "typedoc-plugin-markdown": "^4.6.4",
+        "typescript": "^5.8.2"
+      },
+      "optionalDependencies": {
+        "tiktoken": "^1.0.13"
+      },
+      "peerDependencies": {
+        "@langchain/core": ">=0.3.13",
+        "@langchain/openai": ">=0.3.11",
+        "@openai/agents": ">=0.4.0",
+        "@opentelemetry/api": ">=1.4.0",
+        "@opentelemetry/exporter-trace-otlp-http": ">=0.41.0",
+        "@opentelemetry/exporter-trace-otlp-proto": ">=0.41.0",
+        "@opentelemetry/resources": ">=1.15.0",
+        "@opentelemetry/sdk-trace-base": ">=1.15.0",
+        "openai": ">=4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@langchain/core": {
+          "optional": true
+        },
+        "@langchain/openai": {
+          "optional": true
+        },
+        "@openai/agents": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-http": {
+          "optional": true
+        },
+        "@opentelemetry/exporter-trace-otlp-proto": {
+          "optional": true
+        },
+        "@opentelemetry/resources": {
+          "optional": true
+        },
+        "@opentelemetry/sdk-trace-base": {
+          "optional": true
+        },
+        "openai": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@ai-sdk/amazon-bedrock": {
       "version": "3.0.97",
       "resolved": "https://registry.npmjs.org/@ai-sdk/amazon-bedrock/-/amazon-bedrock-3.0.97.tgz",
@@ -1574,46 +1663,8 @@
       }
     },
     "node_modules/@rungalileo/galileo": {
-      "name": "galileo",
-      "version": "2.0.0",
-      "resolved": "file:..",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/cli-progress": "^3.11.6",
-        "axios": "^1.15.1",
-        "cli-progress": "^3.12.0",
-        "form-data": "^4.0.5",
-        "galileo-generated": "^0.2.11",
-        "jsonwebtoken": "^9.0.2",
-        "openapi-fetch": "^0.13.3",
-        "openapi-typescript-helpers": "^0.0.15",
-        "p-retry": "^4.6.2",
-        "set-cookie-parser": "^2.7.2",
-        "ts-case-convert": "^2.1.0"
-      },
-      "optionalDependencies": {
-        "tiktoken": "^1.0.13"
-      },
-      "peerDependencies": {
-        "@langchain/core": ">=0.3.13",
-        "@langchain/openai": ">=0.3.11",
-        "@openai/agents": ">=0.4.0",
-        "openai": ">=4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@langchain/core": {
-          "optional": true
-        },
-        "@langchain/openai": {
-          "optional": true
-        },
-        "@openai/agents": {
-          "optional": true
-        },
-        "openai": {
-          "optional": true
-        }
-      }
+      "resolved": "..",
+      "link": true
     },
     "node_modules/@smithy/eventstream-codec": {
       "version": "4.2.14",
@@ -1757,14 +1808,6 @@
       "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
       "peer": true
     },
-    "node_modules/@types/cli-progress": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/@types/cli-progress/-/cli-progress-3.11.6.tgz",
-      "integrity": "sha512-cE3+jb9WRlu+uOSAugewNpITJDt1VF8dHOopPO4IABFc3SXYL5WE/+PTz/FCdZRRfIujiWW3n3aMbv1eIGVRWA==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/debug": {
       "version": "4.1.13",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
@@ -1801,7 +1844,8 @@
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "peer": true
     },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
@@ -1964,6 +2008,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -2006,7 +2052,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "peer": true
     },
     "node_modules/atomic-sleep": {
       "version": "1.0.0",
@@ -2025,11 +2072,13 @@
       "peer": true
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }
@@ -2256,7 +2305,8 @@
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
-      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "peer": true
     },
     "node_modules/bufferutil": {
       "version": "4.1.0",
@@ -2393,17 +2443,6 @@
         "url": "https://github.com/sponsors/colinhacks"
       }
     },
-    "node_modules/cli-progress": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
-      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
-      "dependencies": {
-        "string-width": "^4.2.3"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2447,6 +2486,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2605,6 +2645,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2660,6 +2701,7 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -2672,7 +2714,9 @@
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "optional": true,
+      "peer": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -2722,6 +2766,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -3100,6 +3145,7 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -3113,6 +3159,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
       "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3134,6 +3181,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3142,6 +3190,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -3210,17 +3259,6 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/galileo-generated": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/galileo-generated/-/galileo-generated-0.2.12.tgz",
-      "integrity": "sha512-Ju7afAVphMC8d7QLd7ZRrzn5ZXF99Ho4Vl/crYPxEqsGf0H7BxCmWwHFXa0P5YPukAfaEk26CPd5NN0iI2y/SA==",
-      "dependencies": {
-        "zod": "^3.25.65 || ^4.0.0"
-      },
-      "optionalDependencies": {
-        "undici": "^7.22.0"
       }
     },
     "node_modules/gaxios": {
@@ -3435,6 +3473,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -3552,17 +3591,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/ibm-cloud-sdk-core/node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
-      "peer": true,
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^2.1.0"
-      }
-    },
     "node_modules/ibm-cloud-sdk-core/node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -3675,6 +3703,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -3781,6 +3811,7 @@
       "version": "9.0.3",
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "peer": true,
       "dependencies": {
         "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
@@ -3802,6 +3833,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -3812,6 +3844,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -3895,37 +3928,44 @@
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w=="
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "peer": true
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg=="
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "peer": true
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA=="
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "peer": true
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "peer": true
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "peer": true
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw=="
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "peer": true
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg=="
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "peer": true
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -4198,23 +4238,10 @@
         }
       }
     },
-    "node_modules/openapi-fetch": {
-      "version": "0.13.8",
-      "resolved": "https://registry.npmjs.org/openapi-fetch/-/openapi-fetch-0.13.8.tgz",
-      "integrity": "sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==",
-      "dependencies": {
-        "openapi-typescript-helpers": "^0.0.15"
-      }
-    },
     "node_modules/openapi-types": {
       "version": "12.1.3",
       "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-12.1.3.tgz",
       "integrity": "sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw=="
-    },
-    "node_modules/openapi-typescript-helpers": {
-      "version": "0.0.15",
-      "resolved": "https://registry.npmjs.org/openapi-typescript-helpers/-/openapi-typescript-helpers-0.0.15.tgz",
-      "integrity": "sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw=="
     },
     "node_modules/p-finally": {
       "version": "1.0.0",
@@ -4243,6 +4270,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
       "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "peer": true,
       "dependencies": {
         "@types/retry": "0.12.0",
         "retry": "^0.13.1"
@@ -4544,6 +4572,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
       "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -4688,6 +4717,7 @@
       "version": "0.13.1",
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -4736,7 +4766,8 @@
           "type": "consulting",
           "url": "https://feross.org/support"
         }
-      ]
+      ],
+      "peer": true
     },
     "node_modules/safe-stable-stringify": {
       "version": "2.5.0",
@@ -4772,6 +4803,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -4825,7 +4857,8 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "peer": true
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -5016,6 +5049,8 @@
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -5029,6 +5064,8 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -5140,12 +5177,6 @@
       "optional": true,
       "peer": true
     },
-    "node_modules/tiktoken": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/tiktoken/-/tiktoken-1.0.22.tgz",
-      "integrity": "sha512-PKvy1rVF1RibfF3JlXBSP0Jrcw2uq3yXdgcEXtKTYn3QJ/cBRBHDnrJ5jHky+MENZ6DIPwNUGWpkVx+7joCpNA==",
-      "optional": true
-    },
     "node_modules/tldts": {
       "version": "7.0.28",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
@@ -5207,11 +5238,6 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "peer": true
-    },
-    "node_modules/ts-case-convert": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-case-convert/-/ts-case-convert-2.1.0.tgz",
-      "integrity": "sha512-Ye79el/pHYXfoew6kqhMwCoxp4NWjKNcm2kBzpmEMIU9dd9aBmHNNFtZ+WTm0rz1ngyDmfqDXDlyUnBXayiD0w=="
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -5321,15 +5347,6 @@
       "dependencies": {
         "buffer": "^5.2.1",
         "through": "^2.3.8"
-      }
-    },
-    "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "optional": true,
-      "engines": {
-        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/examples/package.json
+++ b/examples/package.json
@@ -20,6 +20,7 @@
     "zod": "^4.0.0"
   },
   "overrides": {
-    "@browserbasehq/stagehand": "^3.2.1"
+    "@browserbasehq/stagehand": "^3.2.1",
+    "axios": "1.16.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@types/cli-progress": "^3.11.6",
-        "axios": "^1.15.1",
+        "axios": "1.16.0",
         "cli-progress": "^3.12.0",
         "form-data": "^4.0.5",
         "galileo-generated": "^0.2.14",
@@ -2931,11 +2931,12 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
         "proxy-from-env": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://www.galileo.ai/",
   "dependencies": {
     "@types/cli-progress": "^3.11.6",
-    "axios": "^1.15.1",
+    "axios": "1.16.0",
     "cli-progress": "^3.12.0",
     "form-data": "^4.0.5",
     "galileo-generated": "^0.2.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
         specifier: ^3.11.6
         version: 3.11.6
       axios:
-        specifier: ^1.15.1
-        version: 1.15.1
+        specifier: 1.16.0
+        version: 1.16.0
       cli-progress:
         specifier: ^3.12.0
         version: 3.12.0
@@ -1396,10 +1396,10 @@ packages:
       }
     engines: { node: '>= 0.4' }
 
-  axios@1.15.1:
+  axios@1.16.0:
     resolution:
       {
-        integrity: sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==
+        integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==
       }
 
   babel-jest@29.7.0:
@@ -6661,7 +6661,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axios@1.15.1:
+  axios@1.16.0:
     dependencies:
       follow-redirects: 1.16.0
       form-data: 4.0.5


### PR DESCRIPTION
# User description
## Changes

- Bump `axios` `1.15.1` → `1.16.0` in `package.json` and refresh `package-lock.json` and `pnpm-lock.yaml`.
- Add an `axios: 1.16.0` override in `examples/package.json` and regenerate `examples/package-lock.json` so the transitively pinned axios (`ibm-cloud-sdk-core` → `1.15.0`) is bumped too.

## Why

Remediates the axios security advisories tracked in the "Security improvements (2026)" epic. axios 1.16.0 fixes:

- SSRF via IPv4-mapped IPv6 NO_PROXY bypass (GHSA-pjwm-pj3p-43mv / CVE-2025-62718) — [sc-66500](https://app.shortcut.com/galileo/story/66500)
- Allocation of resources without limits (GHSA-777c-7fjr-54vf) — [sc-66499](https://app.shortcut.com/galileo/story/66499)
- Insertion of sensitive information into sent data (GHSA-p92q-9vqr-4j8v) — [sc-66502](https://app.shortcut.com/galileo/story/66502)
- Exposure of sensitive information (GHSA-j5f8-grm9-p9fc) — [sc-66503](https://app.shortcut.com/galileo/story/66503)
- Inefficient regular expression complexity (GHSA-hfxv-24rg-xrqf) — [sc-66504](https://app.shortcut.com/galileo/story/66504)

The corresponding `ui` repo bump was already merged in rungalileo/ui#9081; this PR covers the remaining `galileo-js` findings.

## Test plan

- [ ] CI (`npm ci` + tests) passes
- [ ] No `axios@1.15.x` remaining in any lockfile

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Upgrade core dependency manifests so <code>axios</code> now resolves to <code>1.16.0</code>, ensuring both the main package and example workspace inherit the patched client while aligning downstream overrides with the security epic. Summarize the release impact in the changelog and refresh every related lockfile so the dependency graph no longer references the vulnerable <code>1.15.x</code> line.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/627?tool=ast&topic=Dependency+bump>Dependency bump</a>
        </td><td>Upgrade <code>axios</code> references in both the primary manifest and the example override to <code>1.16.0</code> so direct installs and the <code>examples</code> workspace consume the patched client without transitive rollback to <code>1.15.x</code> via <code>ibm-cloud-sdk-core</code>.<details><summary>Modified files (2)</summary><ul><li>examples/package.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ss@rungalileo.io</td><td>fix(security): update ...</td><td>June 09, 2026</td></tr>
<tr><td>ci@rungalileo.io</td><td>chore(release): v2.2.0</td><td>May 26, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/rungalileo/galileo-js/627?tool=ast&topic=Lockfile+%26+changelog>Lockfile & changelog</a>
        </td><td>Regenerate every lockfile plus log the release entry so the new <code>axios</code> resolution surfaces throughout the package-lock, pnpm-lock, and example lock output and the changelog documents the security-minded release.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>examples/package-lock.json</li>
<li>package-lock.json</li>
<li>pnpm-lock.yaml</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>ss@rungalileo.io</td><td>chore: format CHANGELO...</td><td>June 09, 2026</td></tr>
<tr><td>ci@rungalileo.io</td><td>chore(release): v2.2.0</td><td>May 26, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/rungalileo/galileo-js/627?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>